### PR TITLE
Adds sample implementation for struct-based enum

### DIFF
--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (3.2.0)
+  - Alamofire (3.2.1)
   - Moya (6.2.0):
     - Moya/Core (= 6.2.0)
   - Moya/Core (6.2.0):
@@ -7,7 +7,7 @@ PODS:
     - Result (~> 1.0)
   - Moya/ReactiveCocoa (6.2.0):
     - Moya/Core
-    - ReactiveCocoa (= 4.0.0)
+    - ReactiveCocoa (~> 4.0)
   - Moya/RxSwift (6.2.0):
     - Moya/Core
     - RxSwift (~> 2.0)
@@ -26,17 +26,17 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.7.0)
   - Quick (0.9.0)
-  - ReactiveCocoa (4.0.0):
-    - ReactiveCocoa/UI (= 4.0.0)
-    - Result (~> 1.0.1)
-  - ReactiveCocoa/Core (4.0.0):
+  - ReactiveCocoa (4.0.1):
+    - ReactiveCocoa/UI (= 4.0.1)
+    - Result (~> 1.0.2)
+  - ReactiveCocoa/Core (4.0.1):
     - ReactiveCocoa/no-arc
-    - Result (~> 1.0.1)
-  - ReactiveCocoa/no-arc (4.0.0):
-    - Result (~> 1.0.1)
-  - ReactiveCocoa/UI (4.0.0):
+    - Result (~> 1.0.2)
+  - ReactiveCocoa/no-arc (4.0.1):
+    - Result (~> 1.0.2)
+  - ReactiveCocoa/UI (4.0.1):
     - ReactiveCocoa/Core
-    - Result (~> 1.0.1)
+    - Result (~> 1.0.2)
   - Result (1.0.2)
   - RxSwift (2.2.0)
 
@@ -53,12 +53,12 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Alamofire: 4da478599fccddff361205c8929333d7fe18dceb
-  Moya: a5e57a405584177027daab240f4d47baa0722562
+  Alamofire: f11d8624a05f5d39e0c99309b3e600a3ba64298a
+  Moya: 6788cb3b660ec6bca209b7e4f67f291b8d3d59a3
   Nimble: 79d40f4d69d47314229bbabacaa02b8838c779b9
   OHHTTPStubs: d2bf6a0f407620d67e75a1d3f12d86a2b1dd15c0
   Quick: 332eb1da73125a2106dd637424c803f2ae97e4a9
-  ReactiveCocoa: 69be555be30674b07a86b60a91b855063841acc0
+  ReactiveCocoa: f7011630aee4deeb16352fcb1b50d6bde9db4f90
   Result: dd3dd71af3fa2e262f1a999e14fba2c25ec14f16
   RxSwift: b8a749f2204c6c7a5c29b306a9c3bc11d5b87c5b
 

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -2,6 +2,7 @@ import Quick
 import Nimble
 import Alamofire
 import Moya
+import Foundation
 
 class MoyaProviderSpec: QuickSpec {
     override func spec() {
@@ -219,6 +220,83 @@ class MoyaProviderSpec: QuickSpec {
                 default:
                     fail("expected an Underlying error that Houston has a problem")
                 }
+            }
+        }
+
+        describe("struct targets") {
+            struct StructAPI: TargetType {
+                var baseURL = NSURL(string: "http://example.com")!
+                var path = "/endpoint"
+                var method = Moya.Method.GET
+                var parameters: [String: AnyObject]? = ["key": "value"]
+                var sampleData = ("sample data" as NSString).dataUsingEncoding(NSUTF8StringEncoding)!
+            }
+
+            it("uses correct URL") {
+                var requestedURL: String?
+                let endpointResolution = { (endpoint: Endpoint<StructTarget<StructAPI>>, done: NSURLRequest -> Void) in
+                    requestedURL = endpoint.URL
+                    done(endpoint.urlRequest)
+                }
+                let provider = MoyaProvider<StructTarget<StructAPI>>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+
+                waitUntil { done in
+                    provider.request(StructTarget(StructAPI())) { _ in
+                        done()
+                    }
+                }
+
+                expect(requestedURL) == "http://example.com/endpoint"
+            }
+
+            it("uses correct parameters") {
+                var requestParameters: [String: AnyObject]?
+                let endpointResolution = { (endpoint: Endpoint<StructTarget<StructAPI>>, done: NSURLRequest -> Void) in
+                    requestParameters = endpoint.parameters
+                    done(endpoint.urlRequest)
+                }
+                let provider = MoyaProvider<StructTarget<StructAPI>>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+
+                waitUntil { done in
+                    provider.request(StructTarget(StructAPI())) { _ in
+                        done()
+                    }
+                }
+
+                expect(requestParameters?.count) == 1
+            }
+
+            it("uses correct method") {
+                var requestMethod: Moya.Method?
+                let endpointResolution = { (endpoint: Endpoint<StructTarget<StructAPI>>, done: NSURLRequest -> Void) in
+                    requestMethod = endpoint.method
+                    done(endpoint.urlRequest)
+                }
+                let provider = MoyaProvider<StructTarget<StructAPI>>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+
+                waitUntil { done in
+                    provider.request(StructTarget(StructAPI())) { _ in
+                        done()
+                    }
+                }
+
+                expect(requestMethod) == .GET
+            }
+
+            it("uses correct sample data") {
+                var dataString: NSString?
+                let provider = MoyaProvider<StructTarget<StructAPI>>(stubClosure: MoyaProvider.ImmediatelyStub)
+
+                waitUntil { done in
+                    provider.request(StructTarget(StructAPI())) { result in
+                        if case let .Success(response) = result {
+                            dataString = NSString(data: response.data, encoding: NSUTF8StringEncoding)
+                        }
+                        done()
+                    }
+                }
+
+                expect(dataString) == "sample data"
             }
         }
     }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -32,35 +32,30 @@ public enum StructTarget<T: TargetType>: TargetType {
     }
 
     public var path: String {
-        switch self {
-        case .Struct(let t): return t.path
-        }
+        return target.path
     }
 
     public var baseURL: NSURL {
-        switch self {
-        case .Struct(let t): return t.baseURL
-        }
+        return target.baseURL
     }
 
     public var method: Moya.Method {
-        switch self {
-        case .Struct(let t): return t.method
-        }
+        return target.method
     }
 
     public var parameters: [String: AnyObject]? {
-        switch self {
-        case .Struct(let t): return t.parameters
-        }
+        return target.parameters
     }
 
     public var sampleData: NSData {
-        switch self {
-        case .Struct(let t): return t.sampleData
-        }
+        return target.sampleData
     }
 
+    public var target: T {
+        switch self {
+        case .Struct(let t): return t
+        }
+    }
 }
 
 /// Protocol to define the opaque type returned from a request

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -24,6 +24,45 @@ public protocol TargetType {
     var sampleData: NSData { get }
 }
 
+public enum StructTarget<T: TargetType>: TargetType {
+    case Struct(T)
+
+    public init(_ target: T) {
+        self = StructTarget.Struct(target)
+    }
+
+    public var path: String {
+        switch self {
+        case .Struct(let t): return t.path
+        }
+    }
+
+    public var baseURL: NSURL {
+        switch self {
+        case .Struct(let t): return t.baseURL
+        }
+    }
+
+    public var method: Moya.Method {
+        switch self {
+        case .Struct(let t): return t.method
+        }
+    }
+
+    public var parameters: [String: AnyObject]? {
+        switch self {
+        case .Struct(let t): return t.parameters
+        }
+    }
+
+    public var sampleData: NSData {
+        switch self {
+        case .Struct(let t): return t.sampleData
+        }
+    }
+
+}
+
 /// Protocol to define the opaque type returned from a request
 public protocol Cancellable {
     func cancel()


### PR DESCRIPTION
This is an alternative implementation of #408 (in lieu of #424).

Basically, Moya provides an `enum` type called `StructTarget` that has a single case, `.Struct` with an associated, generic value. That value is the "real" `TargetType`, the `struct` that our users would use. So instead of

```swift
MoyaProvider<MyStructAPI>
```

You'd use

```swift
MoyaProvider<StructTarget<MyStructAPI>>
```

Pros:

- Simple implementation
- No breaking changes

Cons:

- More verbose for developers using structs

Curious to know what you think!