### PR TITLE
Custom manager support

### DIFF
--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -66,6 +66,26 @@ class MoyaProviderSpec: QuickSpec {
             expect(provider.manager).to(beIdenticalTo(manager))
         }
 
+        it("uses a custom Alamofire.Manager for session challenges") {
+            var called = false
+            let manager = Manager()
+            manager.delegate.sessionDidReceiveChallenge = { (session, challenge) in
+                called = true
+                let disposition: NSURLSessionAuthChallengeDisposition = .PerformDefaultHandling
+                return (disposition, nil)
+            }
+            let provider = MoyaProvider<GitHub>(manager: manager)
+            let target: GitHub = .Zen
+            waitUntil(timeout: 3) { done in
+              provider.request(target) { (data, statusCode, response, error) in
+                done()
+              }
+              return
+            }
+
+            expect(called) == true
+        }
+
         it("notifies at the beginning of network requests") {
             var called = false
             let provider = MoyaProvider<GitHub>(stubBehavior: MoyaProvider.ImmediateStubbingBehaviour, networkActivityClosure: { (change) -> () in

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -77,10 +77,10 @@ class MoyaProviderSpec: QuickSpec {
             let provider = MoyaProvider<GitHub>(manager: manager)
             let target: GitHub = .Zen
             waitUntil(timeout: 3) { done in
-              provider.request(target) { (data, statusCode, response, error) in
-                done()
-              }
-              return
+                provider.request(target) { (data, statusCode, response, error) in
+                    done()
+                }
+                return
             }
 
             expect(called) == true

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -171,7 +171,7 @@ private extension MoyaProvider {
         // We need to keep a reference to the closure without a reference to ourself.
         let networkActivityCallback = networkActivityClosure
 
-        let request = Alamofire.Manager.sharedInstance.request(request).response { (request: NSURLRequest?, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in
+        let request = manager.request(request).response { (request: NSURLRequest?, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in
                 networkActivityCallback?(change: .Ended)
 
                 // Alamofire always sends the data param as an NSData? type, but we'll


### PR DESCRIPTION
There is an issue where if a custom Alamofire manager is set, it's not actually used for making the requests in Moya - the default Alamofire one is. This pull request features a test to exhibit this behaviour, and a fix to use the manager that's set on the MoyaProvider. Let me know if any further changes are required.