### PR TITLE
Reword an awkward sentence in the README's requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ all of the requirements listed [here](https://github.com/artsy/eidolon/issues/9)
 Mainly:
 
 - Treat test stubs as first-class citizens.
-- Only allow endpoints clearly defined through Moya can be access through Moya,
+- Only endpoints clearly defined through Moya can be accessed through Moya,
 enforced by the compiler.
 - Allow iterating through all potential API requests at runtime for API sanity
 checks.


### PR DESCRIPTION
I flip-flopped a bit between this and "Only allow endpoints clearly defined through Moya to be accessed through Moya", but this one seems more precise to me.
