### PR TITLE
Allow specialization of request parameters at request time

### DIFF
--- a/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
@@ -106,7 +106,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                         super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                 }
 
-                override func request(token: Target, completion: Moya.Completion) -> Cancellable {
+                override func request(token: Target, parameters: [String:AnyObject]?, completion: Moya.Completion) -> Cancellable {
                     return TestCancellable()
                 }
             }
@@ -188,7 +188,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                     }
                     
-                    override func request(token: Target, completion: Moya.Completion) -> Cancellable {
+                    override func request(token: Target, parameters: [String:AnyObject]?, completion: Moya.Completion) -> Cancellable {
                         return TestCancellable()
                     }
                 }
@@ -210,6 +210,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                     disposable.dispose()
                     
                     expect(TestCancellable.cancelled).to( beTrue() )
+                    
                 }
             }
         }

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -38,7 +38,7 @@ PODS:
   - ReactiveCocoa/UI (4.0.0-alpha-3):
     - ReactiveCocoa/Core
     - Result (~> 0.6-beta.4)
-  - Result (0.6.0-beta.5)
+  - Result (0.6.0-beta.6)
   - RxSwift (2.0.0-beta.1)
 
 DEPENDENCIES:
@@ -51,7 +51,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Moya:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   Alamofire: 415bd7f56197722978759078486689f7ef913dce
@@ -60,7 +60,7 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 1a95a653b78287a1fdb44eb38364b43257ac3550
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
   ReactiveCocoa: f03dcfd385b0e4ee5b7a323f5e0b146a498e12d3
-  Result: 8ae33a29ed1e147514b9536de523a978d7faba1f
+  Result: dc390d0b58f9ec43fcd536f1ebdd130803cc6cbc
   RxSwift: a9b0f4d876eac130cda0ae2f3fba627be3baf3ef
 
 COCOAPODS: 0.39.0

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -142,6 +142,11 @@ public class MoyaProvider<Target: MoyaTarget> {
         
         return cancellableToken
     }
+
+    /// Convenience request-making method that takes no extra endpoint parameters
+    public func request(target: Target, completion: Moya.Completion) -> Cancellable {
+        return request(target, parameters: nil, completion: completion)
+    }
 }
 
 /// Mark: Defaults

--- a/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -15,14 +15,14 @@ public class ReactiveCocoaMoyaProvider<Target where Target: MoyaTarget>: MoyaPro
     }
     
     /// Designated request-making method.
-    public func request(token: Target) -> SignalProducer<MoyaResponse, NSError> {
+    public func request(token: Target, parameters: [String:AnyObject]? = nil) -> SignalProducer<MoyaResponse, NSError> {
 
         /// returns a new producer which starts a new producer which invokes the requests. 
         return SignalProducer { [weak self] outerSink, outerDisposable in
             
             let producer: SignalProducer<MoyaResponse, NSError> = SignalProducer { [weak self] requestSink, requestDisposable in
 
-                let cancellableToken = self?.request(token) { data, statusCode, response, error in
+                let cancellableToken = self?.request(token, parameters: parameters) { data, statusCode, response, error in
                     if let error = error {
                         requestSink.sendFailed(error as NSError)
                     } else {

--- a/Source/RxSwift/Moya+RxSwift.swift
+++ b/Source/RxSwift/Moya+RxSwift.swift
@@ -14,12 +14,12 @@ public class RxMoyaProvider<Target where Target: MoyaTarget>: MoyaProvider<Targe
     }
 
     /// Designated request-making method.
-    public func request(token: Target) -> Observable<MoyaResponse> {
+    public func request(token: Target, parameters: [String:AnyObject]? = nil) -> Observable<MoyaResponse> {
 
         return deferred { [weak self] () -> Observable<MoyaResponse> in
 
             let observable: Observable<MoyaResponse> =  AnonymousObservable { observer in
-                let cancellableToken = self?.request(token) { (data, statusCode, response, error) -> () in
+                let cancellableToken = self?.request(token, parameters: parameters) { (data, statusCode, response, error) -> () in
                     if let error = error {
                         observer.on(.Error(error as NSError))
                     } else {


### PR DESCRIPTION
Hi there. I'm proposing this small change to Moya after about a week of real world usage with it. In short, this PR lets one apply additional request parameters at time of calling `request()`, allowing more dynamic requests to be made without necessarily needing new (and special) targets. They are merged into the result of the endpoint closure's parameters.

### Example of why this is nice
So I will provide a current situation of mine as an example. I am working with an API that has a lot of optional parameters that apply to (mostly) any request. Rather than having target enum cases that all have an extra _n_ number of optional associated values that can be provided via `MoyaTarget.parameters`, it would be great to be able to provide additional params as the caller creating/invoking the request instead.

### API Changes
- A new, "designated" `MoyaProvider.request()` function that takes an optional parameter dictionary.
- A "convenience" `MoyaProvider.request()` function with the pre-existing signature, that calls the designated function with `nil` parameters.

Result: No breaking changes.

### Current alternative
With how the target and endpoint closure are the only things able to set parameters, I can only get this behavior by having a special target target enum case, like so:
```swift
public enum SweetAPI: MoyaTarget {
     ...
    indirect case Parameterized(target: SweetAPI, parameters: [String:AnyObject])

    ...
var parameters: [String:AnyObject]? {
    switch self {
    case let .Parameterized(target, params):
        return target.parameters.flatMap { original in
            original.mergeEntriesFromDictionary(params) // pseudo-code
        }
    default: return nil
    }
}
```
But this is less than ideal as it requires this sort of compositional target case to be present in the target type you're using to be able to.