### PR TITLE
Fixes for Xcode 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7
+osx_image: xcode7.1
 language: objective-c
 podfile: Demo/Podfile
 

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -14,8 +14,8 @@ end
 
 target 'DemoTests' do
 
-  pod 'Quick', :git => 'https://github.com/Quick/Quick'
-  pod 'Nimble', :git => 'https://github.com/Quick/Nimble'
+  pod 'Quick'
+  pod 'Nimble'
   pod 'OHHTTPStubs'
 
 end

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -12,21 +12,21 @@ PODS:
   - Moya/RxSwift (4.1.0):
     - Moya/ReactiveCore
     - RxSwift (~> 2.0.0-alpha)
-  - Nimble (2.0.0-rc.3)
-  - OHHTTPStubs (4.2.0):
-    - OHHTTPStubs/Default (= 4.2.0)
-  - OHHTTPStubs/Core (4.2.0)
-  - OHHTTPStubs/Default (4.2.0):
+  - Nimble (3.0.0)
+  - OHHTTPStubs (4.4.0):
+    - OHHTTPStubs/Default (= 4.4.0)
+  - OHHTTPStubs/Core (4.4.0)
+  - OHHTTPStubs/Default (4.4.0):
     - OHHTTPStubs/Core
     - OHHTTPStubs/JSON
     - OHHTTPStubs/NSURLSession
     - OHHTTPStubs/OHPathHelpers
-  - OHHTTPStubs/JSON (4.2.0):
+  - OHHTTPStubs/JSON (4.4.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/NSURLSession (4.2.0):
+  - OHHTTPStubs/NSURLSession (4.4.0):
     - OHHTTPStubs/Core
-  - OHHTTPStubs/OHPathHelpers (4.2.0)
-  - Quick (0.6.0)
+  - OHHTTPStubs/OHPathHelpers (4.4.0)
+  - Quick (0.8.0)
   - ReactiveCocoa (4.0.0-alpha-3):
     - ReactiveCocoa/UI (= 4.0.0-alpha-3)
     - Result (~> 0.6-beta.4)
@@ -45,32 +45,20 @@ DEPENDENCIES:
   - Moya (from `../`)
   - Moya/ReactiveCocoa (from `../`)
   - Moya/RxSwift (from `../`)
-  - Nimble (from `https://github.com/Quick/Nimble`)
+  - Nimble
   - OHHTTPStubs
-  - Quick (from `https://github.com/Quick/Quick`)
+  - Quick
 
 EXTERNAL SOURCES:
   Moya:
     :path: "../"
-  Nimble:
-    :git: https://github.com/Quick/Nimble
-  Quick:
-    :git: https://github.com/Quick/Quick
-
-CHECKOUT OPTIONS:
-  Nimble:
-    :commit: a87c41424b2b8bc7821cf9e0352f87f53daf5263
-    :git: https://github.com/Quick/Nimble
-  Quick:
-    :commit: ac5eadd202dd67741628f80fb96e8c57388d954d
-    :git: https://github.com/Quick/Quick
 
 SPEC CHECKSUMS:
   Alamofire: 415bd7f56197722978759078486689f7ef913dce
   Moya: 3b0e0335468cd0eb68034d5d5bfcb704cb8f5cb0
-  Nimble: 2f64d173ad23dc39f10110840a1ed15f29ef75e8
-  OHHTTPStubs: f639130b83fb5f4f022d38f841141b0a6fa77249
-  Quick: aaa961333f0bec39bfefa4b759128e4eb39f0d0e
+  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
+  OHHTTPStubs: 1a95a653b78287a1fdb44eb38364b43257ac3550
+  Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
   ReactiveCocoa: f03dcfd385b0e4ee5b7a323f5e0b146a498e12d3
   Result: 8ae33a29ed1e147514b9536de523a978d7faba1f
   RxSwift: a9b0f4d876eac130cda0ae2f3fba627be3baf3ef

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -774,7 +774,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -802,6 +802,7 @@
 		091F0D3D1BDE998F009D0A49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -822,6 +823,7 @@
 		091F0D3E1BDE998F009D0A49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -842,6 +844,7 @@
 		091F0D491BDE9A01009D0A49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -862,6 +865,7 @@
 		091F0D4A1BDE9A01009D0A49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -882,6 +886,7 @@
 		091F0D891BDE9D4D009D0A49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -903,6 +908,7 @@
 		091F0D8A1BDE9D4D009D0A49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
This address the tests not being able to run due to Quick/Nimble not being updated to work with Xcode 7.1. There was also a problem with OS X frameworks having `iOS Developer` as their code signing identity.

Changes:
- Fixes wrong code signing identity for OS X frameworks 
- Updates demo podfile to not point to the Quick/Nimble repository
- Updates dependencies in demo project
- Update travis.yml to use Xcode 7.1