### PR TITLE
Updates example with fix to String extension by changing to Optional

### DIFF
--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -18,8 +18,8 @@ Let's take a look at what that might look like.
 
 ```swift
 private extension String {
-    var URLEscapedString: String? {
-        return self.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLHostAllowedCharacterSet())
+    var URLEscapedString: String {
+        return self.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLHostAllowedCharacterSet())!
     }
 }
 
@@ -30,7 +30,7 @@ extension GitHub: TargetType {
         case .Zen:
             return "/zen"
         case .UserProfile(let name):
-            return "/users/\(name.URLEscapedString!)"
+            return "/users/\(name.URLEscapedString)"
         }
     }
     var method: Moya.Method {

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -18,7 +18,7 @@ Let's take a look at what that might look like.
 
 ```swift
 private extension String {
-    var URLEscapedString: String {
+    var URLEscapedString: String? {
         return self.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLHostAllowedCharacterSet())
     }
 }

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -30,7 +30,7 @@ extension GitHub: TargetType {
         case .Zen:
             return "/zen"
         case .UserProfile(let name):
-            return "/users/\(name.URLEscapedString)"
+            return "/users/\(name.URLEscapedString!)"
         }
     }
     var method: Moya.Method {


### PR DESCRIPTION
The `stringByAddingPercentEncodingWithAllowedCharacters` method of `String` returns an optional, thus the compilation fails using the provided example. Changed the `URLEscapedString` property to also return an optional.