### PR TITLE
Adds response computed variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- Adds `response` computed property to `Error` type, which yields a Response object if available.
+
 # 6.1.3
 
 - Updated to ReactiveCocoa 4.0 final.

--- a/Demo/Tests/ErrorTests.swift
+++ b/Demo/Tests/ErrorTests.swift
@@ -5,14 +5,14 @@ import Moya
 
 class ErrorTests: QuickSpec {
     override func spec() {
-        
+
+        var response: Response!
+
+        beforeEach {
+            response = Response(statusCode: 200, data: NSData(), response: nil)
+        }
+
         describe("should convert to NSError") {
-        
-            var response: Response!
-            
-            beforeEach {
-                response = Response(statusCode: 200, data: NSData(), response: nil)
-            }
             
             it("should convert ImageMapping error to NSError") {
                 
@@ -69,6 +69,47 @@ class ErrorTests: QuickSpec {
                 expect(error.userInfo as? [String : String]) == ["data" : "some data"]
             }
         }
+
+        describe("response computed variable") {
+
+            it("should handle ImageMapping error") {
+                let error = Error.ImageMapping(response)
+
+                expect(error.response) == response
+            }
+
+            it("should handle JSONMapping error") {
+                let error = Error.JSONMapping(response)
+
+                expect(error.response) == response
+            }
+
+            it("should handle StringMapping error") {
+                let error = Error.StringMapping(response)
+
+                expect(error.response) == response
+            }
+
+            it("should handle StatusCode error") {
+                let error = Error.StatusCode(response)
+
+                expect(error.response) == response
+            }
+
+            it("should handle Data error") {
+                let error = Error.Data(response)
+
+                expect(error.response) == response
+            }
+
+            it("should not handle Underlying error ") {
+                let nsError = NSError(domain: "Domain", code: 200, userInfo: ["data" : "some data"])
+                let error = Error.Underlying(nsError)
+
+                expect(error.response).to( beNil() )
+            }
+        }
+
         describe("Alamofire responses should return the errors where appropriate") {
             it("should return the underlying error in spite of having a response and data") {
                 let underlyingError = NSError(domain: "", code: 0, userInfo: nil)

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -9,6 +9,20 @@ public enum Error: ErrorType {
     case Underlying(ErrorType)
 }
 
+public extension Moya.Error {
+    /// Depending on error type, returns a Response object.
+    var response: Moya.Response? {
+        switch self {
+        case .ImageMapping(let response): return response
+        case .JSONMapping(let response): return response
+        case .StringMapping(let response): return response
+        case .StatusCode(let response): return response
+        case .Data(let response): return response
+        case .Underlying: return nil
+        }
+    }
+}
+
 @available(*, deprecated, message="This will be removed when ReactiveCocoa 4 becomes final. Please visit https://github.com/Moya/Moya/issues/298 for more information.")
 public let MoyaErrorDomain = "Moya"
 


### PR DESCRIPTION
This is useful when you just need the (possible) network response but don't care about the specific Error (see [this example](https://github.com/artsy/eidolon/pull/584/files#diff-ce82ff0f55f023dbcf5e8ab92d76c934R90) of usage).

It feels silly to have to write it, but it makes sense. May as well only write the silly code once :smile: 