### PR TITLE
Closes #245 Update Endpoints.md to fix endpointResolver typo

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -137,10 +137,7 @@ let requestClosure = { (endpoint: Endpoint<GitHub>, done: NSURLRequest -> Void) 
 provider = MoyaProvider<GitHub>(requestClosure: requestClosure)
 ```
 
-Note that the `endpointResolver` is *not* intended to be used for any sort of 
-application-level mapping. This closure is really about modifying properties 
-specific to the `NSURLRequest`, or providing information to the request that 
-cannot be known until that request is created, like cookies settings.
+This `requestClosure` is useful for modifying properties specific to the `NSURLRequest` or providing information to the request that cannot be known until that request is created, like cookies settings. Note that the `endpointClosure` mentioned above is not intended for this purpose or any request-specific application-level mapping.
 
 This parameter is actually very useful for modifying the request object. 
 `NSURLRequest` has many properties you can customize. Say you want to disable 


### PR DESCRIPTION
Also make wording a bit more clear by discussing the requestClosure first and then then how endpointClosure should not be used for the same purpose after.