### PR TITLE
Removes generic type requirement on StructTarget

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
-- Fixed endpoint setup when adding `parameters` or `headers` when `parameters` or `headers` or nil
+- Fixed endpoint setup when adding `parameters` or `headers` when `parameters` or `headers` or nil.
+- Adds StructTarget for using Moya with structs.
 
 # 6.2.0
 

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -234,11 +234,11 @@ class MoyaProviderSpec: QuickSpec {
 
             it("uses correct URL") {
                 var requestedURL: String?
-                let endpointResolution = { (endpoint: Endpoint<StructTarget<StructAPI>>, done: NSURLRequest -> Void) in
+                let endpointResolution = { (endpoint: Endpoint<StructTarget>, done: NSURLRequest -> Void) in
                     requestedURL = endpoint.URL
                     done(endpoint.urlRequest)
                 }
-                let provider = MoyaProvider<StructTarget<StructAPI>>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+                let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
 
                 waitUntil { done in
                     provider.request(StructTarget(StructAPI())) { _ in
@@ -251,11 +251,11 @@ class MoyaProviderSpec: QuickSpec {
 
             it("uses correct parameters") {
                 var requestParameters: [String: AnyObject]?
-                let endpointResolution = { (endpoint: Endpoint<StructTarget<StructAPI>>, done: NSURLRequest -> Void) in
+                let endpointResolution = { (endpoint: Endpoint<StructTarget>, done: NSURLRequest -> Void) in
                     requestParameters = endpoint.parameters
                     done(endpoint.urlRequest)
                 }
-                let provider = MoyaProvider<StructTarget<StructAPI>>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+                let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
 
                 waitUntil { done in
                     provider.request(StructTarget(StructAPI())) { _ in
@@ -268,11 +268,11 @@ class MoyaProviderSpec: QuickSpec {
 
             it("uses correct method") {
                 var requestMethod: Moya.Method?
-                let endpointResolution = { (endpoint: Endpoint<StructTarget<StructAPI>>, done: NSURLRequest -> Void) in
+                let endpointResolution = { (endpoint: Endpoint<StructTarget>, done: NSURLRequest -> Void) in
                     requestMethod = endpoint.method
                     done(endpoint.urlRequest)
                 }
-                let provider = MoyaProvider<StructTarget<StructAPI>>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
+                let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
 
                 waitUntil { done in
                     provider.request(StructTarget(StructAPI())) { _ in
@@ -285,7 +285,7 @@ class MoyaProviderSpec: QuickSpec {
 
             it("uses correct sample data") {
                 var dataString: NSString?
-                let provider = MoyaProvider<StructTarget<StructAPI>>(stubClosure: MoyaProvider.ImmediatelyStub)
+                let provider = MoyaProvider<StructTarget>(stubClosure: MoyaProvider.ImmediatelyStub)
 
                 waitUntil { done in
                     provider.request(StructTarget(StructAPI())) { result in

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -24,10 +24,10 @@ public protocol TargetType {
     var sampleData: NSData { get }
 }
 
-public enum StructTarget<T: TargetType>: TargetType {
-    case Struct(T)
+public enum StructTarget: TargetType {
+    case Struct(TargetType)
 
-    public init(_ target: T) {
+    public init(_ target: TargetType) {
         self = StructTarget.Struct(target)
     }
 
@@ -51,7 +51,7 @@ public enum StructTarget<T: TargetType>: TargetType {
         return target.sampleData
     }
 
-    public var target: T {
+    public var target: TargetType {
         switch self {
         case .Struct(let t): return t
         }


### PR DESCRIPTION
Based off of work done in #427, refined from [this comment](https://github.com/Moya/Moya/pull/376#issuecomment-197149515). 

This removes the generic parameter for `StructTarget` and instead lets users create one with _any_ struct that conforms to the `TargetType`, so one provider can be used with many different struct targets. 