### PR TITLE
ReactiveCocoa RC2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" ~> 3.0
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-RC.1"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-RC.2"
 github "ReactiveX/RxSwift" "2.0.0"
 github "antitypical/Result" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "3.1.4"
+github "Alamofire/Alamofire" "3.1.5"
 github "antitypical/Result" "1.0.1"
-github "ReactiveX/RxSwift" "2.0.0-rc.0"
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-RC.1"
+github "ReactiveX/RxSwift" "2.0.0"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-RC.2"

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Source/ReactiveCocoa/*.swift"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveCocoa", "4.0.0-RC.1"
+    ss.dependency "ReactiveCocoa", "4.0.0-RC.2"
   end
 
   s.subspec "RxSwift" do |ss|


### PR DESCRIPTION
Hi, I just detected that Moya 6.0.0 uses ReactiveCocoa RC1 as dependency. Updated to RC2 -> https://github.com/ReactiveCocoa/ReactiveCocoa/releases/tag/v4.0.0-RC.2 

I think those changes in ReactiveCocoa don´t affect related code in Moya, but would be happy if anyone could confirm that. (At least I was able to build ReactiveMoya with RC2) 