### PR TITLE
Add optional Alamofire.Manager argument to MoyaProvider's initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+- Add option to pass an `Alamofire.Manager` to `MoyaProvider` initializer
+
 # 2.0.2
 
 - Updates Demo directory's RxSwift version.

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -3,6 +3,7 @@ import Moya
 import Nimble
 import ReactiveCocoa
 import RxSwift
+import Alamofire
 
 class MoyaProviderSpec: QuickSpec {
     override func spec() {
@@ -57,6 +58,17 @@ class MoyaProviderSpec: QuickSpec {
                         
                         expect(cancellable).toNot(beNil())
 
+                    }
+
+                    it("uses the Alamofire.Manager.sharedInstance by default") {
+                        expect(provider.manager).to(beIdenticalTo(Alamofire.Manager.sharedInstance))
+                    }
+
+                    it("accepts a custom Alamofire.Manager") {
+                        let manager = Manager()
+                        let provider = MoyaProvider<GitHub>(manager: manager)
+
+                        expect(manager).to(beIdenticalTo(manager))
                     }
                 })
 
@@ -307,8 +319,8 @@ class MoyaProviderSpec: QuickSpec {
                     }
 
                     class TestProvider<T: MoyaTarget>: ReactiveCocoaMoyaProvider<T> {
-                        override init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-                            super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+                        override init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+                            super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
                         }
 
                         override func request(token: T, completion: MoyaCompletion) -> Cancellable {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -68,7 +68,7 @@ class MoyaProviderSpec: QuickSpec {
                         let manager = Manager()
                         let provider = MoyaProvider<GitHub>(manager: manager)
 
-                        expect(manager).to(beIdenticalTo(manager))
+                        expect(provider.manager).to(beIdenticalTo(manager))
                     }
                 })
 

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -106,13 +106,15 @@ public class MoyaProvider<T: MoyaTarget> {
     public let endpointResolver: MoyaEndpointResolution
     public let stubBehavior: MoyaStubbedBehavior
     public let networkActivityClosure: Moya.NetworkActivityClosure?
-    
+    public let manager: Manager
+
     /// Initializes a provider.
-    public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
+    public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
         self.endpointClosure = endpointClosure
         self.endpointResolver = endpointResolver
         self.stubBehavior = stubBehavior
         self.networkActivityClosure = networkActivityClosure
+        self.manager = manager
     }
     
     /// Returns an Endpoint based on the token, method, and parameters by invoking the endpointsClosure.
@@ -163,7 +165,7 @@ private extension MoyaProvider {
 
         // We need to keep a reference to the closure without a reference to ourself.
         let networkActivityCallback = networkActivityClosure
-        let request = Alamofire.Manager.sharedInstance.request(request)
+        let request = manager.request(request)
             .response { (request: NSURLRequest, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
                 networkActivityCallback?(change: .Ended)
 

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ReactiveCocoa
+import Alamofire
 
 /// Subclass of MoyaProvider that returns RACSignal instances when requests are made. Much better than using completion closures.
 public class ReactiveCocoaMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
@@ -8,8 +9,8 @@ public class ReactiveCocoaMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
 
     /// Initializes a reactive provider.
-    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
     }
 
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -1,5 +1,6 @@
 import Foundation
 import RxSwift
+import Alamofire
 
 /// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.
 public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
@@ -8,8 +9,8 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, Observable<MoyaResponse>>()
 
     /// Initializes a reactive provider.
-    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil) {
-        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure)
+    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEnpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
     }
 
     /// Designated request-making method.

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -90,9 +90,30 @@ let provider = MoyaProvider<MyTarget>(stubBehavior: { (_: MyTarget) -> Moya.Stub
 let provider = MoyaProvider<MyTarget>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour)
 ```
 
-Finally, there's the `networkActivityClosure` parameter. This is a closure
+Next, there's the `networkActivityClosure` parameter. This is a closure
 that you can provide to be notified whenever a network request begins or
 ends. This is useful for working with the [network activitiy indicator](https://github.com/thoughtbot/BOTNetworkActivityIndicator).
 Note that signature of this closure is `(change: NetworkActivityChangeType) -> ()`, 
 so you will only be notified when a request has `.Began` or `.Ended` – 
 you aren't provided any other details about the request itself. 
+
+Finally, there's the `manager` parameter. By default you'll get `Alamofire.Manager.sharedinstance`.
+If you'd like to customize the manager, for example, to add SSL pinning, create one and pass it in,
+all requests will route through the custom configured manager.
+
+```swift
+let policies: [String: ServerTrustPolicy] = [
+    "example.com": .PinPublicKeys(
+        publicKeys: ServerTrustPolicy.publicKeysInBundle(),
+        validateCertificateChain: true,
+        validateHost: true
+    )
+]
+
+let manager = Manager(
+    configuration: NSURLSessionConfiguration.defaultSessionConfiguration(),
+    serverTrustPolicyManager: ServerTrustPolicyManager(policies: policies)
+)
+
+let provider = MoyaProvider<MyTarget>(manager: manager)
+```


### PR DESCRIPTION
This PR adds an optional `Alamofire.Manager` argument to `MoyaProvider`'s init. `Alamofire` 1.3.0 introduced SSL pinning in [PR 581](https://github.com/Alamofire/Alamofire/pull/581). SSL Pinning requires a customized `Alamofire.Manager`. 

```
let policies: [String: ServerTrustPolicy] = [
    "example.com": .PinPublicKeys(
        publicKeys: ServerTrustPolicy.publicKeysInBundle(),
        validateCertificateChain: true,
        validateHost: true
    )
]

let manager = Manager(
    configuration: NSURLSessionConfiguration.defaultSessionConfiguration(),
    serverTrustPolicyManager: ServerTrustPolicyManager(policies: policies)
)
```

Prior to this PR `Moya` used the standard `Alamofire.Manager.sharedinstance`. The default behavior remains but now a customized `Alamofire.Manager` can be used to create a `MoyaProvider`. All `MoyaProvider` request calls will use the customized manager.

```
let manager = Manager()
let provider = MoyaProvider<GitHub>(manager: manager)
```