### PR TITLE
Updated cartfile and podspec to use ReactiveCocoa ~> 4.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" ~> 3.0
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.1"
 github "ReactiveX/RxSwift" ~> 2.0
 github "antitypical/Result" ~> 1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" ~> 3.0
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.1"
+github "ReactiveCocoa/ReactiveCocoa" ~> 4.0
 github "ReactiveX/RxSwift" ~> 2.0
 github "antitypical/Result" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "3.2.0"
+github "Alamofire/Alamofire" "3.2.1"
 github "antitypical/Result" "1.0.2"
 github "ReactiveX/RxSwift" "2.2.0"
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.1"

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Source/ReactiveCocoa/*.swift"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveCocoa", "4.0.0"
+    ss.dependency "ReactiveCocoa", "4.0.1"
   end
 
   s.subspec "RxSwift" do |ss|

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Source/ReactiveCocoa/*.swift"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveCocoa", "4.0.1"
+    ss.dependency "ReactiveCocoa", "~> 4.0"
   end
 
   s.subspec "RxSwift" do |ss|


### PR DESCRIPTION
To resolve ambiguousness due to duplicated declaration of `NoError` in ReactiveCocoa 4.0.0 and Result 1.0.2
