### PR TITLE
Updates required version of dependencies, makes convertResponseToResult accessible

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,3 @@
 github "Alamofire/Alamofire" ~> 3.0
-github "ReactiveCocoa/ReactiveCocoa" ~> 4.0
+github "ReactiveCocoa/ReactiveCocoa" ~> 4.1
 github "ReactiveX/RxSwift" ~> 2.0
-github "antitypical/Result" ~> 1.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+- Makes `convertResponseToResult` public to make use of this method when dealing with Alamofire directly
+- Updates to ReactiveCocoa 4.1
+- Updates to Result 2.0
+
 # 6.3.1
 
 - Updates for Swift 2.2 / Xcode 7.3 compatibility.

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Moya"
-  s.version      = "6.3.1"
+  s.version      = "6.3.2"
   s.summary      = "Network abstraction layer written in Swift"
   s.description  = <<-EOS
   Moya abstracts network commands using Swift Generics to provide developers
@@ -23,14 +23,14 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |ss|
     ss.source_files  = "Source/*.swift", "Source/Plugins/*swift"
     ss.dependency "Alamofire", "~> 3.0"
-    ss.dependency "Result", "~> 1.0"
+    ss.dependency "Result", "~> 2.0"
     ss.framework  = "Foundation"
   end
 
   s.subspec "ReactiveCocoa" do |ss|
     ss.source_files = "Source/ReactiveCocoa/*.swift"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveCocoa", "~> 4.0"
+    ss.dependency "ReactiveCocoa", "~> 4.1"
   end
 
   s.subspec "RxSwift" do |ss|

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -246,7 +246,7 @@ internal extension MoyaProvider {
     }
 }
 
-internal func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?, error: NSError?) ->
+public func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?, error: NSError?) ->
     Result<Moya.Response, Moya.Error> {
     switch (response, data, error) {
     case let (.Some(response), .Some(data), .None):


### PR DESCRIPTION
Hi, 

this pull request fixes https://github.com/Moya/Moya/issues/433

Additionally, in the last couple of days my colleagues and me experienced issues with `Moya` using `Carthage`. I guess the recent release of `ReactiveCocoa 4.1` (which points to `Result ~> 2.0`) is the reason for those issues. I removed `Result` from `Moya´s` cartfile (previously pointed to `Result ~> 1.0` which may conflict with `ReactiveCocoa´s` requirements), so `ReactiveCocoa` takes care of requiring `Result`. We have no more issues with this setup✌🏼

