### PR TITLE
Plugins

### DIFF
--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -167,14 +167,16 @@ class MoyaProviderIntegrationTests: QuickSpec {
                     }
                 }
                 
-                describe("a provider with credential closures") {
+                describe("a provider with credential plugin") {
                     it("credential closure returns nil") {
                         var called = false
-                        let provider  = MoyaProvider<HTTPBin>(credentialClosure: {(target) -> (NSURLCredential?) in
-                            
+                        let plugin = CredentialsPlugin<HTTPBin> { (target) -> (NSURLCredential?) in
                             called = true
                             return nil
-                        })
+                        }
+                        
+                        let provider  = MoyaProvider<HTTPBin>(plugins: [plugin])
+                        expect(provider.plugins.count).to(equal(1))
                         
                         let target: HTTPBin = .BasicAuth
                         provider.request(target) { (data, statusCode, response, error) in }
@@ -186,12 +188,12 @@ class MoyaProviderIntegrationTests: QuickSpec {
                     it("credential closure returns valid username and password") {
                         var called = false
                         var returnedData: NSData?
-                        let provider  = MoyaProvider<HTTPBin>(credentialClosure: {(target) -> (NSURLCredential?) in
-                            
+                        let plugin = CredentialsPlugin<HTTPBin> { (target) -> (NSURLCredential?) in
                             called = true
                             return NSURLCredential(user: "user", password: "passwd", persistence: .None)
-                        })
+                        }
                         
+                        let provider  = MoyaProvider<HTTPBin>(plugins: [plugin])
                         let target: HTTPBin = .BasicAuth
                         provider.request(target) { (data, statusCode, response, error) in
                             returnedData = data
@@ -202,15 +204,16 @@ class MoyaProviderIntegrationTests: QuickSpec {
                     }
                 }
 
-                describe("a provider with network activity closures") {
+                describe("a provider with network activity plugin") {
                     it("notifies at the beginning of network requests") {
                         var called = false
-                        let provider = MoyaProvider<GitHub>(networkActivityClosure: { (change) -> () in
+                        let plugin = NetworkActivityPlugin<GitHub> { (change) -> () in
                             if change == .Began {
                                 called = true
                             }
-                        })
-
+                        }
+                        
+                        let provider = MoyaProvider<GitHub>(plugins: [plugin])
                         let target: GitHub = .Zen
                         provider.request(target) { (data, statusCode, response, error) in }
 
@@ -219,12 +222,13 @@ class MoyaProviderIntegrationTests: QuickSpec {
 
                     it("notifies at the end of network requests") {
                         var called = false
-                        let provider = MoyaProvider<GitHub>(networkActivityClosure: { (change) -> () in
+                        let plugin = NetworkActivityPlugin<GitHub> { (change) -> () in
                             if change == .Ended {
                                 called = true
                             }
-                        })
+                        }
 
+                        let provider = MoyaProvider<GitHub>(plugins: [plugin])
                         let target: GitHub = .Zen
                         provider.request(target) { (data, statusCode, response, error) in }
 

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -61,11 +61,12 @@ class MoyaProviderSpec: QuickSpec {
                 
         it("credential closure returns nil") {
             var called = false
-            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.ImmediatelyStub, credentialClosure: { (target) -> NSURLCredential? in
-                    called = true
-                    return nil
-            })
+            let plugin = CredentialsPlugin<HTTPBin> { (target) -> NSURLCredential? in
+                called = true
+                return nil
+            }
             
+            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
             let target: HTTPBin = .BasicAuth
             provider.request(target) { (data, statusCode, response, error) in }
             
@@ -74,11 +75,12 @@ class MoyaProviderSpec: QuickSpec {
         
         it("credential closure returns valid username and password") {
             var called = false
-            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.ImmediatelyStub, credentialClosure: { (target) -> NSURLCredential? in
+            let plugin = CredentialsPlugin<HTTPBin> { (target) -> NSURLCredential? in
                 called = true
                 return NSURLCredential(user: "user", password: "passwd", persistence: .None)
-            })
+            }
             
+            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
             let target: HTTPBin = .BasicAuth
             provider.request(target) { (data, statusCode, response, error) in }
             
@@ -114,12 +116,13 @@ class MoyaProviderSpec: QuickSpec {
 
         it("notifies at the beginning of network requests") {
             var called = false
-            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, networkActivityClosure: { (change) -> () in
+            let plugin = NetworkActivityPlugin<GitHub> { (change) -> () in
                 if change == .Began {
                     called = true
                 }
-            })
-
+            }
+            
+            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
             let target: GitHub = .Zen
             provider.request(target) { (data, statusCode, response, error) in }
 
@@ -128,12 +131,13 @@ class MoyaProviderSpec: QuickSpec {
 
         it("notifies at the end of network requests") {
             var called = false
-            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, networkActivityClosure: { (change) -> () in
+            let plugin = NetworkActivityPlugin<GitHub> { (change) -> () in
                 if change == .Ended {
                     called = true
                 }
-            })
+            }
 
+            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
             let target: GitHub = .Zen
             provider.request(target) { (data, statusCode, response, error) in }
             

--- a/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
@@ -98,11 +98,10 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 override init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
                     requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
                     stubClosure: StubClosure = MoyaProvider.NeverStub,
-                    networkActivityClosure: Moya.NetworkActivityClosure? = nil,
-                    credentialClosure: CredentialClosure? = nil,
-                    manager: Manager = Alamofire.Manager.sharedInstance) {
+                    manager: Manager = Alamofire.Manager.sharedInstance,
+                    plugins: [Plugin<Target>] = []) {
 
-                        super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, networkActivityClosure: networkActivityClosure, credentialClosure: credentialClosure, manager: manager)
+                        super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                 }
 
                 override func request(token: Target, completion: Moya.Completion) -> Cancellable {
@@ -210,11 +209,10 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                     override init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
                         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
                         stubClosure: StubClosure = MoyaProvider.NeverStub,
-                        networkActivityClosure: Moya.NetworkActivityClosure? = nil,
-                        credentialClosure: CredentialClosure? = nil,
-                        manager: Manager = Alamofire.Manager.sharedInstance) {
+                        manager: Manager = Alamofire.Manager.sharedInstance,
+                        plugins: [Plugin<Target>] = []) {
 
-                            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, networkActivityClosure: networkActivityClosure, credentialClosure: credentialClosure, manager: manager)
+                            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                     }
                     
                     override func request(token: Target, completion: Moya.Completion) -> Cancellable {

--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -160,6 +160,9 @@
 		4B5AACC731938DEA5B8CF05A4EE94927 /* Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BDCEE65A53F8E37D2EB6E1C2F57477C /* Upload.swift */; };
 		4C5A4F5C6F21C76162601ECBC0628A68 /* RACIndexSetSequence.m in Sources */ = {isa = PBXBuildFile; fileRef = D979579EB9BE00A716BCFA0F70E505EA /* RACIndexSetSequence.m */; };
 		4C7563E3F2561E17F5E282512279CEE6 /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0978938314F78837962788B66D839871 /* MainScheduler.swift */; };
+		4D69297B1BBE74200047AF37 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297A1BBE74200047AF37 /* Plugin.swift */; };
+		4D69297C1BBE74200047AF37 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297A1BBE74200047AF37 /* Plugin.swift */; };
+		4D69297D1BBE74200047AF37 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297A1BBE74200047AF37 /* Plugin.swift */; };
 		4ED27FAF27938E52C71E0C875918D33E /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7751264C7513434B25B571E5FE167FD9 /* Debug.swift */; };
 		4ED5A9F0A2EEC3BF10BA3E6ADE0D8D9C /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = C414D73D3BDC8F94CB4670D2557E1FC2 /* QuickSpec.m */; };
 		4F44A17581DA8B4330CA1F2924A1E56E /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0873CB54153AA787FC10F0D40E7CF3 /* OperationQueueScheduler.swift */; };
@@ -729,6 +732,7 @@
 		48B7DD21C6F50EB5725F950F7E1057BB /* RACDynamicSignal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACDynamicSignal.m; path = "ReactiveCocoa/Objective-C/RACDynamicSignal.m"; sourceTree = "<group>"; };
 		4A5B6892138263482EC5489CD8E1F48D /* ObserveOnSerialDispatchQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserveOnSerialDispatchQueue.swift; path = RxSwift/Observables/Implementations/ObserveOnSerialDispatchQueue.swift; sourceTree = "<group>"; };
 		4B56FE48DA6EAFBA448C2B78F990FE67 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Quick/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
+		4D69297A1BBE74200047AF37 /* Plugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 		4EA053EAD48523107EB11F03009F2010 /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = "ReactiveCocoa/Objective-C/RACKVOChannel.m"; sourceTree = "<group>"; };
 		4F57C74B6566B696DE48BC8EA2B1FA14 /* Never.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Never.swift; path = RxSwift/Observables/Implementations/Never.swift; sourceTree = "<group>"; };
 		5063CE719471BA3F427075892A0851B5 /* ReactiveMoya-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ReactiveMoya-dummy.m"; sourceTree = "<group>"; };
@@ -1603,6 +1607,7 @@
 			children = (
 				C40791A23BE84AE84D9122A38F038FF7 /* Endpoint.swift */,
 				D08F1E492B30DF6D7829B737EFE381FD /* Moya.swift */,
+				4D69297A1BBE74200047AF37 /* Plugin.swift */,
 			);
 			path = Moya;
 			sourceTree = "<group>";
@@ -2570,6 +2575,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D69297C1BBE74200047AF37 /* Plugin.swift in Sources */,
 				1636A38CEDCB1E5B003FE49DB018828B /* Endpoint.swift in Sources */,
 				8C38C3BB3CFD1212CA3F64F1940A930C /* Moya+ReactiveCocoa.swift in Sources */,
 				D3EE5901BBC3FE317AFEDF352BFAD5BF /* Moya.swift in Sources */,
@@ -2639,6 +2645,7 @@
 				02CE45128A7EAC5299B6FD9582C1A091 /* MoyaError.swift in Sources */,
 				8A4A2FDAECF996EC9E19E5989C934A4C /* MoyaResponse.swift in Sources */,
 				22806D87264A4B304ED1D00FCBE880A9 /* Observable+Moya.swift in Sources */,
+				4D69297D1BBE74200047AF37 /* Plugin.swift in Sources */,
 				A5E98A2C5D3F61DB05F0F56019058EED /* RxMoya-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2792,6 +2799,7 @@
 			files = (
 				F3078287CAB2A7FC7E6E4B17F21A9635 /* Endpoint.swift in Sources */,
 				E08A084ACE3778841365B973970767F8 /* Moya-dummy.m in Sources */,
+				4D69297B1BBE74200047AF37 /* Plugin.swift in Sources */,
 				82BE4B47F4D0038489B77EA1797FDAAA /* Moya.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -163,6 +163,12 @@
 		4D69297B1BBE74200047AF37 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297A1BBE74200047AF37 /* Plugin.swift */; };
 		4D69297C1BBE74200047AF37 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297A1BBE74200047AF37 /* Plugin.swift */; };
 		4D69297D1BBE74200047AF37 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297A1BBE74200047AF37 /* Plugin.swift */; };
+		4D6929801BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297F1BBE84FA0047AF37 /* CredentialsPlugin.swift */; };
+		4D6929811BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297F1BBE84FA0047AF37 /* CredentialsPlugin.swift */; };
+		4D6929821BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D69297F1BBE84FA0047AF37 /* CredentialsPlugin.swift */; };
+		4D6929841BBE85F70047AF37 /* NetworkActivityPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6929831BBE85F70047AF37 /* NetworkActivityPlugin.swift */; };
+		4D6929851BBE85F70047AF37 /* NetworkActivityPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6929831BBE85F70047AF37 /* NetworkActivityPlugin.swift */; };
+		4D6929861BBE85F70047AF37 /* NetworkActivityPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6929831BBE85F70047AF37 /* NetworkActivityPlugin.swift */; };
 		4ED27FAF27938E52C71E0C875918D33E /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7751264C7513434B25B571E5FE167FD9 /* Debug.swift */; };
 		4ED5A9F0A2EEC3BF10BA3E6ADE0D8D9C /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = C414D73D3BDC8F94CB4670D2557E1FC2 /* QuickSpec.m */; };
 		4F44A17581DA8B4330CA1F2924A1E56E /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0873CB54153AA787FC10F0D40E7CF3 /* OperationQueueScheduler.swift */; };
@@ -733,6 +739,8 @@
 		4A5B6892138263482EC5489CD8E1F48D /* ObserveOnSerialDispatchQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserveOnSerialDispatchQueue.swift; path = RxSwift/Observables/Implementations/ObserveOnSerialDispatchQueue.swift; sourceTree = "<group>"; };
 		4B56FE48DA6EAFBA448C2B78F990FE67 /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Quick/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
 		4D69297A1BBE74200047AF37 /* Plugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
+		4D69297F1BBE84FA0047AF37 /* CredentialsPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialsPlugin.swift; sourceTree = "<group>"; };
+		4D6929831BBE85F70047AF37 /* NetworkActivityPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkActivityPlugin.swift; sourceTree = "<group>"; };
 		4EA053EAD48523107EB11F03009F2010 /* RACKVOChannel.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = RACKVOChannel.m; path = "ReactiveCocoa/Objective-C/RACKVOChannel.m"; sourceTree = "<group>"; };
 		4F57C74B6566B696DE48BC8EA2B1FA14 /* Never.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Never.swift; path = RxSwift/Observables/Implementations/Never.swift; sourceTree = "<group>"; };
 		5063CE719471BA3F427075892A0851B5 /* ReactiveMoya-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "ReactiveMoya-dummy.m"; sourceTree = "<group>"; };
@@ -1602,12 +1610,22 @@
 			name = Core;
 			sourceTree = "<group>";
 		};
+		4D69297E1BBE84E10047AF37 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				4D69297F1BBE84FA0047AF37 /* CredentialsPlugin.swift */,
+				4D6929831BBE85F70047AF37 /* NetworkActivityPlugin.swift */,
+			);
+			path = Plugins;
+			sourceTree = "<group>";
+		};
 		539D3C9D43732102222C0387D70F8FF9 /* Moya */ = {
 			isa = PBXGroup;
 			children = (
 				C40791A23BE84AE84D9122A38F038FF7 /* Endpoint.swift */,
 				D08F1E492B30DF6D7829B737EFE381FD /* Moya.swift */,
 				4D69297A1BBE74200047AF37 /* Plugin.swift */,
+				4D69297E1BBE84E10047AF37 /* Plugins */,
 			);
 			path = Moya;
 			sourceTree = "<group>";
@@ -2581,9 +2599,11 @@
 				D3EE5901BBC3FE317AFEDF352BFAD5BF /* Moya.swift in Sources */,
 				CE75EDBB26797AC8EE31CE5FB8506159 /* MoyaError.swift in Sources */,
 				89FA53796B59EA07E08B607290026A57 /* MoyaResponse.swift in Sources */,
+				4D6929851BBE85F70047AF37 /* NetworkActivityPlugin.swift in Sources */,
 				58A6D53C72144434DF265C3A6864F6CC /* RACSignal+Moya.swift in Sources */,
 				6B9D11E33F380524132BC9A7BBF86FDF /* ReactiveMoya-dummy.m in Sources */,
 				09510C035220F0F36C708AAED6ABBACC /* SignalProducer+Moya.swift in Sources */,
+				4D6929811BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2639,9 +2659,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D6929861BBE85F70047AF37 /* NetworkActivityPlugin.swift in Sources */,
 				9C84D1FCA79212C04BBB28942A35CA39 /* Endpoint.swift in Sources */,
 				A791026D19CA827F7FB839472ECB5768 /* Moya+RxSwift.swift in Sources */,
 				2A2A83C06E4FACFC1676D382A309BE63 /* Moya.swift in Sources */,
+				4D6929821BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */,
 				02CE45128A7EAC5299B6FD9582C1A091 /* MoyaError.swift in Sources */,
 				8A4A2FDAECF996EC9E19E5989C934A4C /* MoyaResponse.swift in Sources */,
 				22806D87264A4B304ED1D00FCBE880A9 /* Observable+Moya.swift in Sources */,
@@ -2799,8 +2821,10 @@
 			files = (
 				F3078287CAB2A7FC7E6E4B17F21A9635 /* Endpoint.swift in Sources */,
 				E08A084ACE3778841365B973970767F8 /* Moya-dummy.m in Sources */,
+				4D6929841BBE85F70047AF37 /* NetworkActivityPlugin.swift in Sources */,
 				4D69297B1BBE74200047AF37 /* Plugin.swift in Sources */,
 				82BE4B47F4D0038489B77EA1797FDAAA /* Moya.swift in Sources */,
+				4D6929801BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -202,9 +202,7 @@ private extension MoyaProvider {
         let plugins = self.plugins
         
         // Give plugins the chance to alter the outgoing request
-        for p in plugins {
-            request = p.willSendRequest(token, request: request)
-        }
+        plugins.forEach { request = $0.willSendRequest(token, request: request) }
         
         // Perform the actual request
         request.response { (_, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -7,15 +7,6 @@ public class Moya {
     /// Closure to be executed when a request has completed.
     public typealias Completion = (data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) -> ()
 
-    /// Network activity change notification type.
-    public enum NetworkActivityChangeType {
-        case Began, Ended
-    }
-
-    /// Network activity change notification closure typealias.
-    /// Explicitly outside the MoyaProvider type since it doesn't touch the Target generic.
-    public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()
-
     /// Represents an HTTP method.
     public enum Method {
         case GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH, TRACE, CONNECT
@@ -117,30 +108,27 @@ public class MoyaProvider<Target: MoyaTarget> {
     /// Closure that decides if/how a request should be stubbed.
     public typealias StubClosure = Target -> Moya.StubBehavior
 
-    public typealias CredentialClosure = Target -> NSURLCredential?
-
     public let endpointClosure: EndpointClosure
     public let requestClosure: RequestClosure
     public let stubClosure: StubClosure
-    public let credentialClosure: CredentialClosure?
-
-    public let networkActivityClosure: Moya.NetworkActivityClosure?
     public let manager: Manager
+    
+    /// A list of plugins
+    /// e.g. for logging, network activity indicator or credentials
+    public let plugins: [Plugin<Target>]
 
     /// Initializes a provider.
     public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
-        networkActivityClosure: Moya.NetworkActivityClosure? = nil,
-        credentialClosure: CredentialClosure? = nil,
-        manager: Manager = Alamofire.Manager.sharedInstance) {
+        manager: Manager = Alamofire.Manager.sharedInstance,
+        plugins: [Plugin<Target>] = []) {
 
         self.endpointClosure = endpointClosure
         self.requestClosure = requestClosure
         self.stubClosure = stubClosure
-        self.networkActivityClosure = networkActivityClosure
-        self.credentialClosure = credentialClosure
         self.manager = manager
+        self.plugins = plugins
     }
 
     /// Returns an Endpoint based on the token, method, and parameters by invoking the endpointsClosure.
@@ -152,9 +140,6 @@ public class MoyaProvider<Target: MoyaTarget> {
     public func request(token: Target, completion: Moya.Completion) -> Cancellable {
         let endpoint = self.endpoint(token)
         let stubBehavior = self.stubClosure(token)
-
-        let credential = credentialClosure?(token)
-
         var cancellableToken = CancellableWrapper()
 
         let performNetworking = { (request: NSURLRequest) in
@@ -162,9 +147,9 @@ public class MoyaProvider<Target: MoyaTarget> {
 
             switch stubBehavior {
             case .Never:
-                cancellableToken.innerCancellable = self.sendRequest(request, credential: credential, completion: completion)
+                cancellableToken.innerCancellable = self.sendRequest(token, request: request, completion: completion)
             default:
-                cancellableToken.innerCancellable = self.stubRequest(request, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
+                cancellableToken.innerCancellable = self.stubRequest(token, request: request, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
             }
         }
 
@@ -212,30 +197,22 @@ public extension MoyaProvider {
 
 private extension MoyaProvider {
 
-    func sendRequest(request: NSURLRequest, credential: NSURLCredential?, completion: Moya.Completion) -> CancellableToken {
-        networkActivityClosure?(change: .Began)
-
-        // We need to keep a reference to the closure without a reference to ourself.
-        let networkActivityCallback = networkActivityClosure
-
+    func sendRequest(token: Target, request: NSURLRequest, completion: Moya.Completion) -> CancellableToken {
         var request = manager.request(request)
+        let plugins = self.plugins
         
-        if let cred = credential {
-            request = request.authenticate(usingCredential: cred)
+        // Give plugins the chance to alter the outgoing request
+        for p in plugins {
+            request = p.willSendRequest(token, request: request)
         }
         
-        request.response { (request: NSURLRequest?, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in
+        // Perform the actual request
+        request.response { (_, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in
+            let statusCode = response?.statusCode
 
-                networkActivityCallback?(change: .Ended)
-
-                // Alamofire always sends the data param as an NSData? type, but we'll
-                // add a check just in case something changes in the future.
-                let statusCode = response?.statusCode
-                if let data = data {
-                    completion(data: data, statusCode: statusCode, response: response, error: error)
-                } else {
-                    completion(data: nil, statusCode: statusCode, response: response, error: error)
-                }
+            // Inform all plugins about the response
+            plugins.forEach { $0.didReceiveResponse(token, data: data, statusCode: statusCode, response: response, error: error) }
+            completion(data: data, statusCode: statusCode, response: response, error: error)
         }
 
         return CancellableToken {
@@ -243,26 +220,28 @@ private extension MoyaProvider {
         }
     }
 
-    func stubRequest(request: NSURLRequest, completion: Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
+    func stubRequest(token: Target, request: NSURLRequest, completion: Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
         var canceled = false
         let cancellableToken = CancellableToken { canceled = true }
-
-        // Begin network activity closure
-        networkActivityClosure?(change: .Began)
-
+        let plugins = self.plugins
+        
+        plugins.forEach { $0.willSendStubbedRequest(token, request: request) }
+        
         let stub: () -> () = {
-            self.networkActivityClosure?(change: .Ended)
-
             if (canceled) {
-                completion(data: nil, statusCode: nil, response: nil, error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+                let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil)
+                plugins.forEach { $0.didReceiveStubbedResponse(token, data: nil, statusCode: nil, response: nil, error: error) }
+                completion(data: nil, statusCode: nil, response: nil, error: error)
                 return
             }
 
             switch endpoint.sampleResponse.evaluate() {
             case .Success(let statusCode, let data):
-                completion(data: data(), statusCode: statusCode, response:nil, error: nil)
+                plugins.forEach { $0.didReceiveStubbedResponse(token, data: data(), statusCode: statusCode, response: nil, error: nil) }
+                completion(data: data(), statusCode: statusCode, response: nil, error: nil)
             case .Error(let statusCode, let error, let data):
-                completion(data: data?(), statusCode: statusCode, response:nil, error: error)
+                plugins.forEach { $0.didReceiveStubbedResponse(token, data: data?(), statusCode: statusCode, response: nil, error: error) }
+                completion(data: data?(), statusCode: statusCode, response: nil, error: error)
             case .Closure:
                 break  // the `evaluate()` method will never actually return a .Closure
             }

--- a/Moya/Plugin.swift
+++ b/Moya/Plugin.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Alamofire
+
+/// A Moya Plugin receives callbacks to perform side effects wherever a request is sent or received.
+///
+/// for example, a plugin may be used to
+///     - log network requests
+///     - hide and show a network avtivity indicator 
+///     - inject additional information into a request
+public class Plugin<Target: MoyaTarget> {
+    
+    // NOTE:
+    //
+    // We cannot implement `Plugin` as a generic protocol here, because `MoyaProvider` needs
+    // to keep references to an array of plugins and a generic protocol cannot be used as an array constraint.
+    //
+    // i.e.
+    // protocol Plugin {
+    //      typealias T: MoyaTarget
+    //      ...
+    // }
+    //
+    // let plugins = [Plugin]()
+    // 
+    // This does not work, because `plugins` is now unable to infer the actual type of the typealias `T`.
+    
+    func willSendRequest(token: Target, request: Alamofire.Request) -> Alamofire.Request {
+        // Should be overridden if necessary
+        return request
+    }
+    
+    func didReceiveResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
+        // Should be overridden if necessary
+    }
+    
+    func willSendStubbedRequest(token: Target, request: NSURLRequest) {
+        // Should be overridden if necessary
+    }
+    
+    func didReceiveStubbedResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
+        // Should be overridden if necessary
+    }
+
+}

--- a/Moya/Plugin.swift
+++ b/Moya/Plugin.swift
@@ -24,20 +24,12 @@ public class Plugin<Target: MoyaTarget> {
     // 
     // This does not work, because `plugins` is now unable to infer the actual type of the typealias `T`.
     
-    func willSendRequest(token: Target, request: Alamofire.Request) -> Alamofire.Request {
+    func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, token: Target) -> Alamofire.Request {
         // Should be overridden if necessary
         return request
     }
     
-    func didReceiveResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
-        // Should be overridden if necessary
-    }
-    
-    func willSendStubbedRequest(token: Target, request: NSURLRequest) {
-        // Should be overridden if necessary
-    }
-    
-    func didReceiveStubbedResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
+    func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, token: Target) {
         // Should be overridden if necessary
     }
 

--- a/Moya/Plugins/CredentialsPlugin.swift
+++ b/Moya/Plugins/CredentialsPlugin.swift
@@ -13,19 +13,13 @@ public class CredentialsPlugin<Target: MoyaTarget>: Plugin<Target> {
     }
     
     
-    // MARK: PluginType
+    // MARK: Plugin
     
-    public override func willSendRequest(token: Target, request: Alamofire.Request) -> Alamofire.Request {
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, token: Target) -> Alamofire.Request {
         if let credentials = credentialsClosure(token) {
             request.authenticate(usingCredential: credentials)
         }
         return request
-    }
-    
-    override func willSendStubbedRequest(token: Target, request: NSURLRequest) {
-        // Just call the closure here to make it possible to test the 
-        // credentials closure when stubbed requests are turned on
-        _ = credentialsClosure(token)
     }
     
 }

--- a/Moya/Plugins/CredentialsPlugin.swift
+++ b/Moya/Plugins/CredentialsPlugin.swift
@@ -25,7 +25,7 @@ public class CredentialsPlugin<Target: MoyaTarget>: Plugin<Target> {
     override func willSendStubbedRequest(token: Target, request: NSURLRequest) {
         // Just call the closure here to make it possible to test the 
         // credentials closure when stubbed requests are turned on
-        let _ = credentialsClosure(token)
+        _ = credentialsClosure(token)
     }
     
 }

--- a/Moya/Plugins/CredentialsPlugin.swift
+++ b/Moya/Plugins/CredentialsPlugin.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Alamofire
+
+
+/// Provides each request with optional NSURLCredentials.
+public class CredentialsPlugin<Target: MoyaTarget>: Plugin<Target> {
+    
+    public typealias CredentialClosure = Target -> NSURLCredential?
+    let credentialsClosure: CredentialClosure
+    
+    public init(credentialsClosure: CredentialClosure) {
+        self.credentialsClosure = credentialsClosure
+    }
+    
+    
+    // MARK: PluginType
+    
+    public override func willSendRequest(token: Target, request: Alamofire.Request) -> Alamofire.Request {
+        if let credentials = credentialsClosure(token) {
+            request.authenticate(usingCredential: credentials)
+        }
+        return request
+    }
+    
+    override func willSendStubbedRequest(token: Target, request: NSURLRequest) {
+        // Just call the closure here to make it possible to test the 
+        // credentials closure when stubbed requests are turned on
+        let _ = credentialsClosure(token)
+    }
+    
+}

--- a/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Moya/Plugins/NetworkActivityPlugin.swift
@@ -17,22 +17,16 @@ public class NetworkActivityPlugin<Target: MoyaTarget>: Plugin<Target> {
     }
     
     
-    // MARK: PluginType
+    // MARK: Plugin
     
-    public override func willSendRequest(token: Target, request: Alamofire.Request) -> Alamofire.Request {
+    /// Called by the provider as soon as the request is about to start
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, token: Target) -> Alamofire.Request {
         networkActivityClosure(change: .Began)
         return request
     }
-    
-    public override func didReceiveResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
-        networkActivityClosure(change: .Ended)
-    }
-    
-    public override func willSendStubbedRequest(token: Target, request: NSURLRequest) {
-        networkActivityClosure(change: .Began)
-    }
-    
-    public override func didReceiveStubbedResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
+
+    /// Called by the provider as soon as a response arrives
+    public override func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, token: Target) {
         networkActivityClosure(change: .Ended)
     }
     

--- a/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Moya/Plugins/NetworkActivityPlugin.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Alamofire
+
+/// Network activity change notification type.
+public enum NetworkActivityChangeType {
+    case Began, Ended
+}
+
+/// Provides each request with optional NSURLCredentials.
+public class NetworkActivityPlugin<Target: MoyaTarget>: Plugin<Target> {
+    
+    public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()
+    let networkActivityClosure: NetworkActivityClosure
+    
+    public init(networkActivityClosure: NetworkActivityClosure) {
+        self.networkActivityClosure = networkActivityClosure
+    }
+    
+    
+    // MARK: PluginType
+    
+    public override func willSendRequest(token: Target, request: Alamofire.Request) -> Alamofire.Request {
+        networkActivityClosure(change: .Began)
+        return request
+    }
+    
+    public override func didReceiveResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
+        networkActivityClosure(change: .Ended)
+    }
+    
+    public override func willSendStubbedRequest(token: Target, request: NSURLRequest) {
+        networkActivityClosure(change: .Began)
+    }
+    
+    public override func didReceiveStubbedResponse(token: Target, data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?) {
+        networkActivityClosure(change: .Ended)
+    }
+    
+}

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -9,11 +9,9 @@ public class ReactiveCocoaMoyaProvider<Target where Target: MoyaTarget>: MoyaPro
     override public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
-        networkActivityClosure: Moya.NetworkActivityClosure? = nil,
-        credentialClosure: CredentialClosure? = nil,
-        manager: Manager = Alamofire.Manager.sharedInstance) {
-        
-            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, networkActivityClosure: networkActivityClosure, credentialClosure: credentialClosure, manager: manager)
+        manager: Manager = Alamofire.Manager.sharedInstance,
+        plugins: [Plugin<Target>] = []) {
+            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }
     
     /// Designated request-making method.

--- a/Moya/RxSwift/Moya+RxSwift.swift
+++ b/Moya/RxSwift/Moya+RxSwift.swift
@@ -8,11 +8,9 @@ public class RxMoyaProvider<Target where Target: MoyaTarget>: MoyaProvider<Targe
     override public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
-        networkActivityClosure: Moya.NetworkActivityClosure? = nil,
-        credentialClosure: CredentialClosure? = nil,
-        manager: Manager = Alamofire.Manager.sharedInstance) {
-        
-            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, networkActivityClosure: networkActivityClosure, credentialClosure: credentialClosure, manager: manager)
+        manager: Manager = Alamofire.Manager.sharedInstance,
+        plugins: [Plugin<Target>] = []) {
+            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }
 
     /// Designated request-making method.


### PR DESCRIPTION
I would like to propose a plugin system for Moya.
`MoyaProvider` can now be initialized with a set of `Plugin`s.  A `Plugin` receives callbacks to perform side effects wherever a request is sent or received.

For example, a plugin may be used to
 * log network requests
 * hide and show a network avtivity indicator
 * inject additional information into a request

This kind of tackles #144 as well, as the number of additional closures is now much lower and can be initialized with an arbitrary number of plugins

I have also added plugins for the existing `CredentialClosure` and `NetworkActivityClosure` to make it easy for everyone to adopt this change. Maybe we should also try to build a plugin from the Logger in #235?

Would love to get some feedback on the idea or how to make this even more generic for everyone to use (I'm not super happy with the subclassing approach). :heart: 


Fixes #144.