### PR TITLE
Added endpointByAddingParameterEncoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+# 2.2.2
+
+- Adds convenience `endpointByAddingParameterEncoding` method.
+
 # 2.2.1
 
 - Adds Moya files as members of RxMoya and ReactiveMoya frameworks.

--- a/Moya/Endpoint.swift
+++ b/Moya/Endpoint.swift
@@ -55,6 +55,12 @@ public class Endpoint<T> {
 
         return Endpoint(URL: URL, sampleResponse: sampleResponse, method: method, parameters: parameters, parameterEncoding: parameterEncoding, httpHeaderFields: newHTTPHeaderFields)
     }
+    
+    /// Convenience method for creating a new Endpoint with the same properties as the receiver, but with another parameter encoding.
+    public func endpointByAddingParameterEncoding(parameterEncoding: Moya.ParameterEncoding) -> Endpoint<T> {
+        
+        return Endpoint(URL: URL, sampleResponse: sampleResponse, method: method, parameters: parameters, parameterEncoding: parameterEncoding, httpHeaderFields: httpHeaderFields)
+    }
 }
 
 /// Extension for converting an Endpoint into an NSURLRequest.

--- a/Moya/Endpoint.swift
+++ b/Moya/Endpoint.swift
@@ -57,9 +57,9 @@ public class Endpoint<T> {
     }
     
     /// Convenience method for creating a new Endpoint with the same properties as the receiver, but with another parameter encoding.
-    public func endpointByAddingParameterEncoding(parameterEncoding: Moya.ParameterEncoding) -> Endpoint<T> {
+    public func endpointByAddingParameterEncoding(newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<T> {
         
-        return Endpoint(URL: URL, sampleResponse: sampleResponse, method: method, parameters: parameters, parameterEncoding: parameterEncoding, httpHeaderFields: httpHeaderFields)
+        return Endpoint(URL: URL, sampleResponse: sampleResponse, method: method, parameters: parameters, parameterEncoding: newParameterEncoding, httpHeaderFields: httpHeaderFields)
     }
 }
 


### PR DESCRIPTION
I think this method can be useful to avoid boilerplate, because in my case I have to use different parameter encodings for some selected requests and I didn't find another method to quickly change encoding for a particular API request, except from directly calling init with all parameters again.