### PR TITLE
Updates to released danger-swiftlint version #trivial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'cocoapods'
 gem 'rake'
 gem 'octokit', '~> 4.3'
 
-gem 'danger', git: 'https://github.com/danger/danger'
-gem 'danger-swiftlint', git: 'https://github.com/ashfurrow/danger-swiftlint'
+gem 'danger'
+gem 'danger-swiftlint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,3 @@
-GIT
-  remote: https://github.com/ashfurrow/danger-swiftlint
-  revision: 9bfd468128022aac4fd76ce93f5b09414c6ee552
-  specs:
-    danger-swiftlint (0.0.1)
-      danger
-
-GIT
-  remote: https://github.com/danger/danger
-  revision: f895ac3be3c1fc2c30062d2ca71598f076a3e0b9
-  specs:
-    danger (0.8.3)
-      claide (~> 1.0)
-      colored (~> 1.2)
-      cork (~> 0.1)
-      faraday (~> 0)
-      git (~> 1)
-      octokit (~> 4.2)
-      redcarpet (~> 3.3)
-      terminal-table (~> 1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -64,6 +43,17 @@ GEM
     colored (1.2)
     cork (0.1.0)
       colored (~> 1.2)
+    danger (0.8.4)
+      claide (~> 1.0)
+      colored (~> 1.2)
+      cork (~> 0.1)
+      faraday (~> 0)
+      git (~> 1)
+      octokit (~> 4.2)
+      redcarpet (~> 3.3)
+      terminal-table (~> 1)
+    danger-swiftlint (0.1.0)
+      danger
     escape (0.0.4)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -101,8 +91,8 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods
-  danger!
-  danger-swiftlint!
+  danger
+  danger-swiftlint
   octokit (~> 4.3)
   rake
   xcpretty


### PR DESCRIPTION
I released [the gem](https://github.com/ashfurrow/danger-swiftlint) so we don't need to refer to it by repo URL anymore. This does the same for Danger.