### PR TITLE
Fix endpoint setup when adding a header or parameters without one of them

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,5 @@
 # Next
 
-# 6.1.1
-
 - Fixed endpoint setup when adding `parameters` or `headers` when `parameters` or `headers` or nil
 
 # 6.2.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+# 6.1.1
+
+- Fixed endpoint setup when adding `parameters` or `headers` when `parameters` or `headers` or nil
+
 # 6.2.0
 
 - Adds `response` computed property to `Error` type, which yields a Response object if available.

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -62,23 +62,25 @@ public class Endpoint<Target> {
     }
     
     private func addParameters(parameters: [String: AnyObject]?) -> [String: AnyObject]? {
-        var newParameters = self.parameters
-        if let unwrappedParameters = parameters where unwrappedParameters.count > 0 {
-            newParameters = self.parameters ?? [String: AnyObject]()
-            unwrappedParameters.forEach { (key, value) in
-                newParameters?[key] = value
-            }
+        guard let unwrappedParameters = parameters where unwrappedParameters.count > 0 else {
+            return self.parameters
+        }
+        
+        var newParameters = self.parameters ?? [String: AnyObject]()
+        unwrappedParameters.forEach { (key, value) in
+            newParameters[key] = value
         }
         return newParameters
     }
     
     private func addHTTPHeaderFields(headers: [String: String]?) -> [String: String]? {
-        var newHTTPHeaderFields = self.httpHeaderFields
-        if let unwrappedHeaders = headers where unwrappedHeaders.count > 0 {
-            newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
-            headers?.forEach { (key, value) in
-                newHTTPHeaderFields?[key] = value
-            }
+        guard let unwrappedHeaders = headers where unwrappedHeaders.count > 0 else {
+            return self.httpHeaderFields
+        }
+        
+        var newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
+        headers?.forEach { (key, value) in
+            newHTTPHeaderFields[key] = value
         }
         return newHTTPHeaderFields
     }

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -79,7 +79,7 @@ public class Endpoint<Target> {
         }
         
         var newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
-        headers?.forEach { (key, value) in
+        unwrappedHeaders.forEach { (key, value) in
             newHTTPHeaderFields[key] = value
         }
         return newHTTPHeaderFields

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -55,19 +55,32 @@ public class Endpoint<Target> {
     
     /// Convenience method for creating a new Endpoint, with changes only to the properties we specify as parameters
     public func endpointByAdding(parameters parameters: [String: AnyObject]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
-        var newParameters = self.parameters ?? [String: AnyObject]()
-        parameters?.forEach { (key, value) in
-            newParameters[key] = value
-        }
-        
-        var newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
-        httpHeaderFields?.forEach { (key, value) in
-            newHTTPHeaderFields[key] = value
-        }
-        
+        let newParameters = addParameters(parameters)
+        let newHTTPHeaderFields = addHTTPHeaderFields(httpHeaderFields)
         let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
-        
         return Endpoint(URL: URL, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
+    }
+    
+    private func addParameters(parameters: [String: AnyObject]?) -> [String: AnyObject]? {
+        var newParameters = self.parameters
+        if let unwrappedParameters = parameters where unwrappedParameters.count > 0 {
+            newParameters = self.parameters ?? [String: AnyObject]()
+            unwrappedParameters.forEach { (key, value) in
+                newParameters?[key] = value
+            }
+        }
+        return newParameters
+    }
+    
+    private func addHTTPHeaderFields(headers: [String: String]?) -> [String: String]? {
+        var newHTTPHeaderFields = self.httpHeaderFields
+        if let unwrappedHeaders = headers where unwrappedHeaders.count > 0 {
+            newHTTPHeaderFields = self.httpHeaderFields ?? [String: String]()
+            headers?.forEach { (key, value) in
+                newHTTPHeaderFields?[key] = value
+            }
+        }
+        return newHTTPHeaderFields
     }
 }
 


### PR DESCRIPTION
That PR fixed #419. Apparently, set an empty array as an endpoint parameters creates all this weird bugs. I have strictly no idea why, and if one you has an answer, I'd love to hear it! :monkey_face: 

The small changes I did to fix my both issues (related to #419) is just to let the current parameters / headers if we aren't adding any values to them.

I make some tests, didn't find anything that could break. What do  you think?