### PR TITLE
Swiftify Protocol Names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+- **Breaking Change** rename `MoyaTarget` protocol to `TargetType`
+- **Breaking Change** rename `MoyaRequest` protocol to `RequestType`
+- **Breaking Change** rename `Plugin` protocol to `PluginType`
 - Removes conversion from `Moya.Method` to `Alamofire.Method` since it was unused 
 - Changes `NetworkLoggingPlugin`'s initializer to also take a function that has the same signature as `print` to simplify testing
 - **Breaking Change** renames `ParameterEncoding`'s `parameterEncoding` method to `toAlamofire` and makes it internal only

--- a/Demo/Demo/GitHubAPI.swift
+++ b/Demo/Demo/GitHubAPI.swift
@@ -20,7 +20,7 @@ public enum GitHub {
     case UserRepositories(String)
 }
 
-extension GitHub : MoyaTarget {
+extension GitHub: TargetType {
     public var baseURL: NSURL { return NSURL(string: "https://api.github.com")! }
     public var path: String {
         switch self {
@@ -56,6 +56,6 @@ extension GitHub : MoyaTarget {
     }
 }
 
-public func url(route: MoyaTarget) -> String {
+public func url(route: TargetType) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }

--- a/Demo/DemoTests/NetworkLogginPluginSpec.swift
+++ b/Demo/DemoTests/NetworkLogginPluginSpec.swift
@@ -72,7 +72,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
     }
 }
 
-private class TestStreamRequest: MoyaRequest {
+private class TestStreamRequest: RequestType {
     var request: NSURLRequest? {
         let r = NSMutableURLRequest(URL: NSURL(string: url(GitHub.Zen))!)
         r.allHTTPHeaderFields = ["Content-Type" : "application/json"]
@@ -90,7 +90,7 @@ private class TestStreamRequest: MoyaRequest {
     }
 }
 
-private class TestBodyRequest: MoyaRequest {
+private class TestBodyRequest: RequestType {
     var request: NSURLRequest? {
         let r = NSMutableURLRequest(URL: NSURL(string: url(GitHub.Zen))!)
         r.allHTTPHeaderFields = ["Content-Type" : "application/json"]
@@ -108,7 +108,7 @@ private class TestBodyRequest: MoyaRequest {
     }
 }
 
-private class TestNilRequest: MoyaRequest {
+private class TestNilRequest: RequestType {
     var request: NSURLRequest? {
         return nil
     }

--- a/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/DemoTests/ReactiveCocoaMoyaProviderTests.swift
@@ -101,12 +101,12 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 }
             }
 
-            class TestProvider<Target: MoyaTarget>: ReactiveCocoaMoyaProvider<Target> {
+            class TestProvider<Target: TargetType>: ReactiveCocoaMoyaProvider<Target> {
                 init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
                     requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
                     stubClosure: StubClosure = MoyaProvider.NeverStub,
                     manager: Manager = Alamofire.Manager.sharedInstance,
-                    plugins: [Plugin] = []) {
+                    plugins: [PluginType] = []) {
 
                         super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                 }
@@ -183,12 +183,12 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                     }
                 }
                 
-                class TestProvider<Target: MoyaTarget>: ReactiveCocoaMoyaProvider<Target> {
+                class TestProvider<Target: TargetType>: ReactiveCocoaMoyaProvider<Target> {
                     init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
                         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
                         stubClosure: StubClosure = MoyaProvider.NeverStub,
                         manager: Manager = Alamofire.Manager.sharedInstance,
-                        plugins: [Plugin] = []) {
+                        plugins: [PluginType] = []) {
 
                             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                     }

--- a/Demo/DemoTests/TestHelpers.swift
+++ b/Demo/DemoTests/TestHelpers.swift
@@ -12,7 +12,7 @@ enum GitHub {
     case UserProfile(String)
 }
 
-extension GitHub : MoyaTarget {
+extension GitHub: TargetType {
     var baseURL: NSURL { return NSURL(string: "https://api.github.com")! }
     var path: String {
         switch self {
@@ -38,7 +38,7 @@ extension GitHub : MoyaTarget {
     }
 }
 
-func url(route: MoyaTarget) -> String {
+func url(route: TargetType) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
@@ -47,7 +47,7 @@ let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     return Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
 }
 
-enum HTTPBin: MoyaTarget {
+enum HTTPBin: TargetType {
     case BasicAuth
 
     var baseURL: NSURL { return NSURL(string: "http://httpbin.org")! }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -37,7 +37,7 @@ public enum StubBehavior {
 }
 
 /// Protocol to define the base URL, path, method, parameters and sample data for a target.
-public protocol MoyaTarget {
+public protocol TargetType {
     var baseURL: NSURL { get }
     var path: String { get }
     var method: Moya.Method { get }
@@ -51,7 +51,7 @@ public protocol Cancellable {
 }
 
 /// Request provider class. Requests should be made through this class only.
-public class MoyaProvider<Target: MoyaTarget> {
+public class MoyaProvider<Target: TargetType> {
     
     /// Closure that defines the endpoints for the provider.
     public typealias EndpointClosure = Target -> Endpoint<Target>
@@ -69,14 +69,14 @@ public class MoyaProvider<Target: MoyaTarget> {
     
     /// A list of plugins
     /// e.g. for logging, network activity indicator or credentials
-    public let plugins: [Plugin]
+    public let plugins: [PluginType]
     
     /// Initializes a provider.
     public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
         manager: Manager = Alamofire.Manager.sharedInstance,
-        plugins: [Plugin] = []) {
+        plugins: [PluginType] = []) {
             
             self.endpointClosure = endpointClosure
             self.requestClosure = requestClosure
@@ -193,7 +193,7 @@ internal extension MoyaProvider {
     }
     
     /// Creates a function which, when called, executes the appropriate stubbing behavior for the given parameters.
-    internal final func createStubFunction(token: CancellableToken, forTarget target: Target, withCompletion completion: Moya.Completion, endpoint: Endpoint<Target>, plugins: [Plugin]) -> (() -> ()) {
+    internal final func createStubFunction(token: CancellableToken, forTarget target: Target, withCompletion completion: Moya.Completion, endpoint: Endpoint<Target>, plugins: [PluginType]) -> (() -> ()) {
         return {
             if (token.canceled) {
                 let error = Moya.Error.Underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
@@ -284,4 +284,4 @@ private struct CancellableWrapper: Cancellable {
 }
 
 /// Make the Alamofire Request type conform to our type, to prevent leaking Alamofire to plugins.
-extension Request: MoyaRequest { }
+extension Request: RequestType { }

--- a/Source/Plugin.swift
+++ b/Source/Plugin.swift
@@ -6,16 +6,16 @@ import Foundation
 ///     - log network requests
 ///     - hide and show a network avtivity indicator 
 ///     - inject additional information into a request
-public protocol Plugin {
+public protocol PluginType {
     /// Called immediately before a request is sent over the network (or stubbed).
-    func willSendRequest(request: MoyaRequest, target: MoyaTarget)
+    func willSendRequest(request: RequestType, target: TargetType)
 
     // Called after a response has been received, but before the MoyaProvider has invoked its completion handler.
-    func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: MoyaTarget)
+    func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType)
 }
 
 /// Request type used by willSendRequest plugin function.
-public protocol MoyaRequest {
+public protocol RequestType {
 
     // Note:
     //

--- a/Source/Plugins/CredentialsPlugin.swift
+++ b/Source/Plugins/CredentialsPlugin.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// Provides each request with optional NSURLCredentials.
-public final class CredentialsPlugin: Plugin {
+public final class CredentialsPlugin: PluginType {
 
-    public typealias CredentialClosure = MoyaTarget -> NSURLCredential?
+    public typealias CredentialClosure = TargetType -> NSURLCredential?
     let credentialsClosure: CredentialClosure
 
     public init(credentialsClosure: CredentialClosure) {
@@ -12,13 +12,13 @@ public final class CredentialsPlugin: Plugin {
 
     // MARK: Plugin
     
-    public func willSendRequest(request: MoyaRequest, target: MoyaTarget) {
+    public func willSendRequest(request: RequestType, target: TargetType) {
         if let credentials = credentialsClosure(target) {
             request.authenticate(usingCredential: credentials)
         }
     }
     
-    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: MoyaTarget) {
+    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType) {
 
     }
 }

--- a/Source/Plugins/NetworkActivityPlugin.swift
+++ b/Source/Plugins/NetworkActivityPlugin.swift
@@ -6,7 +6,7 @@ public enum NetworkActivityChangeType {
 }
 
 /// Provides each request with optional NSURLCredentials.
-public final class NetworkActivityPlugin: Plugin {
+public final class NetworkActivityPlugin: PluginType {
     
     public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()
     let networkActivityClosure: NetworkActivityClosure
@@ -18,13 +18,12 @@ public final class NetworkActivityPlugin: Plugin {
     // MARK: Plugin
 
     /// Called by the provider as soon as the request is about to start
-    public func willSendRequest(request: MoyaRequest, target: MoyaTarget) {
+    public func willSendRequest(request: RequestType, target: TargetType) {
         networkActivityClosure(change: .Began)
     }
     
     /// Called by the provider as soon as a response arrives
-    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: MoyaTarget) {
+    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType) {
         networkActivityClosure(change: .Ended)
     }
 }
-

--- a/Source/Plugins/NetworkLoggerPlugin.swift
+++ b/Source/Plugins/NetworkLoggerPlugin.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Logs network activity (outgoing requests and incoming responses).
-public final class NetworkLoggerPlugin: Plugin {
+public final class NetworkLoggerPlugin: PluginType {
     private let loggerId = "Moya_Logger"
     private let dateFormatString = "dd/MM/yyyy HH:mm:ss"
     private let dateFormatter = NSDateFormatter()
@@ -17,11 +17,11 @@ public final class NetworkLoggerPlugin: Plugin {
         self.output = output
     }
 
-    public func willSendRequest(request: MoyaRequest, target: MoyaTarget) {
+    public func willSendRequest(request: RequestType, target: TargetType) {
         output(items: logNetworkRequest(request.request), separator: separator, terminator: terminator)
     }
 
-    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: MoyaTarget) {        
+    public func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType) {
         if case .Success(let response) = result {
             output(items: logNetworkResponse(response.response, data: response.data, target: target), separator: separator, terminator: terminator)
         } else {
@@ -69,7 +69,7 @@ private extension NetworkLoggerPlugin {
         return output
     }
 
-    func logNetworkResponse(response: NSURLResponse?, data: NSData?, target: MoyaTarget) -> [String] {
+    func logNetworkResponse(response: NSURLResponse?, data: NSData?, target: TargetType) -> [String] {
         guard let response = response else {
            return [format(loggerId, date: date, identifier: "Response", message: "Received empty network response for \(target).")]
         }

--- a/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -3,14 +3,14 @@ import ReactiveCocoa
 import Alamofire
 
 /// Subclass of MoyaProvider that returns SignalProducer instances when requests are made. Much better than using completion closures.
-public class ReactiveCocoaMoyaProvider<Target where Target: MoyaTarget>: MoyaProvider<Target> {
+public class ReactiveCocoaMoyaProvider<Target where Target: TargetType>: MoyaProvider<Target> {
     private let stubScheduler: DateSchedulerType?
     /// Initializes a reactive provider.
     public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
         manager: Manager = Alamofire.Manager.sharedInstance,
-        plugins: [Plugin] = [], stubScheduler: DateSchedulerType? = nil) {
+        plugins: [PluginType] = [], stubScheduler: DateSchedulerType? = nil) {
             self.stubScheduler = stubScheduler
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }

--- a/Source/RxSwift/Moya+RxSwift.swift
+++ b/Source/RxSwift/Moya+RxSwift.swift
@@ -3,13 +3,13 @@ import RxSwift
 import Alamofire
 
 /// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.
-public class RxMoyaProvider<Target where Target: MoyaTarget>: MoyaProvider<Target> {
+public class RxMoyaProvider<Target where Target: TargetType>: MoyaProvider<Target> {
     /// Initializes a reactive provider.
     override public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
         manager: Manager = Alamofire.Manager.sharedInstance,
-        plugins: [Plugin] = []) {
+        plugins: [PluginType] = []) {
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -93,7 +93,7 @@ of replace – it. The `endpointByAddingParameters` and `endpointByAddingHTTPHea
 functions allow you to rely on the existing Moya code and add your own custom
 values. 
 
-Sample responses are a requirement of the `MoyaTarget` protocol. However, they
+Sample responses are a requirement of the `TargetType` protocol. However, they
 only specify the data returned. The Target-to-Endpoint mapping closure is where
 you can specify more details, which is useful for unit testing. 
 

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -13,7 +13,7 @@ enum GitHub {
 ```
 
 This enum is used to make sure that you provide implementation details for each
-target (at compile time). The enum *must* conform to the `MoyaTarget` protocol. 
+target (at compile time). The enum *must* conform to the `TargetType` protocol.
 Let's take a look at what that might look like.
 
 ```swift
@@ -23,7 +23,7 @@ private extension String {
     }
 }
 
-extension GitHub : MoyaTarget {
+extension GitHub: TargetType {
     var baseURL: NSURL { return NSURL(string: "https://api.github.com") }
     var path: String {
         switch self {
@@ -55,14 +55,14 @@ extension GitHub : MoyaTarget {
 
 You can see that the `MoyaPath` protocol translates each value of the enum into
 a relative URL, which can use values embedded in the enum. Super cool.
-The `MoyaTarget` specifies both a base URL for the API and the sample data for
+The `TargetType` specifies both a base URL for the API and the sample data for
 each enum value. The sample data are `NSData` instances, and could represent
 JSON, images, text, whatever you're expecting from that endpoint.
 
 Next, we'll set up the endpoints for use with our API.
 
 ```swift
-public func url(route: MoyaTarget) -> String {
+public func url(route: TargetType) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -116,7 +116,7 @@ included already: one for network activity (`NetworkActivityPlugin`), one for lo
 all network activity (`NetworkLoggerPlugin`), and another for [HTTP Authentication](Authentication.md).
 
 ```
-public final class NetworkActivityPlugin: Plugin {
+public final class NetworkActivityPlugin: PluginType {
     
     public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()
     let networkActivityClosure: NetworkActivityClosure
@@ -128,12 +128,12 @@ public final class NetworkActivityPlugin: Plugin {
     // MARK: Plugin
 
     /// Called by the provider as soon as the request is about to start
-    public func willSendRequest(request: MoyaRequest, target: MoyaTarget) {
+    public func willSendRequest(request: RequestType, target: TargetType) {
         networkActivityClosure(change: .Began)
     }
 
     /// Called by the provider as soon as a response arrives
-    public func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, target: MoyaTarget) {
+    public func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, target: TargetType) {
         networkActivityClosure(change: .Ended)
     }
 }

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -2,7 +2,7 @@ Targets
 =======
 
 Using Moya starts with defining a target – typically some `enum` that conforms 
-to the `MoyaTarget` protocol. Then, the rest of your app deals *only* with 
+to the `TargetType` protocol. Then, the rest of your app deals *only* with 
 those targets. Targets are some action that you want to take on the API, 
 like "`FavouriteTweet(tweetID: String)`". 
 
@@ -16,14 +16,14 @@ public enum GitHub {
 }
 ```
 
-Targets must conform to `MoyaTarget`. The `MoyaTarget` protocol requires a 
+Targets must conform to `TargetType`. The `TargetType` protocol requires a 
 `baseURL` property to be defined on the enum. Note that this should *not* depend 
 on the value of `self`, but should just return a single value (if you're using 
 more than one API base URL, separate them out into separate enums and Moya 
 providers). Here's the beginning of our extension:
 
 ```swift
-extension GitHub : MoyaTarget {
+extension GitHub: TargetType {
     public var baseURL: NSURL { return NSURL(string: "https://api.github.com")! }
 ```
 
@@ -59,7 +59,7 @@ Nice. If some of your endpoints require POST or another method, then you can swi
 on `self` to return the appropriate value. This kind of switching technique is what 
 we saw when calculating our `path` property.
 
-Our `MoyaTarget` is shaping up, but we're not done yet. We also need a `parameters`
+Our `TargetType` is shaping up, but we're not done yet. We also need a `parameters`
 computed property that returns parameters defined by the enum case. Here's an example:
 
 ```swift
@@ -77,7 +77,7 @@ Unlike our `path` property earlier, we don't actually care about the associated 
 of our `UserRepositories` case, so we use the Swift `_` ignored-value symbol.
 
 Finally, notice the `sampleData` property on the enum. This is a requirement of 
-the `MoyaTarget` protocol. Any target you want to hit must provide some non-nil
+the `TargetType` protocol. Any target you want to hit must provide some non-nil
 `NSData` that represents a sample response. This can be used later for tests or
 for providing offline support for developers. This *should* depend on `self`. 
 


### PR DESCRIPTION
As discussed in #300 theses are some changes to the protocol names to match the naming convention is the swift standard library.
 
Changes:
- **Breaking Change** rename `MoyaTarget` protocol to `TargetType`
- **Breaking Change** rename `MoyaRequest` protocol to `RequestType`
- **Breaking Change** rename `Plugin` protocol to `PluginType`