### PR TITLE
endpointByAdding as a convenience method for long method chaining.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
 - Adds `response` computed property to `Error` type, which yields a Response object if available.
+- Adds convenience `endpointByAdding` method.
 
 # 6.1.3
 
@@ -34,7 +35,7 @@
 - Moves to use Antitypical/Result
 
 # 5.2.1
-     
+
 - Update to ReactiveCocoa v4.0.0-RC.1
 - Fixes cases where underlying network errors were not properly propagated.
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (3.1.5)
+  - Alamofire (3.2.0)
   - Moya (6.1.3):
     - Moya/Core (= 6.1.3)
   - Moya/Core (6.1.3):
@@ -37,7 +37,7 @@ PODS:
   - ReactiveCocoa/UI (4.0.0):
     - ReactiveCocoa/Core
     - Result (~> 1.0.1)
-  - Result (1.0.1)
+  - Result (1.0.2)
   - RxSwift (2.1.0)
 
 DEPENDENCIES:
@@ -53,13 +53,13 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Alamofire: 5f730ba29fd113b7ddd71c1e65d0c630acf5d7b0
+  Alamofire: 4da478599fccddff361205c8929333d7fe18dceb
   Moya: 26b290a8d675c167ea6229ba08e07dce562265a5
   Nimble: 79d40f4d69d47314229bbabacaa02b8838c779b9
   OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0
   Quick: 332eb1da73125a2106dd637424c803f2ae97e4a9
   ReactiveCocoa: 69be555be30674b07a86b60a91b855063841acc0
-  Result: caef80340451e1f07492fa1e89117f83613bce24
+  Result: dd3dd71af3fa2e262f1a999e14fba2c25ec14f16
   RxSwift: 110fb07f81c17c2c3b3254d168363057b1880d18
 
 COCOAPODS: 0.39.0

--- a/Demo/Tests/EndpointSpec.swift
+++ b/Demo/Tests/EndpointSpec.swift
@@ -35,9 +35,9 @@ class EndpointSpec: QuickSpec {
             it("returns a new endpoint for endpointByAddingParameters") {
                 let message = "I hate it when villains quote Shakespeare."
                 let newEndpoint = endpoint.endpointByAddingParameters(["message": message])
-                
                 let newEndpointMessageObject: AnyObject? = newEndpoint.parameters?["message"]
                 let newEndpointMessage = newEndpointMessageObject as? String
+                
                 // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
                 expect(newEndpointMessage).to(equal(message))
                 
@@ -51,9 +51,8 @@ class EndpointSpec: QuickSpec {
             it("returns a new endpoint for endpointByAddingHTTPHeaderFields") {
                 let agent = "Zalbinian"
                 let newEndpoint = endpoint.endpointByAddingHTTPHeaderFields(["User-Agent": agent])
+                let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]
                 
-                let newEndpointAgentObject: AnyObject? = newEndpoint.httpHeaderFields?["User-Agent"]
-                let newEndpointAgent = newEndpointAgentObject as? String
                 // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
                 expect(newEndpointAgent).to(equal(agent))
                 
@@ -76,6 +75,25 @@ class EndpointSpec: QuickSpec {
                 expect(newEndpoint.method).to(equal(endpoint.method))
                 expect(newEndpoint.parameters?.count).to(equal(endpoint.parameters?.count))
                 expect(newEndpoint.httpHeaderFields?.count).to(equal(endpoint.httpHeaderFields?.count))
+            }
+            
+            it ("returns a new endpoint for endpointByAdding with all parameters") {
+                let parameterEncoding = Moya.ParameterEncoding.URL
+                let agent = "Zalbinian"
+                let message = "I hate it when villains quote Shakespeare."
+                let newEndpoint = endpoint.endpointByAdding(
+                    parameters: ["message": message],
+                    httpHeaderFields: ["User-Agent": agent],
+                    parameterEncoding: parameterEncoding
+                )
+                
+                let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]
+                let newEndpointMessage = newEndpoint.parameters?["message"] as? String
+                
+                // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
+                expect(newEndpointMessage).to(equal(message))
+                expect(newEndpointAgent).to(equal(agent))
+                expect(newEndpoint.parameterEncoding).to(equal(parameterEncoding))
             }
             
             it("returns a correct URL request") {

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -40,28 +40,34 @@ public class Endpoint<Target> {
 
     /// Convenience method for creating a new Endpoint with the same properties as the receiver, but with added parameters.
     public func endpointByAddingParameters(parameters: [String: AnyObject]) -> Endpoint<Target> {
-        var newParameters = self.parameters ?? [String: AnyObject]()
-        for (key, value) in parameters {
-            newParameters[key] = value
-        }
-
-        return Endpoint(URL: URL, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: parameterEncoding, httpHeaderFields: httpHeaderFields)
+        return endpointByAdding(parameters: parameters)
     }
 
     /// Convenience method for creating a new Endpoint with the same properties as the receiver, but with added HTTP header fields.
     public func endpointByAddingHTTPHeaderFields(httpHeaderFields: [String: String]) -> Endpoint<Target> {
-        var newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
-        for (key, value) in httpHeaderFields {
-            newHTTPHeaderFields[key] = value
-        }
-
-        return Endpoint(URL: URL, sampleResponseClosure: sampleResponseClosure, method: method, parameters: parameters, parameterEncoding: parameterEncoding, httpHeaderFields: newHTTPHeaderFields)
+        return endpointByAdding(httpHeaderFields: httpHeaderFields)
     }
     
     /// Convenience method for creating a new Endpoint with the same properties as the receiver, but with another parameter encoding.
     public func endpointByAddingParameterEncoding(newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<Target> {
+        return endpointByAdding(parameterEncoding: newParameterEncoding)
+    }
+    
+    /// Convenience method for creating a new Endpoint, with changes only to the properties we specify as parameters
+    public func endpointByAdding(parameters parameters: [String: AnyObject]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
+        var newParameters = self.parameters ?? [String: AnyObject]()
+        parameters?.forEach { (key, value) in
+            newParameters[key] = value
+        }
         
-        return Endpoint(URL: URL, sampleResponseClosure: sampleResponseClosure, method: method, parameters: parameters, parameterEncoding: newParameterEncoding, httpHeaderFields: httpHeaderFields)
+        var newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
+        httpHeaderFields?.forEach { (key, value) in
+            newHTTPHeaderFields[key] = value
+        }
+        
+        let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
+        
+        return Endpoint(URL: URL, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
     }
 }
 


### PR DESCRIPTION
So after seeing issue #403 and  [this](https://github.com/Moya/Moya/issues/403#issuecomment-182784469) piece of code, and especially:

```swift
return endpoint.endpointByAddingParameterEncoding(.URL).endpointByAddingHTTPHeaderFields(["Content-Type":"application/x-www-form-urlencoded; charset=UTF-8"])
```

I decided to make a convenience method that we can call without chaining it. 
Please let me know if there is something I can improve. Thanks! 🎉