### PR TITLE
Adds http response and requests logging capabilities 

### DIFF
--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		0E8003AAE8B9F3B063534D856E0F934F /* RxSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CC75A70CD8250B2E7D3256A2A8D9174C /* RxSwift-dummy.m */; };
 		0ED5A23AAB18676CABEB4D0D20D87F12 /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC63F5C1EF75F3DAEF1724E0D531CDA0 /* Concat.swift */; };
 		0F34EA0B7421AC539D4657B2B4B5E3F9 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 554C4EAB1CBA05A60BEFB4F2B6B3984B /* Closures.swift */; };
+		115969381BBC606000C5758C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115969371BBC606000C5758C /* Logger.swift */; settings = {ASSET_TAGS = (); }; };
+		1159693A1BBC608500C5758C /* MoyaLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 115969391BBC608500C5758C /* MoyaLogger.swift */; settings = {ASSET_TAGS = (); }; };
 		1291D8BBE5F28DD5DA646FAE9CB20664 /* RACPassthroughSubscriber.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B0A7A3BD62198A36135BEB036F5E12 /* RACPassthroughSubscriber.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		12D6B8C40B6C66D2FA91A3EA916848B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87F8C487AAEEFDBEB20DA9358700D068 /* Foundation.framework */; };
 		12F199EC4BB04F82D27715FC61CA4773 /* NSInvocation+RACTypeParsing.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EFC451D5D251ABF8213B71E235BEAAE /* NSInvocation+RACTypeParsing.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -607,6 +609,8 @@
 		10949FF48589B6CC028C1C63FC85A8AF /* EXTRuntimeExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXTRuntimeExtensions.h; path = "ReactiveCocoa/Objective-C/extobjc/EXTRuntimeExtensions.h"; sourceTree = "<group>"; };
 		1107E656C360E44D319C54C9EF8FA051 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = RxSwift/Error.swift; sourceTree = "<group>"; };
 		112BDAE8004BF953BF3BAF9AEA3705E3 /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Nimble.modulemap; sourceTree = "<group>"; };
+		115969371BBC606000C5758C /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		115969391BBC608500C5758C /* MoyaLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoyaLogger.swift; sourceTree = "<group>"; };
 		121C5F1D16C9A5C3D5A253F43CF44AA6 /* RACSerialDisposable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACSerialDisposable.m; path = "ReactiveCocoa/Objective-C/RACSerialDisposable.m"; sourceTree = "<group>"; };
 		123070BE45E21584665FAE9B32439066 /* QCKDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QCKDSL.m; path = Quick/DSL/QCKDSL.m; sourceTree = "<group>"; };
 		124E5891CAE7B7BA844CD7308EAF7EB6 /* RACStringSequence.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACStringSequence.m; path = "ReactiveCocoa/Objective-C/RACStringSequence.m"; sourceTree = "<group>"; };
@@ -1259,6 +1263,15 @@
 			path = RxSwift;
 			sourceTree = "<group>";
 		};
+		115969361BBC604D00C5758C /* Logger */ = {
+			isa = PBXGroup;
+			children = (
+				115969371BBC606000C5758C /* Logger.swift */,
+				115969391BBC608500C5758C /* MoyaLogger.swift */,
+			);
+			name = Logger;
+			sourceTree = "<group>";
+		};
 		15A137714EC75138D616B6823466C970 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -1770,6 +1783,7 @@
 		7215885C592D5B3665F84207A3096F21 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				115969361BBC604D00C5758C /* Logger */,
 				539D3C9D43732102222C0387D70F8FF9 /* Moya */,
 			);
 			name = Core;
@@ -2920,6 +2934,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B639404F0D7CC7383D490451F84FCFA /* Alamofire-dummy.m in Sources */,
+				1159693A1BBC608500C5758C /* MoyaLogger.swift in Sources */,
 				851953ACA5191E3C6E2310F34F3D6EA8 /* Alamofire.swift in Sources */,
 				53EC488CE419D85A0D281F6EB0C80AFF /* Download.swift in Sources */,
 				D31845F9CC44E66462C3F1732E8D0FFC /* Error.swift in Sources */,
@@ -2929,6 +2944,7 @@
 				885F87161947200A93B065DFB3CF1B25 /* Request.swift in Sources */,
 				BFF11F029B52E1F6C538D234441B4FC5 /* ResponseSerialization.swift in Sources */,
 				4443BFB06570202BC11B8EC1C4DE1B21 /* Result.swift in Sources */,
+				115969381BBC606000C5758C /* Logger.swift in Sources */,
 				DE453144851445928190E8AC00B21A87 /* ServerTrustPolicy.swift in Sources */,
 				A397147E55F16A784FDA2F094EF8CF1F /* Stream.swift in Sources */,
 				A12BDD79F4AA8CCE50A62F55CA6350B5 /* Upload.swift in Sources */,

--- a/Demo/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Demo/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Logger.swift
+++ b/Logger.swift
@@ -1,8 +1,3 @@
-
-//  Created by Alexander Karaberov on 9/30/15.
-//
-//
-
 import Foundation
 
 

--- a/Logger.swift
+++ b/Logger.swift
@@ -1,0 +1,17 @@
+
+//  Created by Alexander Karaberov on 9/30/15.
+//
+//
+
+import Foundation
+
+
+public protocol Logger {
+    
+    func logNetworkRequest(request: NSURLRequest) -> Void
+    
+    func logNetworkResponse(response: NSHTTPURLResponse?) -> Void
+    
+    func logNetworkResponseData(data: NSData) -> Void
+    
+}

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -177,7 +177,7 @@ private extension MoyaProvider {
         // We need to keep a reference to the closure without a reference to ourself.
         let networkActivityCallback = networkActivityClosure
 
-        //Log network request to the console
+        //Print network request 
         self.logger?.logNetworkRequest(request)
         
         var request = manager.request(request)
@@ -190,14 +190,14 @@ private extension MoyaProvider {
 
                 networkActivityCallback?(change: .Ended)
 
-                //Log network response to the console
+                //Print network response
                 self.logger?.logNetworkResponse(response)
             
                 // Alamofire always sends the data param as an NSData? type, but we'll
                 // add a check just in case something changes in the future.
                 let statusCode = response?.statusCode
                 if let data = data {
-                    //Log response data
+                    //Print network response data
                     self.logger?.logNetworkResponseData(data)
                     
                     completion(data: data, statusCode: statusCode, response: response, error: error)

--- a/MoyaLogger.swift
+++ b/MoyaLogger.swift
@@ -1,0 +1,72 @@
+
+//  Created by Alexander on 9/30/15.
+//
+//
+
+import Foundation
+
+
+public struct MoyaLogger: Logger {
+    
+    private let loggerId = "Moya_Logger"
+    private let dateFormatString = "dd/MM/yyyy HH:mm:ss"
+    private let dateFormatter = NSDateFormatter()
+    
+    private var date: String {
+        
+        dateFormatter.dateFormat = dateFormatString
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        return dateFormatter.stringFromDate(NSDate())
+    }
+    
+    public func logNetworkRequest(request: NSURLRequest) {
+        
+        let requestOutput = String(format: "%@: [%@] Request:  %@", loggerId, date, request.description)
+        print(requestOutput)
+        
+        if let headers = request.allHTTPHeaderFields {
+            let requestHeadersOutput = String(format: "%@ [%@] Request Headers:  %@", loggerId, date, headers)
+            print(requestHeadersOutput)
+        }
+        
+        if let bodyStream = request.HTTPBodyStream {
+            let bodyStreamOutput = String(format: "%@: [%@] Request Body Stream:  %@", loggerId, date, bodyStream.description)
+            print(bodyStreamOutput)
+        }
+        
+        if let httpMethod = request.HTTPMethod {
+            let httpMethodOutput = String(format: "%@: [%@] HTTP Request Method:  %@", loggerId, date, httpMethod)
+            print(httpMethodOutput)
+        }
+        
+        if let body = request.HTTPBody {
+            
+            if let stringOutput = NSString(data: body, encoding: NSUTF8StringEncoding) {
+                
+                let bodyOutput = String(format: "%@: [%@] Request Body:  %@", loggerId, date, stringOutput)
+                print(bodyOutput)
+            }
+        }
+        
+    }
+    
+    public func logNetworkResponse(response: NSHTTPURLResponse?) {
+        
+        if let response = response {
+            let responseOutput = String(format: "%@: [%@] Response:  %@", loggerId, date, response.description)
+            print(responseOutput)
+        }
+    }
+    
+    public func logNetworkResponseData(data: NSData) {
+        
+        let stringRepresentation = NSString(data: data, encoding: NSUTF8StringEncoding)
+        
+        if let stringRepresentation = stringRepresentation {
+            let stringRepresentationOutput = String(format: "%@: [%@] Response Data:  %@", loggerId, date, stringRepresentation)
+            print(stringRepresentationOutput)
+            
+        }
+        
+    }
+}

--- a/MoyaLogger.swift
+++ b/MoyaLogger.swift
@@ -1,8 +1,3 @@
-
-//  Created by Alexander on 9/30/15.
-//
-//
-
 import Foundation
 
 


### PR DESCRIPTION
This feature was discussed in the issue [220](https://github.com/Moya/Moya/issues/220). Current PR adds `Logger` protocol with three methods to log response, request and data, their default implementations via `MoyaLogger` and new `MoyaProvider` ivar called `logger`.  Also, I think we should add some info or instructions about logging to the Moya Documentation, although I don't know where to put it :disappointed: .