### PR TITLE
Fix an issue that stubbed responses still call the network.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- **Breaking Change** pass a built-in `DefaultAlamofireManager` as parameter's default value instead of passing the singleton `Alamofire.Manager.sharedinstance` when initialize a `provider`
+
 # 5.3.0
 
 - Updates to RXSwift 2.0.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Updates to RXSwift 2.0.0
 - Moves to use Antitypical/Result
+- Fixes issue that stubbed responses still call the network.
 
 # 5.2.1
      

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -55,10 +55,11 @@ class MoyaProviderSpec: QuickSpec {
             
         }
         
-        it("uses the Alamofire.Manager.sharedInstance by default") {
-            expect(provider.manager).to(beIdenticalTo(Alamofire.Manager.sharedInstance))
+        it("uses a custom manager by default, startRequestsImmediately should be false") {
+            expect(provider.manager).toNot(beNil())
+            expect(provider.manager.startRequestsImmediately) == false
         }
-        
+
         it("credential closure returns nil") {
             var called = false
             let plugin = CredentialsPlugin { (target) -> NSURLCredential? in

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -119,7 +119,7 @@ public class MoyaProvider<Target: TargetType> {
 
 public extension MoyaProvider {
     
-    // These functions are default mappings to endpoings and requests.
+    // These functions are default mappings to MoyaProvider's properties: endpoints, requests, manager, etc.
     
     public final class func DefaultEndpointMapping(target: Target) -> Endpoint<Target> {
         let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -173,7 +173,9 @@ internal extension MoyaProvider {
             plugins.forEach { $0.didReceiveResponse(result, target: target) }
             completion(result: result)
         }
-        
+
+        alamoRequest.resume()
+
         return CancellableToken(request: alamoRequest)
     }
     

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -154,14 +154,14 @@ public extension MoyaProvider {
 internal extension MoyaProvider {
     
     func sendRequest(target: Target, request: NSURLRequest, completion: Moya.Completion) -> CancellableToken {
-        let request = manager.request(request)
+        let alamoRequest = manager.request(request)
         let plugins = self.plugins
         
         // Give plugins the chance to alter the outgoing request
-        plugins.forEach { $0.willSendRequest(request, target: target) }
+        plugins.forEach { $0.willSendRequest(alamoRequest, target: target) }
         
         // Perform the actual request
-        let alamoRequest = request.response { (_, response: NSHTTPURLResponse?, data: NSData?, error: NSError?) -> () in
+        alamoRequest.response { (_, response: NSHTTPURLResponse?, data: NSData?, error: NSError?) -> () in
             let result = convertResponseToResult(response, data: data, error: error)
             // Inform all plugins about the response
             plugins.forEach { $0.didReceiveResponse(result, target: target) }
@@ -196,8 +196,8 @@ internal extension MoyaProvider {
     
     /// Notify all plugins that a stub is about to be performed. You must call this if overriding `stubRequest`.
     internal final func notifyPluginsOfImpendingStub(request: NSURLRequest, target: Target) {
-        let request = manager.request(request)
-        plugins.forEach { $0.willSendRequest(request, target: target) }
+        let alamoRequest = manager.request(request)
+        plugins.forEach { $0.willSendRequest(alamoRequest, target: target) }
     }
 }
 

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -131,7 +131,10 @@ public extension MoyaProvider {
     }
 
     public final class func DefaultAlamofireManager() -> Manager {
-        let manager = Alamofire.Manager.sharedInstance
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        configuration.HTTPAdditionalHeaders = Manager.defaultHTTPHeaders
+
+        let manager = Manager(configuration: configuration)
         manager.startRequestsImmediately = false
         return manager
     }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -54,7 +54,7 @@ public class MoyaProvider<Target: TargetType> {
     public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = Manager.sharedInstance,
+        manager: Manager = MoyaProvider<Target>.DefaultAlamofireManager(),
         plugins: [PluginType] = []) {
             
             self.endpointClosure = endpointClosure
@@ -128,6 +128,12 @@ public extension MoyaProvider {
     
     public final class func DefaultRequestMapping(endpoint: Endpoint<Target>, closure: NSURLRequest -> Void) {
         return closure(endpoint.urlRequest)
+    }
+
+    public final class func DefaultAlamofireManager() -> Manager {
+        let manager = Alamofire.Manager.sharedInstance
+        manager.startRequestsImmediately = false
+        return manager
     }
 }
 

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -89,8 +89,20 @@ let provider = MoyaProvider<MyTarget>(stubClosure: { (_: MyTarget) -> Moya.StubB
 let provider = MoyaProvider<MyTarget>(stubBehavior: MoyaProvider.ImmediatelyStub)
 ```
 
-Next, there's the `manager` parameter. By default you'll get `Alamofire.Manager.sharedinstance`.
-If you'd like to customize the manager, for example, to add SSL pinning, create one and pass it in,
+Next, there's the `manager` parameter. By default you'll get a custom `Alamofire.Manager` instance with basic configurations.
+```swift
+    public final class func DefaultAlamofireManager() -> Manager {
+        let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
+        configuration.HTTPAdditionalHeaders = Alamofire.Manager.defaultHTTPHeaders
+
+        let manager = Alamofire.Manager(configuration: configuration)
+        manager.startRequestsImmediately = false
+        return manager
+    }
+```
+There is only one particular thing: since construct an `Alamofire.Request` in AF will fire the request immediately by default, even when "stubbing" the requests for unit testing. Therefore in Moya, `startRequestsImmediately` is set to `false` by default.
+
+If you'd like to customize your own manager, for example, to add SSL pinning, create one and pass it in,
 all requests will route through the custom configured manager.
 
 ```swift


### PR DESCRIPTION
This PR suppose to fix issue #350 by calling `request.resume()` manually.