### PR TITLE
Refactor Cancellables

### DIFF
--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -165,6 +165,22 @@ class MoyaProviderSpec: QuickSpec {
                 
                 expect(receivedError).toNot( beNil() )
             }
+
+            it("returns success when request is not cancelled") {
+                var receivedError: ErrorType?
+
+                waitUntil { done in
+                    let target: GitHub = .UserProfile("ashfurrow")
+                    let token = provider.request(target) { result in
+                        if case let .Failure(error) = result {
+                            receivedError = error
+                        }
+                        done()
+                    }
+                }
+
+                expect(receivedError).to( beNil() )
+            }
         }
 
         describe("a provider with a custom endpoint resolver") {

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -183,6 +183,113 @@ class MoyaProviderSpec: QuickSpec {
             }
         }
 
+        describe("a provider with a delayed endpoint resolver") {
+            let beforeRequest: NSTimeInterval = 0.05
+            let requestTime: NSTimeInterval = 0.1
+            let beforeResponse: NSTimeInterval = 0.15
+            let responseTime: NSTimeInterval = 0.2
+            let afterResponse: NSTimeInterval = 0.3
+            var provider: MoyaProvider<GitHub>!
+
+            func delay(delay: NSTimeInterval, block: () -> ()) {
+                let killTimeOffset = Int64(CDouble(delay) * CDouble(NSEC_PER_SEC))
+                let killTime = dispatch_time(DISPATCH_TIME_NOW, killTimeOffset)
+                dispatch_after(killTime, dispatch_get_main_queue(), block)
+            }
+
+            beforeEach {
+                let endpointResolution: MoyaProvider<GitHub>.RequestClosure = { endpoint, done in
+                    delay(requestTime) {
+                        done(.Success(endpoint.urlRequest))
+                    }
+                }
+                provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.DelayedStub(responseTime))
+            }
+
+            it("returns success eventually") {
+                var receivedError: ErrorType?
+
+                waitUntil { done in
+                    let target: GitHub = .UserProfile("ashfurrow")
+                    provider.request(target) { result in
+                        if case let .Failure(error) = result {
+                            receivedError = error
+                        }
+                        done()
+                    }
+                }
+
+                expect(receivedError).to( beNil() )
+            }
+
+            it("never calls completion if cancelled immediately") {
+                var receivedError: ErrorType?
+                var calledCompletion = false
+
+                waitUntil { done in
+                    let target: GitHub = .UserProfile("ashfurrow")
+                    let token = provider.request(target) { result in
+                        calledCompletion = true
+                        if case let .Failure(error) = result {
+                            receivedError = error
+                        }
+                        done()
+                    }
+                    token.cancel()
+                    delay(afterResponse) {
+                        done()
+                    }
+                }
+
+                expect(receivedError).to( beNil() )
+                expect(calledCompletion).to( beFalse() )
+            }
+
+            it("never calls completion if cancelled before request is created") {
+                var receivedError: ErrorType?
+                var calledCompletion = false
+
+                waitUntil { done in
+                    let target: GitHub = .UserProfile("ashfurrow")
+                    let token = provider.request(target) { result in
+                        calledCompletion = true
+                        if case let .Failure(error) = result {
+                            receivedError = error
+                        }
+                        done()
+                    }
+                    delay(beforeRequest) {
+                        token.cancel()
+                    }
+                    delay(afterResponse) {
+                        done()
+                    }
+                }
+
+                expect(receivedError).to( beNil() )
+                expect(calledCompletion).to( beFalse() )
+            }
+
+            it("receives an error if request is cancelled before response comes back") {
+                var receivedError: ErrorType?
+
+                waitUntil { done in
+                    let target: GitHub = .UserProfile("ashfurrow")
+                    let token = provider.request(target) { result in
+                        if case let .Failure(error) = result {
+                            receivedError = error
+                        }
+                        done()
+                    }
+                    delay(beforeResponse) {
+                        token.cancel()
+                    }
+                }
+
+                expect(receivedError).toNot( beNil() )
+            }
+        }
+
         describe("a provider with a custom endpoint resolver") {
             var provider: MoyaProvider<GitHub>!
             var executed = false

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -382,7 +382,7 @@ class MoyaProviderSpec: QuickSpec {
                     }
                     expect(provider.inflightRequests.count).to(equal(1))
                 }
-                let request2:CancellableWrapper = provider.request(target) { result in
+                let request2: CancellableWrapper = provider.request(target) { result in
                     expect(receivedResponse).toNot(beNil())
                     if case let .Success(response) = result {
                         expect(receivedResponse).to(beIndenticalToResponse(response))
@@ -390,8 +390,6 @@ class MoyaProviderSpec: QuickSpec {
                     expect(provider.inflightRequests.count).to(equal(1))
                 } as! CancellableWrapper
 
-                expect(request2.innerCancellable).toEventually( beNil())
-                
                 // Allow for network request to complete
                 expect(provider.inflightRequests.count).toEventually( equal(0))
                 

--- a/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
@@ -50,6 +50,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
         describe("a subsclassed reactive provider that tracks cancellation with delayed stubs") {
             struct TestCancellable: Cancellable {
                 static var cancelled = false
+                var cancelled: Bool { return TestCancellable.cancelled }
 
                 func cancel() {
                     TestCancellable.cancelled = true
@@ -132,6 +133,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             describe("a subsclassed reactive provider that tracks cancellation with delayed stubs") {
                 struct TestCancellable: Cancellable {
                     static var cancelled = false
+                    var cancelled: Bool { return TestCancellable.cancelled }
                     
                     func cancel() {
                         TestCancellable.cancelled = true

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -13,15 +13,15 @@ extension Request: RequestType { }
 public final class CancellableToken: Cancellable, CustomDebugStringConvertible {
     let cancelAction: () -> Void
     let request: Request?
-    private(set) public var canceled: Bool = false
+    private(set) public var cancelled: Bool = false
 
     private var lock: dispatch_semaphore_t = dispatch_semaphore_create(1)
 
     public func cancel() {
         dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER)
         defer { dispatch_semaphore_signal(lock) }
-        guard !canceled else { return }
-        canceled = true
+        guard !cancelled else { return }
+        cancelled = true
         cancelAction()
     }
 

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -13,7 +13,7 @@ extension Request: RequestType { }
 public final class CancellableToken: Cancellable, CustomDebugStringConvertible {
     let cancelAction: () -> Void
     let request: Request?
-    private(set) var canceled: Bool = false
+    private(set) public var canceled: Bool = false
 
     private var lock: dispatch_semaphore_t = dispatch_semaphore_create(1)
 

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -60,7 +60,7 @@ public enum StructTarget: TargetType {
 
 /// Protocol to define the opaque type returned from a request
 public protocol Cancellable {
-    var canceled: Bool { get }
+    var cancelled: Bool { get }
     func cancel()
 }
 
@@ -137,7 +137,7 @@ public class MoyaProvider<Target: TargetType> {
 
 
         let performNetworking = { (requestResult: Result<NSURLRequest, Moya.Error>) in
-            if cancellableToken.canceled { return }
+            if cancellableToken.cancelled { return }
 
             var request: NSURLRequest!
 
@@ -282,7 +282,7 @@ internal extension MoyaProvider {
     /// Creates a function which, when called, executes the appropriate stubbing behavior for the given parameters.
     internal final func createStubFunction(token: CancellableToken, forTarget target: Target, withCompletion completion: Moya.Completion, endpoint: Endpoint<Target>, plugins: [PluginType]) -> (() -> ()) {
         return {
-            if token.canceled {
+            if token.cancelled {
                 let error = Moya.Error.Underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
                 plugins.forEach { $0.didReceiveResponse(.Failure(error), target: target) }
                 completion(result: .Failure(error))
@@ -327,7 +327,7 @@ public func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?,
 internal class CancellableWrapper: Cancellable {
     internal var innerCancellable: Cancellable = SimpleCancellable()
 
-    var canceled: Bool { return innerCancellable.canceled ?? false }
+    var cancelled: Bool { return innerCancellable.cancelled ?? false }
 
     internal func cancel() {
         innerCancellable.cancel()
@@ -335,8 +335,8 @@ internal class CancellableWrapper: Cancellable {
 }
 
 internal class SimpleCancellable: Cancellable {
-    var canceled = false
+    var cancelled = false
     func cancel() {
-        canceled = true
+        cancelled = true
     }
 }


### PR DESCRIPTION
Unless I'm reading this code incorrectly, there are times when calling `cancel()` on the `cancellableToken` will have no effect.

1. Assigning `innerCancellable` to a property of a struct should have no effect once `cancellableToken` is returned to the caller.  The reason it "works" so far, is because `performNetworking` is *usually* called synchronously.
2. The `isCancelled` property on `CancellableWrapper` always returns `false`, so the request would always be sent, *even if* we fixed (1)

To address these issues:

1. Make `CancellableWrapper` a class, so that assigning `innerCancellable` asynchronously in `performNetworking` will have the desired effect.
2. Rename `isCancelled` to `canceled` for consistency w/ `Cancellable / CancellableToken`
3. Assign a default value to `innerCancellable` that keeps track of `canceled`, so that requests can be aborted before they are sent.