### PR TITLE
[Changelog] Update breaking change alias.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Next
 
-- Changes `Moya.Error.Underlying` to have `NSError` instead of `ErrorType`. *Breaking change*
-- Implements inflights tracking by adding `trackInflights = true` to your provider. *Breaking change*
-- Changes `MoyaProvider.RequestClosure` to have `Result<NSURLRequest, Moya.Error> -> Void` instead of `NSURLRequest -> Void` as a `done` closure parameter. *Breaking change*
+- **Breaking Change** Changes `Moya.Error.Underlying` to have `NSError` instead of `ErrorType`.
+- **Breaking Change** Implements inflights tracking by adding `trackInflights = true` to your provider.
+- **Breaking Change** Changes `MoyaProvider.RequestClosure` to have `Result<NSURLRequest, Moya.Error> -> Void` instead of `NSURLRequest -> Void` as a `done` closure parameter.
 
 # 6.4.0
 


### PR DESCRIPTION
In the **Next** section the **breaking change** wasn't bold and was kinda misleading me to think we are not having any breaking changes right now. Also we were doing the alias in the beginning of the change lately, so I've moved it as well, to make it more coherent.