### PR TITLE
Added authentication support

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		110FCE6B1BA16EB200B8673E /* HTTPBinAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110FCE691BA16BAC00B8673E /* HTTPBinAPI.swift */; };
 		4D83CCB99A0290EE6A610D00 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 635CFFB539B0C7F414CAD726 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		5E70E8C31A1BB32400F00C49 /* EndpointSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E70E8BD1A1BB32400F00C49 /* EndpointSpec.swift */; };
 		5E70E8C51A1BB32400F00C49 /* MoyaProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E70E8BF1A1BB32400F00C49 /* MoyaProviderSpec.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		110FCE691BA16BAC00B8673E /* HTTPBinAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HTTPBinAPI.swift; path = ../Demo/HTTPBinAPI.swift; sourceTree = "<group>"; };
 		188277A647D58DEE312983C0 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		3484162586C66FCDAE67ABAB /* Pods-DemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		46D4FBD55F569CF25EE0BF6B /* Pods-DemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-DemoTests/Pods-DemoTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 		5EC197FA1A1BB16D00F4DFD4 /* DemoTests */ = {
 			isa = PBXGroup;
 			children = (
+				110FCE691BA16BAC00B8673E /* HTTPBinAPI.swift */,
 				5E70E8BD1A1BB32400F00C49 /* EndpointSpec.swift */,
 				5E70E8BE1A1BB32400F00C49 /* MoyaProviderIntegrationTests.swift */,
 				5E70E8BF1A1BB32400F00C49 /* MoyaProviderSpec.swift */,
@@ -377,6 +380,7 @@
 				5E70E8C81A1BB32400F00C49 /* TestResources.swift in Sources */,
 				5E70E8C51A1BB32400F00C49 /* MoyaProviderSpec.swift in Sources */,
 				5E70E8C31A1BB32400F00C49 /* EndpointSpec.swift in Sources */,
+				110FCE6B1BA16EB200B8673E /* HTTPBinAPI.swift in Sources */,
 				5E70E8C61A1BB32400F00C49 /* RACSignal+MoyaSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/Demo/HTTPBinAPI.swift
+++ b/Demo/Demo/HTTPBinAPI.swift
@@ -1,0 +1,43 @@
+//
+//  HTTPBinAPI.swift
+//  Demo
+//
+//  Created by Alexander von Franqué on 10.09.15.
+//  Copyright (c) 2015 Ash Furrow. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+
+public enum HTTPBin {
+    case BasicAuth
+}
+
+extension HTTPBin : MoyaTarget {
+    
+    public var baseURL: NSURL { return NSURL(string: "http://httpbin.org")! }
+    public var path: String {
+        switch self {
+        case .BasicAuth:
+            return "/basic-auth/user/passwd"
+        }
+    }
+    
+    public var method: Moya.Method {
+        return .GET
+    }
+    public var parameters: [String: AnyObject] {
+        switch self {
+        default:
+            return [:]
+        }
+    }
+    
+    public var sampleData: NSData {
+        switch self {
+        case .BasicAuth:
+            return "{\"authenticated\": true, \"user\": \"user\"}".dataUsingEncoding(NSUTF8StringEncoding)!
+        }
+    }
+}

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -71,6 +71,32 @@ class MoyaProviderSpec: QuickSpec {
                         expect(provider.manager).to(beIdenticalTo(manager))
                     }
                 })
+                
+                it("credential closure returns nil") {
+                    var called = false
+                    var provider = MoyaProvider<HTTPBin>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour, credentialClosure: { (target) -> NSURLCredential? in
+                            called = true
+                            return nil
+                    })
+                    
+                    let target: HTTPBin = .BasicAuth
+                    provider.request(target) { (data, statusCode, response, error) in }
+                    
+                    expect(called) == true
+                }
+                
+                it("credential closure returns valid username and password") {
+                    var called = false
+                    var provider = MoyaProvider<HTTPBin>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour, credentialClosure: { (target) -> NSURLCredential? in
+                        called = true
+                        return NSURLCredential(user: "user", password: "passwd", persistence: .None)
+                    })
+                    
+                    let target: HTTPBin = .BasicAuth
+                    provider.request(target) { (data, statusCode, response, error) in }
+                    
+                    expect(called) == true
+                }
 
                 it("notifies at the beginning of network requests") {
                     var called = false

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -320,7 +320,7 @@ class MoyaProviderSpec: QuickSpec {
 
                     class TestProvider<T: MoyaTarget>: ReactiveCocoaMoyaProvider<T> {
                         override init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, credentialClosure: MoyaCredentialClosure? = nil, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
-                            super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
+                            super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, credentialClosure: credentialClosure, manager: manager)
                         }
 
                         override func request(token: T, completion: MoyaCompletion) -> Cancellable {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -319,7 +319,7 @@ class MoyaProviderSpec: QuickSpec {
                     }
 
                     class TestProvider<T: MoyaTarget>: ReactiveCocoaMoyaProvider<T> {
-                        override init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+                        override init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, credentialClosure: MoyaCredentialClosure? = nil, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
                             super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
                         }
 

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -101,17 +101,20 @@ public class MoyaProvider<T: MoyaTarget> {
     /// Closure that resolves an Endpoint into an NSURLRequest.
     public typealias MoyaEndpointResolution = (endpoint: Endpoint<T>) -> (NSURLRequest)
     public typealias MoyaStubbedBehavior = ((T) -> (Moya.StubbedBehavior))
+    public typealias MoyaCredentialClosure = (T) -> (NSURLCredential?)
     
     public let endpointClosure: MoyaEndpointsClosure
     public let endpointResolver: MoyaEndpointResolution
+    public let credentialClosure: MoyaCredentialClosure?
     public let stubBehavior: MoyaStubbedBehavior
     public let networkActivityClosure: Moya.NetworkActivityClosure?
     public let manager: Manager
 
     /// Initializes a provider.
-    public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+    public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, credentialClosure: MoyaCredentialClosure? = nil, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
         self.endpointClosure = endpointClosure
         self.endpointResolver = endpointResolver
+        self.credentialClosure = credentialClosure
         self.stubBehavior = stubBehavior
         self.networkActivityClosure = networkActivityClosure
         self.manager = manager
@@ -126,11 +129,12 @@ public class MoyaProvider<T: MoyaTarget> {
     public func request(token: T, completion: MoyaCompletion) -> Cancellable {
         let endpoint = self.endpoint(token)
         let request = endpointResolver(endpoint: endpoint)
+        let credential = credentialClosure?(token)
         let stubBehavior = self.stubBehavior(token)
 
         switch stubBehavior {
         case .NoStubbing:
-            return sendRequest(request, completion: completion)
+            return sendRequest(request, credential:credential, completion: completion)
         default:
             return stubRequest(request, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
         }
@@ -163,14 +167,19 @@ public class MoyaProvider<T: MoyaTarget> {
 }
 
 private extension MoyaProvider {
-    func sendRequest(request: NSURLRequest, completion: MoyaCompletion) -> CancellableToken {
+    func sendRequest(request: NSURLRequest, credential: NSURLCredential?, completion: MoyaCompletion) -> CancellableToken {
 
         networkActivityClosure?(change: .Began)
 
         // We need to keep a reference to the closure without a reference to ourself.
         let networkActivityCallback = networkActivityClosure
-        let request = manager.request(request)
-            .response { (request: NSURLRequest, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
+        var request = manager.request(request)
+        
+        if let cred = credential {
+            request = request.authenticate(usingCredential: cred)
+        }
+        
+        request.response { (request: NSURLRequest, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
                 networkActivityCallback?(change: .Ended)
 
                 // Alamofire always sends the data param as an NSData? type, but we'll

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -9,8 +9,8 @@ public class ReactiveCocoaMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
 
     /// Initializes a reactive provider.
-    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
-        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
+    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, credentialClosure: MoyaCredentialClosure? = nil, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, credentialClosure: credentialClosure, networkActivityClosure: networkActivityClosure, manager: manager)
     }
 
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -10,7 +10,7 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
 
     /// Initializes a reactive provider.
     override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, credentialClosure: MoyaCredentialClosure? = nil, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
-        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
+        super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, credentialClosure: credentialClosure, networkActivityClosure: networkActivityClosure, manager: manager)
     }
 
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -9,7 +9,7 @@ public class RxMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
     public var inflightRequests = Dictionary<Endpoint<T>, Observable<MoyaResponse>>()
 
     /// Initializes a reactive provider.
-    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
+    override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, credentialClosure: MoyaCredentialClosure? = nil, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
         super.init(endpointClosure: endpointClosure, endpointResolver: endpointResolver, stubBehavior: stubBehavior, networkActivityClosure: networkActivityClosure, manager: manager)
     }
 


### PR DESCRIPTION
Hi,

I added HTTP Basic auth support (and other protocols that Alamofire supports, like NTLM) by adding an optional closure to the `MoyaProvider` initializer. This has been discussed previously and I've basically implemented what Ash suggested [here](https://github.com/Moya/Moya/issues/151#issuecomment-112961113).

I've only tested this with NTLM (yeah, I know...), so this should probably be tested a bit more with other authentication protocols before being merged. There also seems to be an issue with the current Alamofire version and NTLM, for more info [see here](https://github.com/Alamofire/Alamofire/issues/721).