### PR TITLE
Removes Inflight Request tracking/deduplication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+- Removes inflight request tracking for ReactiveCocoa and RxSwift providers. **Breaking Change**
+
 # 2.3.0
 
 - Adds data processing functions for use with `RxMoyaProvider`

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -194,30 +194,6 @@ class MoyaProviderIntegrationTests: QuickSpec {
 
                         expect{message}.toEventually( equal(userMessage) )
                     }
-                    
-                    it("returns identical signals for inflight requests") {
-                        let target: GitHub = .Zen
-                        let signal1 = provider.request(target)
-                        let signal2 = provider.request(target)
-                        
-                        expect(provider.inflightRequests.count).to(equal(0))
-                        
-                        var receivedResponse: MoyaResponse!
-                        
-                        signal1.subscribeNext { (response) -> Void in
-                            receivedResponse = response as? MoyaResponse
-                            expect(provider.inflightRequests.count).to(equal(1))
-                        }
-                        
-                        signal2.subscribeNext { (response) -> Void in
-                            expect(receivedResponse).toNot(beNil())
-                            expect(receivedResponse).to(beIndenticalToResponse( response as! MoyaResponse) )
-                            expect(provider.inflightRequests.count).to(equal(1))
-                        }
-                        
-                        // Allow for network request to complete
-                        expect(provider.inflightRequests.count).toEventually( equal(0) )
-                    }
                 }
             }
         }

--- a/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
@@ -53,31 +53,6 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             expect(receivedResponse) == sampleResponse
         }
 
-        it("returns identical signals for inflight requests") {
-            let target: GitHub = .Zen
-
-            // The synchronous nature of stubbed responses makes this kind of tricky. We use the
-            // subscribeNext closure to get the provider into a state where the signal has been
-            // added to the inflightRequests dictionary. Then we ask for an identical request,
-            // which should return the same signal. We can't *test* those signals equivalency
-            // due to the use of RACSignal.defer, but we can check if the number of inflight
-            // requests went up or not.
-
-            let outerSignal = provider.request(target)
-            outerSignal.subscribeNext { (object) -> Void in
-                expect(provider.inflightRequests.count).to(equal(1))
-
-                // Create a new signal and force subscription, so that the inflightRequests dictionary is accessed.
-                let innerSignal = provider.request(target)
-                innerSignal.subscribeNext { (object) -> Void in
-                    // nop
-                }
-                expect(provider.inflightRequests.count).to(equal(1))
-            }
-
-            expect(provider.inflightRequests.count).to(equal(0))
-        }
-
         describe("failing") {
             var provider: ReactiveCocoaMoyaProvider<GitHub>!
             beforeEach {

--- a/Demo/DemoTests/RxSwiftMoyaProviderTests.swift
+++ b/Demo/DemoTests/RxSwiftMoyaProviderTests.swift
@@ -46,33 +46,6 @@ class RxSwiftMoyaProviderSpec: QuickSpec {
             let sampleResponse: NSDictionary = try! NSJSONSerialization.JSONObjectWithData(sampleData, options: []) as! NSDictionary
             expect(receivedResponse).toNot(beNil())
         }
-
-        it("returns identical observables for inflight requests") {
-            let target: GitHub = .Zen
-
-            var response: MoyaResponse!
-
-            let parallelCount = 10
-            let observables = Array(0..<parallelCount).map { _ in provider.request(target) }
-            var completions = Array(0..<parallelCount).map { _ in false }
-            let queue = dispatch_queue_create("testing", DISPATCH_QUEUE_CONCURRENT)
-            dispatch_apply(observables.count, queue) { idx in
-                let i = idx
-                observables[i].subscribeNext { _ -> Void in
-                    if i == 5 { // We only need to check it once.
-                        expect(provider.inflightRequests.count).to(equal(1))
-                    }
-                    completions[i] = true
-                }
-            }
-
-            func allTrue(cs: [Bool]) -> Bool {
-                return cs.reduce(true) { (a,b) -> Bool in a && b }
-            }
-
-            expect(allTrue(completions)).toEventually(beTrue())
-            expect(provider.inflightRequests.count).to(equal(0))
-        }
     }
 }
 

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -4,9 +4,6 @@ import Alamofire
 
 /// Subclass of MoyaProvider that returns RACSignal instances when requests are made. Much better than using completion closures.
 public class ReactiveCocoaMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
-    /// Current requests that have not completed or errored yet.
-    /// Note: Do not access this directly. It is public only for unit-testing purposes (sigh).
-    public var inflightRequests = Dictionary<Endpoint<T>, RACSignal>()
 
     /// Initializes a reactive provider.
     override public init(endpointClosure: MoyaEndpointsClosure = MoyaProvider.DefaultEndpointMapping, endpointResolver: MoyaEndpointResolution = MoyaProvider.DefaultEndpointResolution, stubBehavior: MoyaStubbedBehavior = MoyaProvider.NoStubbingBehavior, networkActivityClosure: Moya.NetworkActivityClosure? = nil, manager: Manager = Alamofire.Manager.sharedInstance) {
@@ -15,21 +12,10 @@ public class ReactiveCocoaMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
 
     /// Designated request-making method.
     public func request(token: T) -> RACSignal {
-        let endpoint = self.endpoint(token)
-        
         // weak self just for best practices – RACSignal will take care of any retain cycles anyway,
         // and we're connecting immediately (below), so self in the block will always be non-nil
 
         return RACSignal.`defer` { [weak self] () -> RACSignal! in
-            
-            if let weakSelf = self {
-                objc_sync_enter(weakSelf)
-                let inFlight = weakSelf.inflightRequests[endpoint]
-                objc_sync_exit(weakSelf)
-                if let existingSignal = inFlight {
-                    return existingSignal
-                }
-            }
             
             let signal = RACSignal.createSignal { (subscriber) -> RACDisposable! in
                 let cancellableToken = self?.request(token) { data, statusCode, response, error in
@@ -48,21 +34,10 @@ public class ReactiveCocoaMoyaProvider<T where T: MoyaTarget>: MoyaProvider<T> {
                 }
                 
                 return RACDisposable { () -> Void in
-                    if let weakSelf = self {
-                        objc_sync_enter(weakSelf)
-                        weakSelf.inflightRequests[endpoint] = nil
-                        cancellableToken?.cancel()
-                        objc_sync_exit(weakSelf)
-                    }
+                    cancellableToken?.cancel()
                 }
-            }.publish().autoconnect()
-            
-            if let weakSelf = self {
-                objc_sync_enter(weakSelf)
-                weakSelf.inflightRequests[endpoint] = signal
-                objc_sync_exit(weakSelf)
             }
-            
+
             return signal
         }
     }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Some awesome features of Moya:
 
 - Compile-time checking for correct API endpoint accesses.
 - Lets you define a clear usage of different endpoints with associated enum values.
-- Keeps track of inflight requests with ReactiveCocoa and prevents duplicate requests.
 - Treats test stubs as first-class citizens so unit testing is super-easy.
 
 Sample Project


### PR DESCRIPTION
This caused issues for developers not expecting Moya to deduplicate network requests, as well as made it a _pain_ to test and maintain. Ideally, if people even want these, we can further subclass our Rx providers and limit the scope of what they do _just_ to inflight tracking. I don't think anyone will miss it, anyway. 