### PR TITLE
Update to MoyaCompletion closure for recent Alamofire changes

### DIFF
--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -2,7 +2,7 @@ import Foundation
 import Alamofire
 
 /// Block to be executed when a request has completed.
-public typealias MoyaCompletion = (data: NSData?, statusCode: Int?, response: NSURLResponse?, error: NSError?) -> ()
+public typealias MoyaCompletion = (data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) -> ()
 
 /// General-purpose class to store some enums and class funcs.
 public class Moya {
@@ -163,13 +163,13 @@ private extension MoyaProvider {
 
         // We need to keep a reference to the closure without a reference to ourself.
         let networkActivityCallback = networkActivityClosure
-        let request = Alamofire.Manager.sharedInstance.request(request).response { (request: NSURLRequest?, response: NSHTTPURLResponse?, data: AnyObject?, error: NSError?) -> () in
+        let request = Alamofire.Manager.sharedInstance.request(request).response { (request: NSURLRequest?, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in
                 networkActivityCallback?(change: .Ended)
 
                 // Alamofire always sends the data param as an NSData? type, but we'll
                 // add a check just in case something changes in the future.
                 let statusCode = response?.statusCode
-                if let data = data as? NSData {
+                if let data = data {
                     completion(data: data, statusCode: statusCode, response:response, error: error)
                 } else {
                     completion(data: nil, statusCode: statusCode, response:response, error: error)


### PR DESCRIPTION
I did a `carthage update` this morning and saw that Alamofire pushed a new commit to their `swift-2.0` branch which breaks Moya. The commit (https://github.com/Alamofire/Alamofire/commit/64a004472c16313d04671518ef03ef4b72293dbc) swaps out NSError for ErrorType. 

I've updated MoyaCompletion to now take `ErrorType` rather than `NSError` to be inline with Swift 2 changes.

I should note that I haven't updated the RxSwift nor ReactiveCocoa extensions simply because I wasn't sure how you would want to handle the following bit that's present in both Moya+RxSwift and Moya+ReactiveCocoa.

    if let statusCode = statusCode {
        observer.on(.Error(NSError(domain: error.domain, code: statusCode, userInfo: error.userInfo)))
    } else {
        observer.on(.Error(error))
    }

As you can see, this just replaces the statusCode if it's been given back by Alamofire. We can't suck out the domain and userInfo from the ErrorType unless it's cast to NSError. Xcode 7 beta 6 spits out a warning that this always succeeds so I was certainly averse to putting that particular code smell in. I suppose we could potentially make a new ErrorType within Moya which has the statusCode as an argument but I didn't know whether that'd be a bit of an overkill? Alternatively we could just simplify it and return the existing error. I haven't been using either of these extensions at this point so I figured I'd leave that to someone who might have a bit more expertise with them on how it should be handled.