### PR TITLE
Makes Endpoint Mapping Asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - `DefaultEndpointResolution` to `DefaultRequestMapping`
 - Renamed `T` generic types of `MoyaProvider` and `Endpoint` classes to `Target`.
 - Removed errantly named `DefaultEndpointResolution`
+- Changes the closure to map `Endpoint`s to `NSURLRequest`s asynchonous.
 
 # 2.3.0
 

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -119,9 +119,9 @@ class MoyaProviderSpec: QuickSpec {
             
             beforeEach {
                 executed = false
-                let endpointResolution = { (endpoint: Endpoint<GitHub>) -> (NSURLRequest) in
+                let endpointResolution = { (endpoint: Endpoint<GitHub>, done: NSURLRequest -> Void) in
                     executed = true
-                    return endpoint.urlRequest
+                    done(endpoint.urlRequest)
                 }
                 provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
             }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -145,13 +145,12 @@ public class MoyaProvider<Target: MoyaTarget> {
     /// Designated request-making method. Returns a Cancellable token to cancel the request later.
     public func request(token: Target, completion: Moya.Completion) -> Cancellable {
         let endpoint = self.endpoint(token)
+        let stubBehavior = self.stubClosure(token)
 
         var cancellableToken = CancellableWrapper()
 
         let performNetworking = { (request: NSURLRequest) in
             if cancellableToken.isCancelled { return }
-
-            let stubBehavior = self.stubClosure(token)
 
             switch stubBehavior {
             case .Never:

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -113,21 +113,31 @@ coding framework with which to access the network – that's Alamofire's job.
 Instead, Moya is about a way to frame your thoughts about network access and 
 provide compile-time checking of well-defined network targets. You've already 
 seen how to map targets into endpoints using the `endpointClosure` parameter
-of the `MoyaProvider` initializer. That let you create an `Endpoint` instance
+of the `MoyaProvider` initializer. That lets you create an `Endpoint` instance
 that Moya will use to reason about the network API call. At some point, that
 `Endpoint` must be resolved into an actual `NSURLRequest` to give to Alamofire. 
-That's what the `endpointResolver` parameter is for. 
+That's what the `requestClosure` parameter is for. 
 
-The `endpointResolver` is an optional, last-minute way to modify the request 
-that hits the network. It has a default value of `MoyaProvider.DefaultEnpointResolution`, 
+The `requestClosure` is an optional, last-minute way to modify the request 
+that hits the network. It has a default value of `MoyaProvider.DefaultRequestMapper`, 
 which simply uses the `urlRequest` property of the `Endpoint` instance. 
 
-This closure receives an `Endpoint` instance and is responsible for returning a
-`NSURLRequest` that represents the resources to be accessed. It's here that 
-you'd do your OAuth signing or whatever. Since you return an `NSURLRequest`, you
-can use whatever general-purpose authentication library you want. You can return 
-the `urlRequest` property of the instance that you're passed in, which would not 
-change the request at all. That could be useful for logging, for example. 
+This closure receives an `Endpoint` instance and is responsible for invoking a
+its argument of `NSURLRequest -> Void` with a request that represents the Endpoint.
+It's here that you'd do your OAuth signing or whatever. Since you may invoke the 
+closure asynchronously, you can use whatever authentication library you like ([example](https://github.com/rheinfabrik/Heimdall.swift)). 
+Instead of modifying the request, you could simply log it, instead.
+
+```swift
+let requestClosure = { (endpoint: Endpoint<GitHub>, done: NSURLRequest -> Void) in
+    let request = endpoint.urlRequest
+
+    // Modify the request however you like.
+
+    done(request)
+}
+provider = MoyaProvider<GitHub>(requestClosure: requestClosure)
+```
 
 Note that the `endpointResolver` is *not* intended to be used for any sort of 
 application-level mapping. This closure is really about modifying properties 


### PR DESCRIPTION
(Relies on the #228 pull request – didn't want the eventual merge conflicts.)

This is just an idea to make the mapping from `Endpoint` to `NSURLRequest` asynchronous. This is useful if you need to refresh network credentials (asynchronously) before being able to generate the `NSURLRequest` with a proper signature. 

As discussed in #209, I'm not _totally_ happy with how the cancellation works here, since it relies on state. If anyone has suggestions for a lightweight way to synchronously return a token that can be used to cancel a request that hasn't yet been created, please chime in :notes: 

Fixes #209.