### PR TITLE
Changes changelog Danger error to warning

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -12,7 +12,7 @@ warn("Big PR") if lines_of_code > 500
 fail("fit left in tests") if `grep -r "fit Demo/Tests/ `.length > 1
 
 # Changelog entries are 
-fail("No Changelog entries made") if !modified_files.include?("Changelog.md") && !declared_trivial
+warn("No Changelog entries made") if !modified_files.include?("Changelog.md") && !declared_trivial
 
 # Run SwiftLint
 swiftlint.lint_files


### PR DESCRIPTION
PR authors should be reminded of changelog entries, but missing entries shouldn't fail the CI build.