### PR TITLE
A few other renames, documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@
 - Removes inflight request tracking for ReactiveCocoa and RxSwift providers. **Breaking Change**
 - Adds support for ReactiveCocoa 4 by moving `ReactiveCocoaMoyaProvider` to use `SignalProducer` instead of `RACSignal`
 - Renamed `EndpointSampleResponse` cases: **Breaking Change**
-  - `Success` to `NetworkResponse`
+  - `Success` to `NetworkResponse`, now contains `NSData` instead of `() -> NSData`.
   - `Error` to `NetworkError`
   - Additionally, `NetworkError` no longer has a status code or data associated with it. This represents an error from the underlying iOS network stack, like an inability to connect. See [#200](https://github.com/Moya/Moya/issues/200) for more details.
-- ReactiveCocoa provider no longer replaces errors that contain status codes (an unlikely situation) with its own errors. It passes all errors directly through. 
+  - Also additionally, removed `Closure` case (see below).
+- Changed `Endpoint` to use a `sampleResponseClosure` instead of a `sampleResponse`, making all sample responses lazily executed. **Breaking Change**
+- ReactiveCocoa provider no longer replaces errors that contain status codes (an unlikely situation) with its own errors. It passes all errors directly through.
 
 # 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   - Also additionally, removed `Closure` case (see below).
 - Changed `Endpoint` to use a `sampleResponseClosure` instead of a `sampleResponse`, making all sample responses lazily executed. **Breaking Change**
 - ReactiveCocoa provider no longer replaces errors that contain status codes (an unlikely situation) with its own errors. It passes all errors directly through.
+- Renames `token` to `target` (it was usually `target` anyway, just made it consistent).
 
 # 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 - Changes the closure to map `Endpoint`s to `NSURLRequest`s asynchonous.
 - Removes inflight request tracking for ReactiveCocoa and RxSwift providers. **Breaking Change**
 - Adds support for ReactiveCocoa 4 by moving `ReactiveCocoaMoyaProvider` to use `SignalProducer` instead of `RACSignal`
+- Renamed `EndpointSampleResponse` cases: **Breaking Change**
+  - `Success` to `NetworkResponse`
+  - `Error` to `NetworkError`
+  - Additionally, `NetworkError` no longer has a status code or data associated with it. This represents an error from the underlying iOS network stack, like an inability to connect. See [#200](https://github.com/Moya/Moya/issues/200) for more details.
+- ReactiveCocoa provider no longer replaces errors that contain status codes (an unlikely situation) with its own errors. It passes all errors directly through. 
 
 # 2.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   - Additionally, `NetworkError` no longer has a status code or data associated with it. This represents an error from the underlying iOS network stack, like an inability to connect. See [#200](https://github.com/Moya/Moya/issues/200) for more details.
   - Also additionally, removed `Closure` case (see below).
 - Changed `Endpoint` to use a `sampleResponseClosure` instead of a `sampleResponse`, making all sample responses lazily executed. **Breaking Change**
+- New plugin architecture **Breaking Change**
+  - This replaces `networkActivityClosure` with a plugin.
 - ReactiveCocoa provider no longer replaces errors that contain status codes (an unlikely situation) with its own errors. It passes all errors directly through.
 - Renames `token` to `target` (it was usually `target` anyway, just made it consistent).
 

--- a/Demo/DemoTests/EndpointSpec.swift
+++ b/Demo/DemoTests/EndpointSpec.swift
@@ -29,7 +29,7 @@ class EndpointSpec: QuickSpec {
                 let target: GitHub = .Zen
                 let parameters = ["Nemesis": "Harvey"]
                 let headerFields = ["Title": "Dominar"]
-                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkResponse(200, {target.sampleData}), method: Moya.Method.GET, parameters: parameters, parameterEncoding: .JSON, httpHeaderFields: headerFields)
+                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: Moya.Method.GET, parameters: parameters, parameterEncoding: .JSON, httpHeaderFields: headerFields)
             }
             
             it("returns a new endpoint for endpointByAddingParameters") {

--- a/Demo/DemoTests/EndpointSpec.swift
+++ b/Demo/DemoTests/EndpointSpec.swift
@@ -29,7 +29,7 @@ class EndpointSpec: QuickSpec {
                 let target: GitHub = .Zen
                 let parameters = ["Nemesis": "Harvey"]
                 let headerFields = ["Title": "Dominar"]
-                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: Moya.Method.GET, parameters: parameters, parameterEncoding: .JSON, httpHeaderFields: headerFields)
+                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkResponse(200, {target.sampleData}), method: Moya.Method.GET, parameters: parameters, parameterEncoding: .JSON, httpHeaderFields: headerFields)
             }
             
             it("returns a new endpoint for endpointByAddingParameters") {

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -75,14 +75,13 @@ private func url(route: MoyaTarget) -> String {
 }
 
 private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.Success(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
 }
 
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    let errorData = "Houston, we have a problem".dataUsingEncoding(NSUTF8StringEncoding)!
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil), {errorData}), method: target.method, parameters: target.parameters)
+    let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
 }
-
 
 func beIndenticalToResponse(expectedValue: MoyaResponse) -> MatcherFunc<MoyaResponse> {
     return MatcherFunc { actualExpression, failureMessage in

--- a/Demo/DemoTests/MoyaProviderIntegrationTests.swift
+++ b/Demo/DemoTests/MoyaProviderIntegrationTests.swift
@@ -74,13 +74,9 @@ private func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
-private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
-}
-
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
 }
 
 func beIndenticalToResponse(expectedValue: MoyaResponse) -> MatcherFunc<MoyaResponse> {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -229,27 +229,6 @@ class MoyaProviderSpec: QuickSpec {
                 expect(receivedError?.localizedDescription) == "Houston, we have a problem"
             }
         }
-
-        describe("with lazy data") {
-            var provider: MoyaProvider<GitHub>!
-            beforeEach {
-                provider = MoyaProvider<GitHub>(endpointClosure: lazyEndpointClosure, stubClosure: MoyaProvider.ImmediatelyStub)
-            }
-
-            it("returns stubbed data for zen request") {
-                var message: String?
-
-                let target: GitHub = .Zen
-                provider.request(target) { (data, statusCode, response, error) in
-                    if let data = data {
-                        message = NSString(data: data, encoding: NSUTF8StringEncoding) as? String
-                    }
-                }
-
-                let sampleData = target.sampleData as NSData
-                expect(message).to(equal(NSString(data: sampleData, encoding: NSUTF8StringEncoding)))
-            }
-        }
     }
 }
 
@@ -294,13 +273,9 @@ private func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
-private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
-}
-
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
 }
 
 private enum HTTPBin: MoyaTarget {

--- a/Demo/DemoTests/MoyaProviderSpec.swift
+++ b/Demo/DemoTests/MoyaProviderSpec.swift
@@ -217,18 +217,16 @@ class MoyaProviderSpec: QuickSpec {
                 let _ = target.sampleData
                 expect{errored}.toEventually(beTruthy(), timeout: 1, pollInterval: 0.1)
             }
-            
+
             it("returns stubbed error data when present") {
-                var errorMessage = ""
+                var receivedError: NSError?
                 
                 let target: GitHub = .UserProfile("ashfurrow")
                 provider.request(target) { (object, statusCode, response, error) in
-                    if let object = object {
-                        errorMessage = NSString(data: object, encoding: NSUTF8StringEncoding) as! String
-                    }
+                    receivedError = error as NSError?
                 }
 
-                expect{errorMessage}.toEventually(equal("Houston, we have a problem"), timeout: 1, pollInterval: 0.1)
+                expect(receivedError?.localizedDescription) == "Houston, we have a problem"
             }
         }
 
@@ -297,12 +295,12 @@ private func url(route: MoyaTarget) -> String {
 }
 
 private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.Success(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
 }
 
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    let errorData = "Houston, we have a problem".dataUsingEncoding(NSUTF8StringEncoding)!
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil), {errorData}), method: target.method, parameters: target.parameters)
+    let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
 }
 
 private enum HTTPBin: MoyaTarget {

--- a/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
@@ -62,7 +62,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 provider = ReactiveCocoaMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.ImmediatelyStub)
             }
 
-            fit("returns the correct error message") {
+            it("returns the correct error message") {
                 var receivedError: NSError!
 
                 waitUntil { done in
@@ -257,13 +257,9 @@ private func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
-private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
-}
-
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
 }
 
 private enum HTTPBin: MoyaTarget {

--- a/Demo/DemoTests/RxSwiftMoyaProviderTests.swift
+++ b/Demo/DemoTests/RxSwiftMoyaProviderTests.swift
@@ -88,13 +88,9 @@ private func url(route: MoyaTarget) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
-private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
-}
-
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
 }
 
 private enum HTTPBin: MoyaTarget {

--- a/Demo/DemoTests/RxSwiftMoyaProviderTests.swift
+++ b/Demo/DemoTests/RxSwiftMoyaProviderTests.swift
@@ -42,8 +42,6 @@ class RxSwiftMoyaProviderSpec: QuickSpec {
                 receivedResponse = try! NSJSONSerialization.JSONObjectWithData(response.data, options: []) as? NSDictionary
             }
 
-            let sampleData = target.sampleData as NSData
-            let sampleResponse: NSDictionary = try! NSJSONSerialization.JSONObjectWithData(sampleData, options: []) as! NSDictionary
             expect(receivedResponse).toNot(beNil())
         }
     }
@@ -91,12 +89,12 @@ private func url(route: MoyaTarget) -> String {
 }
 
 private let lazyEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.Success(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Closure({.NetworkResponse(200, {target.sampleData})}), method: target.method, parameters: target.parameters)
 }
 
 private let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
-    let errorData = "Houston, we have a problem".dataUsingEncoding(NSUTF8StringEncoding)!
-    return Endpoint<GitHub>(URL: url(target), sampleResponse: .Error(401, NSError(domain: "com.moya.error", code: 0, userInfo: nil), {errorData}), method: target.method, parameters: target.parameters)
+    let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
+    return Endpoint<GitHub>(URL: url(target), sampleResponse: .NetworkError(error), method: target.method, parameters: target.parameters)
 }
 
 private enum HTTPBin: MoyaTarget {

--- a/Demo/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Demo/Pods/Pods.xcodeproj/project.pbxproj
@@ -189,6 +189,9 @@
 		5C9B7B10D50C75730C35E4DBCD6718C2 /* UITableViewHeaderFooterView+RACSignalSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 108D0F459849DF09F7B9D426BE71881D /* UITableViewHeaderFooterView+RACSignalSupport.m */; };
 		5D7D5C1DC009E47F0AD0B3DBDCF5015B /* RACUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = D51628CB64572F4A5065A3435640CB22 /* RACUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D88405B1BABC61255B91D3967F3664B /* RACDisposable.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E2AC210FEDE02B39E416479B76A0F05 /* RACDisposable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5E0BA6DC1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0BA6DB1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift */; settings = {ASSET_TAGS = (); }; };
+		5E0BA6DD1BC09F7700DF2A91 /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0BA6DB1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift */; settings = {ASSET_TAGS = (); }; };
+		5E0BA6DE1BC09F7800DF2A91 /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0BA6DB1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift */; settings = {ASSET_TAGS = (); }; };
 		5EB3133D6F3854E89CB7E425EAC3A946 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75983DD08D77A6E7A920F3B7ABCE8010 /* EndWith.swift */; };
 		5EDED09309DA38E561718A04D401B791 /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4744E5AB3CDDC046300BED46B2A1F142 /* StartWith.swift */; };
 		5FE69727D1C937B93955E6339260B334 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AC938085160408977FDA0DA8A88FD0 /* DSL+Wait.swift */; };
@@ -777,6 +780,7 @@
 		5CF63396AFFB4D3EE8AE8559F1C0FEC5 /* RACImmediateScheduler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = RACImmediateScheduler.h; path = "ReactiveCocoa/Objective-C/RACImmediateScheduler.h"; sourceTree = "<group>"; };
 		5D1BF1700B404713C81EA42708448F80 /* DisposeBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBase.swift; path = RxSwift/Disposables/DisposeBase.swift; sourceTree = "<group>"; };
 		5D38B2FF55E91860325C2621DA292ADD /* Variable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Variable.swift; path = RxSwift/Subjects/Variable.swift; sourceTree = "<group>"; };
+		5E0BA6DB1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkLoggerPlugin.swift; sourceTree = "<group>"; };
 		5E90B93F7F0178E64180BBF4C9E24196 /* ObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObjCMatcher.swift; path = Nimble/Wrappers/ObjCMatcher.swift; sourceTree = "<group>"; };
 		5EA4F28DD575931B4AEE9BF0A31E9B2C /* RxMoya-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "RxMoya-Private.xcconfig"; sourceTree = "<group>"; };
 		5EE9CDAA66A1AEF359EDAC1E3E493801 /* RACScheduler+Subclass.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "RACScheduler+Subclass.h"; path = "ReactiveCocoa/Objective-C/RACScheduler+Subclass.h"; sourceTree = "<group>"; };
@@ -1615,6 +1619,7 @@
 			children = (
 				4D69297F1BBE84FA0047AF37 /* CredentialsPlugin.swift */,
 				4D6929831BBE85F70047AF37 /* NetworkActivityPlugin.swift */,
+				5E0BA6DB1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift */,
 			);
 			path = Plugins;
 			sourceTree = "<group>";
@@ -2594,6 +2599,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D69297C1BBE74200047AF37 /* Plugin.swift in Sources */,
+				5E0BA6DD1BC09F7700DF2A91 /* NetworkLoggerPlugin.swift in Sources */,
 				1636A38CEDCB1E5B003FE49DB018828B /* Endpoint.swift in Sources */,
 				8C38C3BB3CFD1212CA3F64F1940A930C /* Moya+ReactiveCocoa.swift in Sources */,
 				D3EE5901BBC3FE317AFEDF352BFAD5BF /* Moya.swift in Sources */,
@@ -2667,6 +2673,7 @@
 				02CE45128A7EAC5299B6FD9582C1A091 /* MoyaError.swift in Sources */,
 				8A4A2FDAECF996EC9E19E5989C934A4C /* MoyaResponse.swift in Sources */,
 				22806D87264A4B304ED1D00FCBE880A9 /* Observable+Moya.swift in Sources */,
+				5E0BA6DE1BC09F7800DF2A91 /* NetworkLoggerPlugin.swift in Sources */,
 				4D69297D1BBE74200047AF37 /* Plugin.swift in Sources */,
 				A5E98A2C5D3F61DB05F0F56019058EED /* RxMoya-dummy.m in Sources */,
 			);
@@ -2825,6 +2832,7 @@
 				4D69297B1BBE74200047AF37 /* Plugin.swift in Sources */,
 				82BE4B47F4D0038489B77EA1797FDAAA /* Moya.swift in Sources */,
 				4D6929801BBE84FA0047AF37 /* CredentialsPlugin.swift in Sources */,
+				5E0BA6DC1BC09F2A00DF2A91 /* NetworkLoggerPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.default_subspec = "Core"
 
   s.subspec "Core" do |ss|
-    ss.source_files  = "Moya/*.swift"
+    ss.source_files  = "Moya/*.swift", "Moya/Plugins/*swift"
     ss.dependency "Alamofire", "~> 2.0"
     ss.framework  = "Foundation"
   end

--- a/Moya/Endpoint.swift
+++ b/Moya/Endpoint.swift
@@ -5,13 +5,14 @@ import Alamofire
 public enum EndpointSampleResponse {
     // Swift won't let us put an enum inside a generic class like Endpoint.
 
-    case Success(Int, () -> NSData)
-    case Error(Int?, ErrorType?, (() -> NSData)?)
+    case NetworkResponse(Int, () -> NSData)
+    case NetworkError(ErrorType?)
+    // TODO: We don't need this anymore, let's just evaluate all the sample responses.
     case Closure(() -> EndpointSampleResponse)
 
     func evaluate() -> EndpointSampleResponse {
         switch self {
-        case Success, Error: return self
+        case NetworkResponse, NetworkError: return self
         case Closure(let closure):
             return closure().evaluate()
         }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -167,7 +167,7 @@ public extension MoyaProvider {
 
     public final class func DefaultEndpointMapping(target: Target) -> Endpoint<Target> {
         let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-        return Endpoint(URL: url, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+        return Endpoint(URL: url, sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     }
 
     public final class func DefaultRequestMapping(endpoint: Endpoint<Target>, closure: NSURLRequest -> Void) {
@@ -235,12 +235,12 @@ private extension MoyaProvider {
             }
 
             switch endpoint.sampleResponse.evaluate() {
-            case .Success(let statusCode, let data):
+            case .NetworkResponse(let statusCode, let data):
                 plugins.forEach { $0.didReceiveResponse(data(), statusCode: statusCode, response: nil, error: nil, provider: self, token: token) }
                 completion(data: data(), statusCode: statusCode, response: nil, error: nil)
-            case .Error(let statusCode, let error, let data):
-                plugins.forEach { $0.didReceiveResponse(data?(), statusCode: statusCode, response: nil, error: error, provider: self, token: token) }
-                completion(data: data?(), statusCode: statusCode, response: nil, error: error)
+            case .NetworkError(let error):
+                plugins.forEach { $0.didReceiveResponse(nil, statusCode: nil, response: nil, error: error, provider: self, token: token) }
+                completion(data: nil, statusCode: nil, response: nil, error: error)
             case .Closure:
                 break  // the `evaluate()` method will never actually return a .Closure
             }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -260,3 +260,6 @@ private struct CancellableWrapper: Cancellable {
         innerCancellable?.cancel()
     }
 }
+
+/// Make the Alamofire Request type conform to our type, to prevent leaking Alamofire to plugins.
+extension Request: MoyaRequest { }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -179,11 +179,11 @@ public extension MoyaProvider {
 private extension MoyaProvider {
 
     func sendRequest(target: Target, request: NSURLRequest, completion: Moya.Completion) -> CancellableToken {
-        var request = manager.request(request)
+        let request = manager.request(request)
         let plugins = self.plugins
         
         // Give plugins the chance to alter the outgoing request
-        plugins.forEach { request = $0.willSendRequest(request, provider: self, target: target) }
+        plugins.forEach { $0.willSendRequest(request, provider: self, target: target) }
         
         // Perform the actual request
         request.response { (_, response: NSHTTPURLResponse?, data: NSData?, error: ErrorType?) -> () in

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -77,25 +77,6 @@ public protocol Cancellable {
     func cancel()
 }
 
-/// Internal token that can be used to cancel requests
-struct CancellableToken: Cancellable {
-    let cancelAction: () -> Void
-
-    func cancel() {
-        cancelAction()
-    }
-}
-
-struct CancellableWrapper: Cancellable {
-    var innerCancellable: CancellableToken? = nil
-
-    private var isCancelled = false
-
-    func cancel() {
-        innerCancellable?.cancel()
-    }
-}
-
 /// Request provider class. Requests should be made through this class only.
 public class MoyaProvider<Target: MoyaTarget> {
 
@@ -258,5 +239,24 @@ private extension MoyaProvider {
         }
 
         return cancellableToken
+    }
+}
+
+/// Private token that can be used to cancel requests
+private struct CancellableToken: Cancellable {
+    let cancelAction: () -> Void
+
+    func cancel() {
+        cancelAction()
+    }
+}
+
+private struct CancellableWrapper: Cancellable {
+    var innerCancellable: CancellableToken? = nil
+
+    private var isCancelled = false
+
+    func cancel() {
+        innerCancellable?.cancel()
     }
 }

--- a/Moya/Moya.swift
+++ b/Moya/Moya.swift
@@ -167,7 +167,7 @@ public extension MoyaProvider {
 
     public final class func DefaultEndpointMapping(target: Target) -> Endpoint<Target> {
         let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-        return Endpoint(URL: url, sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+        return Endpoint(URL: url, sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
     }
 
     public final class func DefaultRequestMapping(endpoint: Endpoint<Target>, closure: NSURLRequest -> Void) {
@@ -234,15 +234,13 @@ private extension MoyaProvider {
                 return
             }
 
-            switch endpoint.sampleResponse.evaluate() {
+            switch endpoint.sampleResponseClosure() {
             case .NetworkResponse(let statusCode, let data):
-                plugins.forEach { $0.didReceiveResponse(data(), statusCode: statusCode, response: nil, error: nil, provider: self, token: token) }
-                completion(data: data(), statusCode: statusCode, response: nil, error: nil)
+                plugins.forEach { $0.didReceiveResponse(data, statusCode: statusCode, response: nil, error: nil, provider: self, token: token) }
+                completion(data: data, statusCode: statusCode, response: nil, error: nil)
             case .NetworkError(let error):
                 plugins.forEach { $0.didReceiveResponse(nil, statusCode: nil, response: nil, error: error, provider: self, token: token) }
                 completion(data: nil, statusCode: nil, response: nil, error: error)
-            case .Closure:
-                break  // the `evaluate()` method will never actually return a .Closure
             }
         }
 

--- a/Moya/Plugin.swift
+++ b/Moya/Plugin.swift
@@ -24,9 +24,8 @@ public class Plugin<Target: MoyaTarget> {
     // 
     // This does not work, because `plugins` is now unable to infer the actual type of the typealias `T`.
     
-    func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
+    func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
         // Should be overridden if necessary
-        return request
     }
     
     func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {

--- a/Moya/Plugin.swift
+++ b/Moya/Plugin.swift
@@ -24,12 +24,12 @@ public class Plugin<Target: MoyaTarget> {
     // 
     // This does not work, because `plugins` is now unable to infer the actual type of the typealias `T`.
     
-    func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, token: Target) -> Alamofire.Request {
+    func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
         // Should be overridden if necessary
         return request
     }
     
-    func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, token: Target) {
+    func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {
         // Should be overridden if necessary
     }
 

--- a/Moya/Plugin.swift
+++ b/Moya/Plugin.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// A Moya Plugin receives callbacks to perform side effects wherever a request is sent or received.
 ///
@@ -23,13 +22,32 @@ public class Plugin<Target: MoyaTarget> {
     // let plugins = [Plugin]()
     // 
     // This does not work, because `plugins` is now unable to infer the actual type of the typealias `T`.
-    
-    func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
-        // Should be overridden if necessary
-    }
-    
-    func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {
+
+    /// Called immediately before a request is sent over the network (or stubbed).
+    func willSendRequest(request: MoyaRequest, provider: MoyaProvider<Target>, target: Target) {
         // Should be overridden if necessary
     }
 
+    // Called after a response has been received, but before the MoyaProvider has invoked its completion handler.
+    func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {
+        // Should be overridden if necessary
+    }
+}
+
+/// Request type used by willSendRequest plugin function.
+public protocol MoyaRequest {
+
+    // Note:
+    //
+    // We use this protocol instead of the Alamofire request to avoid leaking that abstraction. 
+    // A plugin should not know about Alamofire at all.
+
+    /// Retrieve an NSURLRequest represetation.
+    var request: NSURLRequest? { get }
+
+    /// Authenticates the request with a username and password.
+    func authenticate(user user: String, password: String, persistence: NSURLCredentialPersistence) -> Self
+
+    /// Authnenticates the request with a NSURLCredential instance.
+    func authenticate(usingCredential credential: NSURLCredential) -> Self
 }

--- a/Moya/Plugins/CredentialsPlugin.swift
+++ b/Moya/Plugins/CredentialsPlugin.swift
@@ -15,11 +15,9 @@ public class CredentialsPlugin<Target: MoyaTarget>: Plugin<Target> {
     
     // MARK: Plugin
     
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
         if let credentials = credentialsClosure(target) {
             request.authenticate(usingCredential: credentials)
         }
-        return request
     }
-    
 }

--- a/Moya/Plugins/CredentialsPlugin.swift
+++ b/Moya/Plugins/CredentialsPlugin.swift
@@ -15,8 +15,8 @@ public class CredentialsPlugin<Target: MoyaTarget>: Plugin<Target> {
     
     // MARK: Plugin
     
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, token: Target) -> Alamofire.Request {
-        if let credentials = credentialsClosure(token) {
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
+        if let credentials = credentialsClosure(target) {
             request.authenticate(usingCredential: credentials)
         }
         return request

--- a/Moya/Plugins/CredentialsPlugin.swift
+++ b/Moya/Plugins/CredentialsPlugin.swift
@@ -1,21 +1,18 @@
 import Foundation
-import Alamofire
-
 
 /// Provides each request with optional NSURLCredentials.
 public class CredentialsPlugin<Target: MoyaTarget>: Plugin<Target> {
-    
+
     public typealias CredentialClosure = Target -> NSURLCredential?
     let credentialsClosure: CredentialClosure
-    
+
     public init(credentialsClosure: CredentialClosure) {
         self.credentialsClosure = credentialsClosure
     }
-    
-    
+
     // MARK: Plugin
     
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
+    public override func willSendRequest(request: MoyaRequest, provider: MoyaProvider<Target>, target: Target) {
         if let credentials = credentialsClosure(target) {
             request.authenticate(usingCredential: credentials)
         }

--- a/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Moya/Plugins/NetworkActivityPlugin.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// Network activity change notification type.
 public enum NetworkActivityChangeType {
@@ -15,12 +14,11 @@ public class NetworkActivityPlugin<Target: MoyaTarget>: Plugin<Target> {
     public init(networkActivityClosure: NetworkActivityClosure) {
         self.networkActivityClosure = networkActivityClosure
     }
-    
-    
+
     // MARK: Plugin
-    
+
     /// Called by the provider as soon as the request is about to start
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
+    public override func willSendRequest(request: MoyaRequest, provider: MoyaProvider<Target>, target: Target) {
         networkActivityClosure(change: .Began)
     }
 
@@ -28,5 +26,4 @@ public class NetworkActivityPlugin<Target: MoyaTarget>: Plugin<Target> {
     public override func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {
         networkActivityClosure(change: .Ended)
     }
-    
 }

--- a/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Moya/Plugins/NetworkActivityPlugin.swift
@@ -20,9 +20,8 @@ public class NetworkActivityPlugin<Target: MoyaTarget>: Plugin<Target> {
     // MARK: Plugin
     
     /// Called by the provider as soon as the request is about to start
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
         networkActivityClosure(change: .Began)
-        return request
     }
 
     /// Called by the provider as soon as a response arrives

--- a/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Moya/Plugins/NetworkActivityPlugin.swift
@@ -20,13 +20,13 @@ public class NetworkActivityPlugin<Target: MoyaTarget>: Plugin<Target> {
     // MARK: Plugin
     
     /// Called by the provider as soon as the request is about to start
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, token: Target) -> Alamofire.Request {
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
         networkActivityClosure(change: .Began)
         return request
     }
 
     /// Called by the provider as soon as a response arrives
-    public override func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, token: Target) {
+    public override func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {
         networkActivityClosure(change: .Ended)
     }
     

--- a/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Alamofire
+
+public class NetworkLoggerPlugin<Target: MoyaTarget>: Plugin<Target> {
+    private let loggerId = "Moya_Logger"
+    private let dateFormatString = "dd/MM/yyyy HH:mm:ss"
+    private let dateFormatter = NSDateFormatter()
+
+    /// If true, also logs response data
+    public let verbose: Bool
+
+    public init(verbose: Bool = false) {
+        self.verbose = verbose
+    }
+
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
+        logNetworkRequest(request.request)
+
+        return request
+    }
+
+    public override func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {
+        logNetworkResponse(response, data: data, target: target)
+    }
+
+}
+
+private extension NetworkLoggerPlugin {
+
+    private var date: String {
+        dateFormatter.dateFormat = dateFormatString
+        dateFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
+        return dateFormatter.stringFromDate(NSDate())
+    }
+
+    func logNetworkRequest(request: NSURLRequest?) {
+
+        var output = ""
+
+        output += String(format: "%@: [%@] Request:  %@", loggerId, date, request?.description ?? "(invalid request)")
+
+        if let headers = request?.allHTTPHeaderFields {
+            output += String(format: "%@ [%@] Request Headers:  %@", loggerId, date, headers)
+        }
+
+        if let bodyStream = request?.HTTPBodyStream {
+            output += String(format: "%@: [%@] Request Body Stream:  %@", loggerId, date, bodyStream.description)
+        }
+
+        if let httpMethod = request?.HTTPMethod {
+            output += String(format: "%@: [%@] HTTP Request Method:  %@", loggerId, date, httpMethod)
+        }
+
+        if let body = request?.HTTPBody where verbose == true {
+            if let stringOutput = NSString(data: body, encoding: NSUTF8StringEncoding) {
+                output += String(format: "%@: [%@] Request Body:  %@", loggerId, date, stringOutput)
+            }
+        }
+
+        print(output)
+    }
+
+    func logNetworkResponse(response: NSURLResponse?, data: NSData?, target: Target) {
+        guard let response = response else {
+            print("Received empty network response for \(target).")
+            return
+        }
+
+        var output = ""
+
+        output += String(format: "%@: [%@] Response:  %@", loggerId, date, response.description)
+
+        if let data = data,
+            let stringData = NSString(data: data, encoding: NSUTF8StringEncoding) as? String
+            where verbose == true {
+            output += stringData
+        }
+
+        print(output)
+    }
+}

--- a/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -1,19 +1,19 @@
 import Foundation
-import Alamofire
 
+/// Logs network activity (outgoing requests and incoming responses).
 public class NetworkLoggerPlugin<Target: MoyaTarget>: Plugin<Target> {
     private let loggerId = "Moya_Logger"
     private let dateFormatString = "dd/MM/yyyy HH:mm:ss"
     private let dateFormatter = NSDateFormatter()
 
-    /// If true, also logs response data
+    /// If true, also logs response body data.
     public let verbose: Bool
 
     public init(verbose: Bool = false) {
         self.verbose = verbose
     }
 
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
+    public override func willSendRequest(request: MoyaRequest, provider: MoyaProvider<Target>, target: Target) {
         logNetworkRequest(request.request)
     }
 

--- a/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -13,10 +13,8 @@ public class NetworkLoggerPlugin<Target: MoyaTarget>: Plugin<Target> {
         self.verbose = verbose
     }
 
-    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) -> Alamofire.Request {
+    public override func willSendRequest(request: Alamofire.Request, provider: MoyaProvider<Target>, target: Target) {
         logNetworkRequest(request.request)
-
-        return request
     }
 
     public override func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, provider: MoyaProvider<Target>, target: Target) {

--- a/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Moya/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -24,11 +24,7 @@ public class ReactiveCocoaMoyaProvider<Target where Target: MoyaTarget>: MoyaPro
 
                 let cancellableToken = self?.request(token) { data, statusCode, response, error in
                     if let error = error {
-                        if let statusCode = statusCode {
-                            sendError(requestSink, NSError(domain: MoyaErrorDomain, code: statusCode, userInfo: [NSUnderlyingErrorKey: error as NSError]))
-                        } else {
-                            sendError(requestSink, error as NSError)
-                        }
+                        sendError(requestSink, error as NSError)
                     } else {
                         if let data = data {
                             sendNext(requestSink, MoyaResponse(statusCode: statusCode!, data: data, response: response))

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some awesome features of Moya:
 Sample Project
 --------------
 
-There's a sample project in the Demo directory. Go nuts!
+There's a sample project in the Demo directory. Have fun!
 
 Project Status
 --------------
@@ -89,7 +89,7 @@ github "Moya/Moya"
 Use
 ---
 
-After some setup, using Moya is really simple. You can access an API like this:
+After [some setup](docs/Examples.md), using Moya is really simple. You can access an API like this:
 
 ```swift
 provider.request(.Zen) { (data, statusCode, response, error) in
@@ -113,7 +113,7 @@ provider.request(.UserProfile("ashfurrow")) { (data, statusCode, response, error
 No more typos in URLs. No more missing parameter values. No more messing with
 parameter encoding.
 
-For more examples, see the [documentation](docs/).
+For examples, see the [documentation](docs/).
 
 ReactiveCocoa Extensions
 ------------------------

--- a/ReactiveMoya.podspec
+++ b/ReactiveMoya.podspec
@@ -4,6 +4,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/Moya/Moya.git", :tag => s.version }
 
-  s.source_files = ["Moya/*swift", "Moya/ReactiveCore/*.swift", "Moya/ReactiveCocoa/*.swift"]
+  s.source_files = ["Moya/*swift", "Moya/Plugins/*swift", "Moya/ReactiveCore/*.swift", "Moya/ReactiveCocoa/*.swift"]
   s.dependency "ReactiveCocoa", "~> 4.0-alpha.1"
 end

--- a/RxMoya.podspec
+++ b/RxMoya.podspec
@@ -4,6 +4,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/Moya/Moya.git", :tag => s.version }
 
-  s.source_files = ["Moya/*swift", "Moya/ReactiveCore/*.swift", "Moya/RxSwift/*.swift"]
+  s.source_files = ["Moya/*swift", "Moya/Plugins/*swift", "Moya/ReactiveCore/*.swift", "Moya/RxSwift/*.swift"]
   s.dependency "RxSwift", "~> 2.0.0-alpha"
 end

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -1,0 +1,62 @@
+Authentication
+==============
+
+Authentication can be tricky. There are a few ways network requests
+can be authenticated. Let's discuss two of the common ones.
+
+Basic HTTP Auth
+---------------
+
+HTTP auth is a username/password challenge built into the HTTP protocol
+itself. If you need to use HTTP auth, you can provide a `CredentialsPlugin`
+when initializeing your provider. 
+
+```swift
+let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin<HTTPBin> { _ -> NSURLCredential? in
+    return NSURLCredential(user: "user", password: "passwd", persistence: .None)
+  }
+])
+```
+
+This specific examples shows a use of HTTP that authenticates _every_ request, 
+which is usually not necessary. This might be a better idea:
+
+```swift
+let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin<HTTPBin> { target -> NSURLCredential? in
+    switch target {
+      case .TargetThatNeedsAuthentication:
+        return NSURLCredential(user: "user", password: "passwd", persistence: .None)
+      default:
+        return nil
+    }
+  }
+])
+```
+
+OAuth
+-----
+
+OAuth is quite a bit trickier. It involes a multistep process that is often 
+different between different APIs. You _really_ don't want to do OAuth yourself –
+there are other libraries to do it for you. [Heimdall.swift](https://github.com/rheinfabrik/Heimdall.swift),
+for example. The trick is just getting Moya and whatever you're using to talk
+to one another. 
+
+Moya is built with OAuth in mind. "Signing" a network request with OAuth can
+itself sometimes require network requests be performed _first_, so signing
+a request for Moya is an asynchronous process. Let's see an example. 
+
+```swift
+let requestClosure = { (endpoint: Endpoint<YourAPI>, done: NSURLRequest -> Void) in
+    let request = endpoint.urlRequest // This is the request Moya generates
+    YourAwesomeOAuthProvider.signRequest(request, completion: { signedRequest in
+      // The OAuth provider can make its own network calls to sign your request.
+      // However, you *must* call `done()` with the signed so that Moya can
+      // actually send it!
+      done(signedRequest)
+    })
+}
+let provider = MoyaProvider(requestClosure: requestClosure)
+```
+
+(Note that Swift is able to infer the `YourAPI` generic – neat!)

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -25,7 +25,7 @@ The first might resemble the following:
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-    return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    return Endpoint(URL: url!, sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
 }
 ```
 
@@ -61,7 +61,7 @@ analytics.
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
     return endpoint.endpointByAddingHTTPHeaderFields(["APP_NAME": "MY_AWESOME_APP"])
 }
 ```
@@ -74,7 +74,7 @@ target that actually does the authentication. We could construct an
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
 
     // Sign all non-authenticating requests
     switch target {

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -25,7 +25,7 @@ The first might resemble the following:
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-    return Endpoint(URL: url!, sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    return Endpoint(URL: url!, sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 }
 ```
 
@@ -61,7 +61,7 @@ analytics.
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
     return endpoint.endpointByAddingHTTPHeaderFields(["APP_NAME": "MY_AWESOME_APP"])
 }
 ```
@@ -74,7 +74,7 @@ target that actually does the authentication. We could construct an
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url(target), sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 
     // Sign all non-authenticating requests
     switch target {

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -142,7 +142,7 @@ provider = MoyaProvider<GitHub>(requestClosure: requestClosure)
 Note that the `endpointResolver` is *not* intended to be used for any sort of 
 application-level mapping. This closure is really about modifying properties 
 specific to the `NSURLRequest`, or providing information to the request that 
-cannot be known until that request is created, like an OAuth signature. 
+cannot be known until that request is created, like cookies settings.
 
 This parameter is actually very useful for modifying the request object. 
 `NSURLRequest` has many properties you can customize. Say you want to disable 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -67,7 +67,7 @@ public func url(route: MoyaTarget) -> String {
 }
 
 let endpointClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponse: .Success(200, target.sampleData))
+    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponse: .NetworkResponse(200, target.sampleData))
 }
 ```
 
@@ -88,9 +88,9 @@ whatever you want. Say you want to test errors, too.
 let failureEndpointClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
     let sampleResponse = { () -> (EndpointSampleResponse) in
         if sendErrors {
-            return .Error(404, NSError())
+            return .NetworkError(NSError())
         } else {
-            return .Success(200, target.sampleData)
+            return .NetworkResponse(200, target.sampleData)
         }
     }()
     return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponse: sampleResponse)

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -67,7 +67,7 @@ public func url(route: MoyaTarget) -> String {
 }
 
 let endpointClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
-    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponse: .NetworkResponse(200, target.sampleData))
+    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponseClosure: {.NetworkResponse(200, target.sampleData)})
 }
 ```
 
@@ -82,18 +82,18 @@ example, though, they're just passed right through.
 Most of the time, this closure is just a straight translation from target,
 method, and parameters, into an `Endpoint` instance. However, since it's a
 closure, it'll be executed at each invocation of the API, so you could do
-whatever you want. Say you want to test errors, too.
+whatever you want. Say you want to test network error conditions like timeouts, too.
 
 ```swift
 let failureEndpointClosure = { (target: GitHub, method: Moya.Method, parameters: [String: AnyObject]) -> Endpoint<GitHub> in
-    let sampleResponse = { () -> (EndpointSampleResponse) in
-        if sendErrors {
+    let sampleResponseClosure = { () -> (EndpointSampleResponse) in
+        if shouldTimeout {
             return .NetworkError(NSError())
         } else {
             return .NetworkResponse(200, target.sampleData)
         }
     }()
-    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponse: sampleResponse)
+    return Endpoint<GitHub>(URL: url(target), method: method, parameters: parameters, sampleResponseClosure: sampleResponseClosure)
 }
 ```
 

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -120,5 +120,5 @@ let provider = MoyaProvider<MyTarget>(manager: manager)
 
 You may also provide an array of `plugins` to the provider. These receive callbacks
 before a request is sent and after a response is received. There are a few plugins
-included already: one for network activity (`NetworkActivityPlugin`) and another
-for [HTTP Authentication](Authentication.md).
+included already: one for network activity (`NetworkActivityPlugin`), one for logging
+all network activity (`NetworkLoggerPlugin`), and another for [HTTP Authentication](Authentication.md).

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -38,7 +38,7 @@ concrete `Endpoint` instance. Let's take a look at what one might look like.
 ```swift
 let endpointClosure = { target: MyTarget -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-    return Endpoint(URL: url!, sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    return Endpoint(URL: url!, sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 }
 let provider = MoyaProvider(endpointClosure: endpointClosure)
 ```

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -117,3 +117,8 @@ let manager = Manager(
 
 let provider = MoyaProvider<MyTarget>(manager: manager)
 ```
+
+You may also provide an array of `plugins` to the provider. These receive callbacks
+before a request is sent and after a response is received. There are a few plugins
+included already: one for network activity (`NetworkActivityPlugin`) and another
+for [HTTP Authentication](Authentication.md).

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -38,7 +38,7 @@ concrete `Endpoint` instance. Let's take a look at what one might look like.
 ```swift
 let endpointClosure = { target: MyTarget -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-    return Endpoint(URL: url!, sampleResponse: .Success(200, {target.sampleData}), method: target.method, parameters: target.parameters)
+    return Endpoint(URL: url!, sampleResponse: .NetworkResponse(200, {target.sampleData}), method: target.method, parameters: target.parameters)
 }
 let provider = MoyaProvider(endpointClosure: endpointClosure)
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ It accomplishes this with the following pipline.
 ----------------
 
 <p align="center">
-    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="ReactiveExtensions.md">ReactiveCocoa</a>
+    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveExtensions.md">ReactiveCocoa</a>
 </p>
 
 ----------------
@@ -17,6 +17,9 @@ It accomplishes this with the following pipline.
 You _should not_ have to reference Alamofire directly. It's an _awesome_ 
 library, but the point of Moya is that you don't have to deal with details
 that are that low-level. 
+
+(If you _need_ to use Alamofire, you can pass in a `Manager` instance to the
+`MoyaProvider` initializer.)
 
 If there is something you want to change about the behaviour of Moya, there is 
 probably a way to do it without modifying the library. Moya is designed to be 


### PR DESCRIPTION
This does a few things.

- All sample responses are now evaluated lazily, obviating the need for a `Closure` case in the sample response enum.
- The `EndpointSampleResponse` has been simplified. No one really understood what the difference between `Success` and `Error` was (looking at the unit tests, it doesn't look like _I_ even understood the difference).
- Adds documentation for authentication (HTTP and OAuth).
- Adds logging plugin based on @AlexanderKaraberov's work in #235).

Generally I really like how 3.0.0 has been coming along. Thanks to a lot of work from a lot of different contributors, Moya has gotten simpler and less complex, while also far more powerful. 

After this I thing we should go ahead and release 3.0.0 (see #236).

Fixes #200.
Fixes #220.