### PR TITLE
Ensure underlying errors are mapped appropriately where at all possible.

### DIFF
--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -36,7 +36,7 @@ PODS:
   - ReactiveCocoa/UI (4.0.4-alpha-4):
     - ReactiveCocoa/Core
     - Result (~> 1.0)
-  - Result (1.0.0)
+  - Result (1.0.1)
   - RxSwift (2.0.0-beta.4)
 
 DEPENDENCIES:
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
   Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
   ReactiveCocoa: e459ea92099447802df20c4735e31e8139b06094
-  Result: feaaff535eb59c414c6c7f95e6145ab991b1b07f
+  Result: caef80340451e1f07492fa1e89117f83613bce24
   RxSwift: 191c6b06da783a8671433cf35a54d2ad2fd2d9de
 
 COCOAPODS: 0.39.0

--- a/Demo/Tests/ErrorTests.swift
+++ b/Demo/Tests/ErrorTests.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+@testable
 import Moya
 
 class ErrorTests: QuickSpec {
@@ -66,6 +67,26 @@ class ErrorTests: QuickSpec {
                 expect(error.domain) == "Domain"
                 expect(error.code) == 200
                 expect(error.userInfo as? [String : String]) == ["data" : "some data"]
+            }
+        }
+        describe("Alamofire responses should return the errors where appropriate") {
+            it("should return the underlying error in spite of having a response and data") {
+                let underlyingError = NSError(domain: "", code: 0, userInfo: nil)
+                let response = NSHTTPURLResponse()
+                let data = NSData()
+                let result = convertResponseToResult(response, data: data, error: underlyingError)
+                switch result {
+                case let .Failure(error):
+                    switch error {
+                    case let .Underlying(e):
+                        expect(e as NSError) == underlyingError
+                    default:
+                        XCTFail("expected to get underlying error")
+                    }
+
+                case .Success:
+                    XCTFail("expected to be failing result")
+                }
             }
         }
     }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -222,7 +222,7 @@ internal extension MoyaProvider {
     }
 }
 
-private func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?, error: NSError?) -> Moya.Result<Moya.Response, Moya.Error> {
+internal func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?, error: NSError?) -> Moya.Result<Moya.Response, Moya.Error> {
     switch (response, data, error) {
     case let (.Some(response), .Some(data), .None):
         let response = Moya.Response(statusCode: response.statusCode, data: data, response: response)

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -227,7 +227,7 @@ private func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?
     case let (.Some(response), .Some(data), .None):
         let response = Moya.Response(statusCode: response.statusCode, data: data, response: response)
         return Moya.Result(success: response)
-    case let (.None, .None, .Some(error)):
+    case let (_, _, .Some(error)):
         let error = Moya.Error.Underlying(error)
         return Moya.Result(failure: error)
     default:


### PR DESCRIPTION
This fixes a pretty egregious bug where underlying errors would be rarely, if ever, handled appropriately. In short, the presence of an NSURLResponse would cause Moya to discard the underlying error entirely, which is _not good_.