### PR TITLE
Deprecate wrong-named function

### DIFF
--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -14,7 +14,7 @@ public class Moya {
 
     /// Network activity change notification closure typealias.
     public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()
-    
+
     /// Represents an HTTP method.
     public enum Method {
         case GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH, TRACE, CONNECT
@@ -49,7 +49,7 @@ public class Moya {
         case JSON
         case PropertyList(NSPropertyListFormat, NSPropertyListWriteOptions)
         case Custom((URLRequestConvertible, [String: AnyObject]?) -> (NSMutableURLRequest, NSError?))
-        
+
         func parameterEncoding() -> Alamofire.ParameterEncoding {
             switch self {
             case .URL:
@@ -88,7 +88,7 @@ public protocol Cancellable {
 /// Internal token that can be used to cancel requests
 struct CancellableToken: Cancellable {
     let cancelAction: () -> ()
-    
+
     func cancel() {
         cancelAction()
     }
@@ -101,7 +101,7 @@ public class MoyaProvider<T: MoyaTarget> {
     /// Closure that resolves an Endpoint into an NSURLRequest.
     public typealias MoyaEndpointResolution = (endpoint: Endpoint<T>) -> (NSURLRequest)
     public typealias MoyaStubbedBehavior = ((T) -> (Moya.StubbedBehavior))
-    
+
     public let endpointClosure: MoyaEndpointsClosure
     public let endpointResolver: MoyaEndpointResolution
     public let stubBehavior: MoyaStubbedBehavior
@@ -116,12 +116,12 @@ public class MoyaProvider<T: MoyaTarget> {
         self.networkActivityClosure = networkActivityClosure
         self.manager = manager
     }
-    
+
     /// Returns an Endpoint based on the token, method, and parameters by invoking the endpointsClosure.
     public func endpoint(token: T) -> Endpoint<T> {
         return endpointClosure(token)
     }
-    
+
     /// Designated request-making method.
     public func request(token: T, completion: MoyaCompletion) -> Cancellable {
         let endpoint = self.endpoint(token)
@@ -141,7 +141,7 @@ public class MoyaProvider<T: MoyaTarget> {
         return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     }
 
-    public class func DefaultEnpointResolution(endpoint: Endpoint<T>) -> NSURLRequest {
+    @availability(*, deprecated=2.1.0) public class func DefaultEnpointResolution(endpoint: Endpoint<T>) -> NSURLRequest {
         return DefaultEndpointResolution(endpoint)
     }
 

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -141,7 +141,8 @@ public class MoyaProvider<T: MoyaTarget> {
         return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     }
 
-    @availability(*, deprecated=2.1.0) public class func DefaultEnpointResolution(endpoint: Endpoint<T>) -> NSURLRequest {
+    @availability(*, unavailable, renamed="DefaultEndpointResolution", message="Use #DefaultEndpointResolution method instead")
+    public class func DefaultEnpointResolution(endpoint: Endpoint<T>) -> NSURLRequest {
         return DefaultEndpointResolution(endpoint)
     }
 


### PR DESCRIPTION
Maurice Kelly add new function and fix typo in fde0eca3d63d79b615093db8c072673091c53375.
I believe we should left old-named method for backward compatability for a while, but it would be nice to deprecate wrong named method. Then we can delete it in next major update.