### PR TITLE
Fix to doubled 6.2.0 header in changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,6 @@
 
 # 6.2.0
 
-# 6.2.0
-
 - Adds `response` computed property to `Error` type, which yields a Response object if available.
 - Added URLEncodedInURL to ParameterEncoding.
 - Adds convenience `endpointByAdding` method.


### PR DESCRIPTION
In a new release there is doubled 6.2.0 header in Changelog, fixed it :)