### PR TITLE
[Readme] Update usage section.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,9 +77,10 @@ github "Moya/Moya"
 Usage
 ---
 
-After [some setup](docs/Examples), using Moya is really simple. You can access an API like this:
+After [some setup](docs/Examples/Basic.md), using Moya is really simple. You can access an API like this:
 
 ```swift
+provider = MoyaProvider<GitHub>()
 provider.request(.Zen) { result in
     switch result {
     case let .Success(moyaResponse):

--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,7 @@ That's a basic example. Many API requests need parameters. Moya encodes these
 into the enum you use to access the endpoint, like this:
 
 ```swift
+provider = MoyaProvider<GitHub>()
 provider.request(.UserProfile("ashfurrow")) { result in
     // do something with the result
 }
@@ -108,17 +109,17 @@ provider.request(.UserProfile("ashfurrow")) { result in
 No more typos in URLs. No more missing parameter values. No more messing with
 parameter encoding.
 
-For examples, see the [documentation](docs/).
+For more examples, see the [documentation](docs/Examples).
 
 Reactive Extensions
 -------------------
 
 Even cooler are the reactive extensions. Moya provides reactive extensions for
-[ReactiveCocoa](docs/ReactiveCocoa.md) and [RxSwift](docs/RxSwift.md).
+[ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) and [RxSwift](https://github.com/ReactiveX/RxSwift).
 
 ## ReactiveCocoa
 
-For `ReactiveCocoa`, it immediately returns a `SignalProducer` (`RACSignal`
+After `ReactiveCocoa` [docs/ReactiveCocoa.md](setup), `.request(:)` method immediately returns a `SignalProducer` (`RACSignal`
 is also available if needed) that you can start or bind or map or whatever
 you want to do. To handle errors, for instance, we could do the following:
 

--- a/Readme.md
+++ b/Readme.md
@@ -115,15 +115,18 @@ Reactive Extensions
 -------------------
 
 Even cooler are the reactive extensions. Moya provides reactive extensions for
-[ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) and [RxSwift](https://github.com/ReactiveX/RxSwift).
+[ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa) and
+[RxSwift](https://github.com/ReactiveX/RxSwift).
 
 ## ReactiveCocoa
 
-After `ReactiveCocoa` [docs/ReactiveCocoa.md](setup), `.request(:)` method immediately returns a `SignalProducer` (`RACSignal`
-is also available if needed) that you can start or bind or map or whatever
-you want to do. To handle errors, for instance, we could do the following:
+After `ReactiveCocoa` [docs/ReactiveCocoa.md](setup), `.request(:)` method
+immediately returns a `SignalProducer` (`RACSignal` is also available if needed)
+that you can start or bind or map or whateveryou want to do. To handle errors,
+for instance, we could do the following:
 
 ```swift
+provider = ReactiveCocoaMoyaProvider<GitHub>()
 provider.request(.UserProfile("ashfurrow")).start { (event) -> Void in
     switch event {
     case .Next(let response):
@@ -136,13 +139,14 @@ provider.request(.UserProfile("ashfurrow")).start { (event) -> Void in
 }
 ```
 
-##RxSwift
+## RxSwift
 
-For `RxSwift`, it immediately returns an `Observable` that you can subscribe to
-or bind or map or whatever you want to do. To handle errors, for instance,
-we could do the following:
+After `RxSwift` [docs/RxSwift.md](setup), `.request(:)` method immediately
+returns an `Observable` that you can subscribe to or bind or map or whatever you
+want to do. To handle errors, for instance, we could do the following:
 
 ```swift
+provider = RxMoyaProvider<GitHub>()
 provider.request(.UserProfile("ashfurrow")).subscribe { (event) -> Void in
     switch event {
     case .Next(let response):

--- a/Readme.md
+++ b/Readme.md
@@ -120,7 +120,7 @@ Even cooler are the reactive extensions. Moya provides reactive extensions for
 
 ## ReactiveCocoa
 
-After `ReactiveCocoa` [docs/ReactiveCocoa.md](setup), `.request(:)` method
+After `ReactiveCocoa` [setup](docs/ReactiveCocoa.md), `request(:)` method
 immediately returns a `SignalProducer` (`RACSignal` is also available if needed)
 that you can start or bind or map or whateveryou want to do. To handle errors,
 for instance, we could do the following:
@@ -141,7 +141,7 @@ provider.request(.UserProfile("ashfurrow")).start { (event) -> Void in
 
 ## RxSwift
 
-After `RxSwift` [docs/RxSwift.md](setup), `.request(:)` method immediately
+After `RxSwift` [setup](docs/RxSwift.md), `request(:)` method immediately
 returns an `Observable` that you can subscribe to or bind or map or whatever you
 want to do. To handle errors, for instance, we could do the following:
 

--- a/docs/ReactiveCocoa.md
+++ b/docs/ReactiveCocoa.md
@@ -11,7 +11,7 @@ A `ReactiveCocoaMoyaProvider` can be created much like a
 [`MoyaProvider`](Providers.md) and can be used as follows:
 
 ```swift
-let GitHubProvider = ReactiveCocoaMoyaProvider<GitHub>()
+let provider = ReactiveCocoaMoyaProvider<GitHub>()
 ```
 
 After that simple setup, you're off to the races:

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -10,7 +10,7 @@ A `RxMoyaProvider` can be created much like a
 [`MoyaProvider`](Providers.md) and can be used as follows:
 
 ```swift
-let GitHubProvider = RxMoyaProvider<GitHub>()
+let provider = RxMoyaProvider<GitHub>()
 ```
 
 After that simple setup, you're off to the races:


### PR DESCRIPTION
I've made some changes to Readme due to the feedback. Basically some people didn't really get why their code didn't work with just `MoyaProvider`, while using Reactive Extensions. Because of that, I've added example of provider initializing before the request. The next step I took was to add explicit info about different setup needed for `RxSwift` and `ReactiveCocoa`, instead of linking to them before their sections. Other than that I've made some fixes to URLs that we didn't change after the examples upgrade.

Also, I've changed `GitHubProvider` name in `RxSwift` and `ReactiveCocoa` docs to just `provider` like it is [here](https://github.com/Moya/Moya/blob/master/docs/Providers.md), to be more consistent. 

As always, let me know what do you think! :tada: