### PR TITLE
Move Defaults and Stubbing from MoyaProvider to MoyaDefaults.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
-- Fixed endpoint setup when adding `parameters` or `headers` when `parameters` or `headers` or nil
+- **Breaking Change** move Defaults (`DefaultAlamofireManager`, `DefaultRequestMapping`, `DefaultEndpointMapping`) and Stubbing (`NeverStub`, `ImmediatelyStub`, `DelayedStub`) from `MoyaProvider` to the new class `MoyaDefaults`.
+- Fixed endpoint setup when adding `parameters` or `headers` when `parameters` or `headers` or nil.
 
 # 6.2.0
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (3.2.0)
+  - Alamofire (3.2.1)
   - Moya (6.2.0):
     - Moya/Core (= 6.2.0)
   - Moya/Core (6.2.0):
@@ -53,7 +53,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Alamofire: 4da478599fccddff361205c8929333d7fe18dceb
+  Alamofire: f11d8624a05f5d39e0c99309b3e600a3ba64298a
   Moya: a5e57a405584177027daab240f4d47baa0722562
   Nimble: 79d40f4d69d47314229bbabacaa02b8838c779b9
   OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -7,7 +7,7 @@ class MoyaProviderSpec: QuickSpec {
     override func spec() {
         var provider: MoyaProvider<GitHub>!
         beforeEach {
-            provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub)
+            provider = MoyaProvider<GitHub>(stubClosure: MoyaDefaults.ImmediatelyStub)
         }
         
         it("returns stubbed data for zen request") {
@@ -67,7 +67,7 @@ class MoyaProviderSpec: QuickSpec {
                 return nil
             }
             
-            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
+            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaDefaults.ImmediatelyStub, plugins: [plugin])
             let target: HTTPBin = .BasicAuth
             provider.request(target) { _ in  }
             
@@ -81,7 +81,7 @@ class MoyaProviderSpec: QuickSpec {
                 return NSURLCredential(user: "user", password: "passwd", persistence: .None)
             }
             
-            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
+            let provider = MoyaProvider<HTTPBin>(stubClosure: MoyaDefaults.ImmediatelyStub, plugins: [plugin])
             let target: HTTPBin = .BasicAuth
             provider.request(target) { _ in  }
             
@@ -103,7 +103,7 @@ class MoyaProviderSpec: QuickSpec {
                 }
             }
             
-            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
+            let provider = MoyaProvider<GitHub>(stubClosure: MoyaDefaults.ImmediatelyStub, plugins: [plugin])
             let target: GitHub = .Zen
             provider.request(target) { _ in  }
             
@@ -118,7 +118,7 @@ class MoyaProviderSpec: QuickSpec {
                 }
             }
             
-            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, plugins: [plugin])
+            let provider = MoyaProvider<GitHub>(stubClosure: MoyaDefaults.ImmediatelyStub, plugins: [plugin])
             let target: GitHub = .Zen
             provider.request(target) { _ in  }
             
@@ -126,7 +126,7 @@ class MoyaProviderSpec: QuickSpec {
         }
         
         it("delays execution when appropriate") {
-            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.DelayedStub(2))
+            let provider = MoyaProvider<GitHub>(stubClosure: MoyaDefaults.DelayedStub(2))
             
             let startDate = NSDate()
             var endDate: NSDate?
@@ -148,11 +148,11 @@ class MoyaProviderSpec: QuickSpec {
             
             beforeEach {
                 executed = false
-                let endpointResolution = { (endpoint: Endpoint<GitHub>, done: NSURLRequest -> Void) in
+                let endpointResolution = { (endpoint: Endpoint<TargetType>, done: NSURLRequest -> Void) in
                     executed = true
                     done(endpoint.urlRequest)
                 }
-                provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+                provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaDefaults.ImmediatelyStub)
             }
             
             it("executes the endpoint resolver") {
@@ -166,7 +166,7 @@ class MoyaProviderSpec: QuickSpec {
         describe("with stubbed errors") {
             var provider: MoyaProvider<GitHub>!
             beforeEach {
-                provider = MoyaProvider(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.ImmediatelyStub)
+                provider = MoyaProvider(endpointClosure: failureEndpointClosure, stubClosure: MoyaDefaults.ImmediatelyStub)
             }
             
             it("returns stubbed data for zen request") {

--- a/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
@@ -8,7 +8,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
     override func spec() {
         var provider: ReactiveCocoaMoyaProvider<GitHub>!
         beforeEach {
-            provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub)
+            provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaDefaults.ImmediatelyStub)
         }
         
         describe("provider with RACSignal") {
@@ -59,7 +59,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
         describe("failing") {
             var provider: ReactiveCocoaMoyaProvider<GitHub>!
             beforeEach {
-                provider = ReactiveCocoaMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.ImmediatelyStub)
+                provider = ReactiveCocoaMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaDefaults.ImmediatelyStub)
             }
             
             it("returns the correct error message") {
@@ -102,9 +102,9 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             }
 
             class TestProvider<Target: TargetType>: ReactiveCocoaMoyaProvider<Target> {
-                init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-                    requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
-                    stubClosure: StubClosure = MoyaProvider.NeverStub,
+                init(endpointClosure: EndpointClosure = MoyaDefaults.DefaultEndpointMapping,
+                    requestClosure: RequestClosure = MoyaDefaults.DefaultRequestMapping,
+                    stubClosure: StubClosure = MoyaDefaults.NeverStub,
                     manager: Manager = Alamofire.Manager.sharedInstance,
                     plugins: [PluginType] = []) {
 
@@ -120,7 +120,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             beforeEach {
                 TestCancellable.cancelled = false
 
-                provider = TestProvider<GitHub>(stubClosure: MoyaProvider.DelayedStub(1))
+                provider = TestProvider<GitHub>(stubClosure: MoyaDefaults.DelayedStub(1))
             }
 
             it("cancels network request when subscription is cancelled") {
@@ -184,9 +184,9 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 }
                 
                 class TestProvider<Target: TargetType>: ReactiveCocoaMoyaProvider<Target> {
-                    init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-                        requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
-                        stubClosure: StubClosure = MoyaProvider.NeverStub,
+                    init(endpointClosure: EndpointClosure = MoyaDefaults.DefaultEndpointMapping,
+                        requestClosure: RequestClosure = MoyaDefaults.DefaultRequestMapping,
+                        stubClosure: StubClosure = MoyaDefaults.NeverStub,
                         manager: Manager = Alamofire.Manager.sharedInstance,
                         plugins: [PluginType] = []) {
 
@@ -202,7 +202,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 beforeEach {
                     TestCancellable.cancelled = false
                     
-                    provider = TestProvider<GitHub>(stubClosure: MoyaProvider.DelayedStub(1))
+                    provider = TestProvider<GitHub>(stubClosure: MoyaDefaults.DelayedStub(1))
                 }
                 
                 it("cancels network request when subscription is cancelled") {
@@ -223,7 +223,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             var response: Moya.Response? = nil
             beforeEach {
                 testScheduler = TestScheduler()
-                provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, stubScheduler: testScheduler)
+                provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaDefaults.ImmediatelyStub, stubScheduler: testScheduler)
                 provider.request(.Zen).startWithNext { next in
                     response = next
                 }

--- a/Demo/Tests/RxSwiftMoyaProviderTests.swift
+++ b/Demo/Tests/RxSwiftMoyaProviderTests.swift
@@ -12,7 +12,7 @@ class RxSwiftMoyaProviderSpec: QuickSpec {
             var provider: RxMoyaProvider<GitHub>!
             
             beforeEach {
-                provider = RxMoyaProvider(stubClosure: MoyaProvider.ImmediatelyStub)
+                provider = RxMoyaProvider(stubClosure: MoyaDefaults.ImmediatelyStub)
             }
             
             it("returns a Response object") {
@@ -52,7 +52,7 @@ class RxSwiftMoyaProviderSpec: QuickSpec {
         describe("failing") {
             var provider: RxMoyaProvider<GitHub>!
             beforeEach {
-                provider = RxMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.ImmediatelyStub)
+                provider = RxMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaDefaults.ImmediatelyStub)
             }
             
             it("returns the correct error message") {

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -42,9 +42,9 @@ func url(route: TargetType) -> String {
     return route.baseURL.URLByAppendingPathComponent(route.path).absoluteString
 }
 
-let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
+let failureEndpointClosure = { (target: TargetType) -> Endpoint<TargetType> in
     let error = NSError(domain: "com.moya.error", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
+    return Endpoint<TargetType>(URL: url(target), sampleResponseClosure: {.NetworkError(error)}, method: target.method, parameters: target.parameters)
 }
 
 enum HTTPBin: TargetType {

--- a/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -5,10 +5,10 @@ import ReactiveCocoa
 public class ReactiveCocoaMoyaProvider<Target where Target: TargetType>: MoyaProvider<Target> {
     private let stubScheduler: DateSchedulerType?
     /// Initializes a reactive provider.
-    public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-        requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
-        stubClosure: StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = ReactiveCocoaMoyaProvider<Target>.DefaultAlamofireManager(),
+    public init(endpointClosure: EndpointClosure = MoyaDefaults.DefaultEndpointMapping,
+        requestClosure: RequestClosure = MoyaDefaults.DefaultRequestMapping,
+        stubClosure: StubClosure = MoyaDefaults.NeverStub,
+        manager: Manager = MoyaDefaults.DefaultAlamofireManager(),
         plugins: [PluginType] = [], stubScheduler: DateSchedulerType? = nil) {
             self.stubScheduler = stubScheduler
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
@@ -37,7 +37,7 @@ public class ReactiveCocoaMoyaProvider<Target where Target: TargetType>: MoyaPro
         }
     }
 
-    override func stubRequest(target: Target, request: NSURLRequest, completion: Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
+    override func stubRequest(target: Target, request: NSURLRequest, completion: Moya.Completion, endpoint: Endpoint<TargetType>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
         guard let stubScheduler = self.stubScheduler else {
             return super.stubRequest(target, request: request, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
         }

--- a/Source/RxSwift/Moya+RxSwift.swift
+++ b/Source/RxSwift/Moya+RxSwift.swift
@@ -4,10 +4,10 @@ import RxSwift
 /// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.
 public class RxMoyaProvider<Target where Target: TargetType>: MoyaProvider<Target> {
     /// Initializes a reactive provider.
-    override public init(endpointClosure: EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-        requestClosure: RequestClosure = MoyaProvider.DefaultRequestMapping,
-        stubClosure: StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = RxMoyaProvider<Target>.DefaultAlamofireManager(),
+    override public init(endpointClosure: EndpointClosure = MoyaDefaults.DefaultEndpointMapping,
+        requestClosure: RequestClosure = MoyaDefaults.DefaultRequestMapping,
+        stubClosure: StubClosure = MoyaDefaults.NeverStub,
+        manager: Manager = MoyaDefaults.DefaultAlamofireManager(),
         plugins: [PluginType] = []) {
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }


### PR DESCRIPTION
While preparing for Structs API that potentially could be coming to Moya, we decided that the PR #424 was too large and, what is more important, it had breaking change that is extracted to this PR. 

In this PR we extracted from `MoyaProvider`:
- Defaults: `DefaultAlamofireManager`, `DefaultRequestMapping`, `DefaultEndpointMapping`
- Stubbing: `NeverStub`, `ImmediatelyStub`, `DelayedStub`

and moved them to the new class `MoyaDefaults`.

For more information you can take a look at description of #424. Thanks! 🎉
