### PR TITLE
Remove redundant casting to NSError from tests.

### DIFF
--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -239,7 +239,7 @@ class MoyaProviderSpec: QuickSpec {
                 }
                 
                 switch receivedError {
-                case .Some(.Underlying(let error as NSError)):
+                case .Some(.Underlying(let error)):
                     expect(error.localizedDescription) == "Houston, we have a problem"
                 default:
                     fail("expected an Underlying error that Houston has a problem")

--- a/Demo/Tests/Observable+MoyaSpec.swift
+++ b/Demo/Tests/Observable+MoyaSpec.swift
@@ -230,7 +230,7 @@ class ObservableMoyaSpec: QuickSpec {
                 
                 expect(receivedError).toNot(beNil())
                 switch receivedError {
-                case .Some(.Underlying(let error as NSError)):
+                case .Some(.Underlying(let error)):
                     expect(error.domain).to(equal("\(NSCocoaErrorDomain)"))
                 default:
                     fail("expected NSError with \(NSCocoaErrorDomain) domain")

--- a/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
@@ -73,7 +73,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 }
                 
                 switch receivedError {
-                case .Some(.Underlying(let error as NSError)):
+                case .Some(.Underlying(let error)):
                     expect(error.localizedDescription) == "Houston, we have a problem"
                 default:
                     fail("expected an Underlying error that Houston has a problem")

--- a/Demo/Tests/RxSwiftMoyaProviderTests.swift
+++ b/Demo/Tests/RxSwiftMoyaProviderTests.swift
@@ -66,7 +66,7 @@ class RxSwiftMoyaProviderSpec: QuickSpec {
                 }
                 
                 switch receivedError {
-                case .Some(.Underlying(let error as NSError)):
+                case .Some(.Underlying(let error)):
                     expect(error.localizedDescription) == "Houston, we have a problem"
                 default:
                     fail("expected an Underlying error that Houston has a problem")

--- a/Demo/Tests/SignalProducer+MoyaSpec.swift
+++ b/Demo/Tests/SignalProducer+MoyaSpec.swift
@@ -229,7 +229,7 @@ class SignalProducerMoyaSpec: QuickSpec {
                 
                 expect(receivedError).toNot(beNil())
                 switch receivedError {
-                case .Some(.Underlying(let error as NSError)):
+                case .Some(.Underlying(let error)):
                     expect(error.domain).to(equal("\(NSCocoaErrorDomain)"))
                 default:
                     fail("expected NSError with \(NSCocoaErrorDomain) domain")


### PR DESCRIPTION
So because #479 was merged, we don't really need casting with `as NSError` anymore, because it always succeeds. 🐼 