### PR TITLE
Use DefaultAlamofireManager for ReactiveCocoaMoyaProvider and RxMoyaProvider

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- The built-in `DefaultAlamofireManager` as parameter's default value instead of the singleton `Alamofire.Manager.sharedinstance` is now used when instantiating `ReactiveCocoaMoyaProvider` and `RxMoyaProvider` as well.
+
 # 6.0.1
 
 - Updates to ReactiveCocoa 4 RC 2.

--- a/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -8,7 +8,7 @@ public class ReactiveCocoaMoyaProvider<Target where Target: TargetType>: MoyaPro
     public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = Manager.sharedInstance,
+        manager: Manager = ReactiveCocoaMoyaProvider<Target>.DefaultAlamofireManager(),
         plugins: [PluginType] = [], stubScheduler: DateSchedulerType? = nil) {
             self.stubScheduler = stubScheduler
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)

--- a/Source/RxSwift/Moya+RxSwift.swift
+++ b/Source/RxSwift/Moya+RxSwift.swift
@@ -7,7 +7,7 @@ public class RxMoyaProvider<Target where Target: TargetType>: MoyaProvider<Targe
     override public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = Manager.sharedInstance,
+        manager: Manager = RxMoyaProvider<Target>.DefaultAlamofireManager(),
         plugins: [PluginType] = []) {
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }


### PR DESCRIPTION
The built-in `DefaultAlamofireManager` as parameter's default value instead of the singleton `Alamofire.Manager.sharedinstance` is now used when instantiating `ReactiveCocoaMoyaProvider` and `RxMoyaProvider` as well. Fixes #373.