### PR TITLE
Updated Cartfile and Moya.podspec to use RAC4 release 

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" ~> 3.0
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0-RC.2"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.0"
 github "ReactiveX/RxSwift" "2.0.0"
 github "antitypical/Result" ~> 1.0

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Source/ReactiveCocoa/*.swift"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveCocoa", "4.0.0-RC.2"
+    ss.dependency "ReactiveCocoa", "4.0.0"
   end
 
   s.subspec "RxSwift" do |ss|


### PR DESCRIPTION
Only problematic part i see now — only 4.0.0 RC2 is available at Pods Spec repo 