### PR TITLE
Added documentation for plugins

### DIFF
--- a/docs/Examples/CustomPlugin.md
+++ b/docs/Examples/CustomPlugin.md
@@ -1,0 +1,63 @@
+Creating a custom plugin
+=========================================================
+
+As an example of building a custom plugin, let's say we wanted to inform the user about our network activity so we will show an alert view with some basic info about the request as it is being sent, and let users know if a response indicated a failed request (for this example we will also need to assume we dont mind bothering the user with lots of alerts)
+
+First we create a class which will conform to `PluginType`, and accept a reference to a view controller (required to present a `UIAlertController`):
+
+```
+final class RequestAlertPlugin: PluginType {
+    
+    private let viewController: UIViewController
+    
+    init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+    
+    func willSendRequest(request: RequestType, target: TargetType) {
+        
+    }
+    
+    func didReceiveResponse(result: Result<Response, Error>, target: TargetType) {
+        
+    }
+}
+```
+
+Then we add some functionality to the function called when a request will be sent:
+
+```
+func willSendRequest(request: RequestType, target: TargetType) {
+        
+        //make sure we have a URL string to display
+        guard let requestURLString = request.request?.URL?.absoluteString else { return }
+        
+        //create alert view controller with a single action
+        let alertViewController = UIAlertController(title: "Sending Request", message: requestURLString, preferredStyle: .Alert)
+        alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+        
+        //and present using the view controller we created at initialisation
+        viewController.presentViewController(alertViewController, animated: true, completion: nil)
+    }
+```
+
+Finally, let's implement `didReceiveResponse` to show an alert if the result was a failure
+
+```
+func didReceiveResponse(result: Result<Response, Error>, target: TargetType) {
+        
+        //only continue if result is a failure
+        guard case Result.Failure(let error) = result else { return }
+        
+        //create alert view controller with a single action and messing displaying status code
+        let alertViewController = UIAlertController(title: "Error", message: "Request failed with status code: \(error.response?.statusCode ?? 0)", preferredStyle: .Alert)
+        alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+        
+        //and present using the view controller we created at initialisation
+        viewController.presentViewController(alertViewController, animated: true, completion: nil)
+    }
+```
+
+And that's it, you now have very well informed, if slightly annoyed users.
+ 
+_(Please note that this example will usually fail since presenting an alert twice on the same view controller is not allowed)_

--- a/docs/Examples/README.md
+++ b/docs/Examples/README.md
@@ -21,3 +21,7 @@ Examples
 ####Error handling
 
 * [Handling different error types](ErrorTypes.md)
+
+####Plugins
+
+* [Creating a custom plugin](CustomPlugin.md)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -3,26 +3,26 @@ Plugins
 
 Moya plugins are used to perform some side effect whenever a request is sent or received. Plugins are defined by the `PluginType` protocol, which can receive callbacks when a request is going to be sent, and when a response has been received. 
 
-##Built in plugins##
+##Built in plugins
 Moya ships with some default plugins which can be used for common functions: authentication, network activity indicator management, and logging.
 
-####Authentication####
+####Authentication
 The authentication plugin allows a user to assign an optional `NSURLCredential` per request. There is no action when a request is received. 
 
 The plugin can be found at [`Source/Plugins/CredentialsPlugin.swift`](../Source/Plugins/CredentialsPlugin.swift)
 
-####Network Activity Indicator####
+####Network Activity Indicator
 One very common task with iOS networking is to show a network activitiy indicator during network requests, and remove it when all requests have finished. The provided plugin adds callbacks which are called when a requests starts and finishes, which can be used to keep track of the number of requests in progress, and show / hide the network activity indicator accordingly. 
 
 The plugin can be found at [`Source/Plugins/NetworkActivityPlugin.swift`](../Source/Plugins/NetworkActivityPlugin.swift)
 
-####Logging####
+####Logging
 During development it can be very useful to log network activity to the console. This can be anything from the URL of a request as sent and received, to logging full headers, method, request body on each request and response. 
 
 The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initialising the plugin, you can choose options for verbosity, wether to log curl commands, and provide functions for outputing data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `NSUTF8StringEncoding` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in [`Demo/Demo/GitHubAPI.swift`](../Demo/Demo/GitHubAPI.swift) for a example that does exactly that)
 
 The plugin can be found at [`Source/Plugins/NetworkLoggerPlugin.swift`](../Source/Plugins/NetworkLoggerPlugin.swift)
 
-##Custom plugins##
+##Custom plugins
 
 For an example of creating a new plugin, see [`docs/Examples/CustomPlugin.md`](Examples/CustomPlugin.md)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,0 +1,28 @@
+Plugins
+=======
+
+Moya plugins are used to perform some side effect whenever a request is sent or received. Plugins are defined by the `PluginType` protocol, which can receive callbacks when a request is going to be sent, and when a response has been received. 
+
+##Built in plugins##
+Moya ships with some default plugins which can be used for common functions: authentication, network activity indicator management, and logging.
+
+####Authentication####
+The authentication plugin allows a user to assign an optional `NSURLCredential` per request. There is no action when a request is received. 
+
+The plugin can be found at `Source/Plugins/CredentialsPlugin.swift`
+
+####Network Activity Indicator####
+One very common task with iOS networking is to show a network activitiy indicator during network requests, and remove it when all requests have finished. The provided plugin adds callbacks which are called when a requests starts and finishes, which can be used to keep track of the number of requests in progress, and show / hide the network activity indicator accordingly. 
+
+The plugin can be found at `Source/Plugins/NetworkActivityPlugin.swift`
+
+####Logging####
+During development it can be very useful to log network activity to the console. This can be anything from the URL of a request as sent and received, to logging full headers, method, request body on each request and response. 
+
+The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initialising the plugin, you can choose options for verbosity, wether to log curl commands, and provide functions for outputing data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `NSUTF8StringEncoding` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in `Demo/Demo/GitHubAPI.swift` for a example that does exactly that)
+
+The plugin can be found at `Source/Plugins/NetworkLoggerPlugin.swift`
+
+##Custom plugins##
+
+For an example of creating a new plugin, see `docs/Examples/CustomPlugin.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ It accomplishes this with the following pipeline.
 ----------------
 
 <p align="center">
-    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveCocoa.md">ReactiveCocoa</a> &bull; <a href="RxSwift.md">RxSwift</a>
+    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveCocoa.md">ReactiveCocoa</a> &bull; <a href="RxSwift.md">RxSwift</a> &bull; <a href="Plugins.md">Plugins</a>
 </p>
 
 ----------------


### PR DESCRIPTION
This adds 2 new doc files:
- `Plugins.md` for an overview of plugins and descriptions of the existing core plugins
- `CustomPlugin.md` for an example of creating a new plugin

Original discussion is here: https://github.com/Moya/Moya/issues/397

I wrote this locally and I wasn't sure how to setup links, use swift syntax etc in markdown so any feedback would be great. 

Thanks