### PR TITLE
Updates reactive extension documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,18 +115,47 @@ parameter encoding.
 
 For examples, see the [documentation](docs/).
 
-ReactiveCocoa Extensions
-------------------------
+Reactive Extensions
+-------------------
 
-Even cooler are the ReactiveCocoa extensions. It immediately returns a
-`RACSignal` that you can subscribe to or bind or map or whatever you want to
-do. To handle errors, for instance, we could do the following:
+Even cooler are the reactive extensions. Moya provides reactive extensions for
+`ReactiveCocoa` and `RxSwift`.
+
+## ReactiveCocoa
+
+For `ReactiveCocoa`, it immediately returns a `SignalProducer` (`RACSignal` is also
+ available if needed) that you can start or bind or map or whatever you want to do.
+ To handle errors, for instance, we could do the following:
 
 ```swift
-provider.request(.UserProfile("ashfurrow")).subscribeNext { (object) -> Void in
-    image = UIImage(data: object as? NSData)
-}, error: { (error) -> Void in
-    println(error)
+provider.request(.UserProfile("ashfurrow")).start { (event) -> Void in
+    switch event {
+    case .Next(let response):
+        image = UIImage(data: response.data)
+    case .Error(let error):
+        print(error)
+    default:
+      break
+    }
+}
+```
+
+##RxSwift
+
+For `RxSwift`, it immediately returns an `Observable` that you can subscribe to
+or bind or map or whatever you want to do. To handle errors, for instance, we could do
+the following:
+
+```swift
+provider.request(.UserProfile("ashfurrow")).subscribe { (event) -> Void in
+    switch event {
+    case .Next(let response):
+        image = UIImage(data: response.data)
+    case .Error(let error):
+        print(error)
+    default:
+        break
+    }
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,31 +1,31 @@
 Documentation
 =============
 
-Moya is about working at *high levels of abstraction* in your application. 
-It accomplishes this with the following pipline. 
+Moya is about working at *high levels of abstraction* in your application.
+It accomplishes this with the following pipeline.
 
 ![Pipeline](https://raw.github.com/Moya/Moya/master/web/pipeline.png)
 
 ----------------
 
 <p align="center">
-    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveExtensions.md">ReactiveCocoa</a>
+    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveCocoa.md">ReactiveCocoa</a> &bull; <a href="RxSwift.md">RxSwift</a>
 </p>
 
 ----------------
 
-You _should not_ have to reference Alamofire directly. It's an _awesome_ 
+You _should not_ have to reference Alamofire directly. It's an _awesome_
 library, but the point of Moya is that you don't have to deal with details
-that are that low-level. 
+that are that low-level.
 
 (If you _need_ to use Alamofire, you can pass in a `Manager` instance to the
 `MoyaProvider` initializer.)
 
-If there is something you want to change about the behaviour of Moya, there is 
-probably a way to do it without modifying the library. Moya is designed to be 
-super-flexible and accommodate the needs of every developer. It's less of a 
-framework _of code_ and more of a framework of _how to think_ about network 
-requests. 
+If there is something you want to change about the behaviour of Moya, there is
+probably a way to do it without modifying the library. Moya is designed to be
+super-flexible and accommodate the needs of every developer. It's less of a
+framework _of code_ and more of a framework of _how to think_ about network
+requests.
 
-Remember, if at any point you have a question, just [open an issue](http://github.com/Moya/Moya/issues/new) 
+Remember, if at any point you have a question, just [open an issue](http://github.com/Moya/Moya/issues/new)
 and we'll get you some help.

--- a/docs/ReactiveCocoa.md
+++ b/docs/ReactiveCocoa.md
@@ -1,0 +1,53 @@
+ReactiveCocoa
+=============
+
+Moya provides an optional `ReactiveCocoaMoyaProvider` subclass of
+`MoyaProvider` that does a few interesting things. Instead of
+calling the `request()` method and providing a callback closure
+to be executed when the request completes, we use `SignalProducer`s
+(`RACSignal`s are also available for those who need it).
+
+The network request is not started until the signal is subscribed
+to. If a request is made while an identical request is already
+in-progress, the original signal is returned, instead. If the
+subscription to the signal is disposed of before the request
+completes, it is cancelled.
+
+If the request completes normally, two things happen:
+
+1. The signal sends a value, a `MoyaResponse` instance.
+2. The signal completes.
+
+If the request produces an error (typically a NSURLSession error),
+then it sends an error, instead. The error's `code` is the failing
+request's status code, if any, and the response data, if any.
+
+The `MoyaResponse` class contains a `statusCode`, some `data`,
+and a(n optional) `NSURLResponse`. You can use these values however
+you like in `startWithNext` or `map` calls.
+
+To make things even awesomer, Moya provides some extensions to
+`SignalProducer` (and `RACSignal`) that make dealing with `MoyaResponses`
+really easy.
+
+- `filterStatusCodes()` takes a range of status codes. If the
+  response's status code is not within that range, an error is
+  produced.
+- `filterStatusCode()` looks for a specific status code, and errors
+  if it finds anything else.
+- `filterSuccessfulStatusCodes()` filters status codes that
+  are in the 200-range.
+- `filterSuccessfulStatusAndRedirectCodes()` filters status codes
+  that are in the 200-300 range.
+- `mapImage()` tries to map the response data to a `UIImage` instance
+  and errors if unsuccessful.
+- `mapJSON()` tries to map the response data to a JSON object and
+  errors if unsuccessful.
+- `mapString()` tries to map the response data to a string and
+  errors if unsuccessful.
+
+In the error cases, the error's `domain` is `MoyaErrorDomain`. The code
+is one of `MoyaErrorCode`'s `rawValue`s, where appropriate. Wherever
+possible, underlying errors are provided and the original response
+data is included in the `NSError`'s `userInfo` dictionary using the
+"data" key.

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -1,0 +1,51 @@
+RxSwift
+=======
+
+Moya provides an optional `RxMoyaProvider` subclass of
+`MoyaProvider` that does a few interesting things. Instead of
+calling the `request()` method and providing a callback closure
+to be executed when the request completes, we use `Observable`s.
+
+The network request is not started until the signal is subscribed
+to. If a request is made while an identical request is already
+in-progress, the original signal is returned, instead. If the
+subscription to the signal is disposed of before the request
+completes, it is cancelled.
+
+If the request completes normally, two things happen:
+
+1. The observable sends a value, a `MoyaResponse` instance.
+2. The observable completes.
+
+If the request produces an error (typically a NSURLSession error),
+then it sends an error, instead. The error's `code` is the failing
+request's status code, if any, and the response data, if any.
+
+The `MoyaResponse` class contains a `statusCode`, some `data`,
+and a(n optional) `NSURLResponse`. You can use these values however
+you like in `subscribeNext` or `map` calls.
+
+To make things even awesomer, Moya provides some extensions to
+`Observable` that make dealing with `MoyaResponses`really easy.
+
+- `filterStatusCodes()` takes a range of status codes. If the
+  response's status code is not within that range, an error is
+  produced.
+- `filterStatusCode()` looks for a specific status code, and errors
+  if it finds anything else.
+- `filterSuccessfulStatusCodes()` filters status codes that
+  are in the 200-range.
+- `filterSuccessfulStatusAndRedirectCodes()` filters status codes
+  that are in the 200-300 range.
+- `mapImage()` tries to map the response data to a `UIImage` instance
+  and errors if unsuccessful.
+- `mapJSON()` tries to map the response data to a JSON object and
+  errors if unsuccessful.
+- `mapString()` tries to map the response data to a string and
+  errors if unsuccessful.
+
+In the error cases, the error's `domain` is `MoyaErrorDomain`. The code
+is one of `MoyaErrorCode`'s `rawValue`s, where appropriate. Wherever
+possible, underlying errors are provided and the original response
+data is included in the `NSError`'s `userInfo` dictionary using the
+"data" key.


### PR DESCRIPTION
Updates the documentation to reflect the 3.0.0 changes to the reactive providers. Addresses #227 and also updates the documentation to ReactiveCocoa 4. Possibly both could ReactiveCocoa and RxSwift documentation could be combined since they are very similar but I left it separate since most likely a user will be looking for one or the other and not both.

It also updates the examples in the main readme and adds an RxSwift one (#177).