### PR TITLE
Allowing RxSwift 2.x in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" ~> 3.0
 github "ReactiveCocoa/ReactiveCocoa" "v4.0.0"
-github "ReactiveX/RxSwift" "2.0.0"
+github "ReactiveX/RxSwift" ~> "2.0"
 github "antitypical/Result" ~> 1.0


### PR DESCRIPTION
Moya.podspec already has RxSwift dependancy of ~> "2.0"