### PR TITLE
Changed MoyaResponse in RxSwift docs to Moya.Response

### DIFF
--- a/docs/ReactiveCocoa.md
+++ b/docs/ReactiveCocoa.md
@@ -35,19 +35,19 @@ is disposed of before the request completes, the request is cancelled.
 
 If the request completes normally, two things happen:
 
-1. The signal sends a value, a `MoyaResponse` instance.
+1. The signal sends a value, a `Moya.Response` instance.
 2. The signal completes.
 
 If the request produces an error (typically a NSURLSession error),
 then it sends an error, instead. The error's `code` is the failing
 request's status code, if any, and the response data, if any.
 
-The `MoyaResponse` class contains a `statusCode`, some `data`,
+The `Moya.Response` class contains a `statusCode`, some `data`,
 and a(n optional) `NSURLResponse`. You can use these values however
 you like in `startWithNext` or `map` calls.
 
 To make things even awesomer, Moya provides some extensions to
-`SignalProducer` (and `RACSignal`) that make dealing with `MoyaResponses`
+`SignalProducer` (and `RACSignal`) that make dealing with `Moya.Responses`
 really easy.
 
 - `filterStatusCodes()` takes a range of status codes. If the

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -34,14 +34,14 @@ is disposed of before the request completes, the request is cancelled.
 
 If the request completes normally, two things happen:
 
-1. The observable sends a value, a `MoyaResponse` instance.
+1. The observable sends a value, a `Moya.Response` instance.
 2. The observable completes.
 
 If the request produces an error (typically a NSURLSession error),
 then it sends an error, instead. The error's `code` is the failing
 request's status code, if any, and the response data, if any.
 
-The `MoyaResponse` class contains a `statusCode`, some `data`,
+The `Moya.Response` class contains a `statusCode`, some `data`,
 and a(n optional) `NSURLResponse`. You can use these values however
 you like in `subscribeNext` or `map` calls.
 


### PR DESCRIPTION
At first I got confused when reading the documentation, because `MoyaResponse` does not exist (`RxMoyaProvider` does on the other hand). Changed the docs to match the class location which is `Moya.Response`.