### PR TITLE
mapImage uses implicitly unwrapped optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+- Changes `mapImage()` RxSwift function to use `UIImage!` instead of `UIImage`.
+
 # 3.0.0
 
 - Makes `parameters` on `MoyaTarget` an optional `[String: AnyObject]` dictionary.

--- a/Moya/RxSwift/Observable+Moya.swift
+++ b/Moya/RxSwift/Observable+Moya.swift
@@ -27,8 +27,8 @@ extension ObservableType where E: MoyaResponse {
     }
     
     /// Maps data received from the signal into a UIImage. If the conversion fails, the signal errors.
-    public func mapImage() -> Observable<UIImage> {
-        return flatMap { response -> Observable<UIImage> in
+    public func mapImage() -> Observable<UIImage!> {
+        return flatMap { response -> Observable<UIImage!> in
             guard let image = UIImage(data: response.data) else {
                 throw NSError(domain: MoyaErrorDomain, code: MoyaErrorCode.ImageMapping.rawValue, userInfo: ["data": response])
             }


### PR DESCRIPTION
A small change, not breaking. Adds compatibility with RxCocoa's `rx_image` property on `UIImageView`. 