### PR TITLE
Refactors and consistency (sending requests, canceling requests, and progress)

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		5E1B4EA21D146CDB007F9C4B /* Community.md in Sources */ = {isa = PBXBuildFile; fileRef = 5E1B4EA11D146CDB007F9C4B /* Community.md */; };
 		0E0D2E00A181E393B2E47B4D /* Pods_MoyaTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6595C3F3DB028ABB25108C2 /* Pods_MoyaTests_tvOS.framework */; };
 		1D2B50BF1D2ED44400F6CE90 /* GiphyAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2B50BE1D2ED44400F6CE90 /* GiphyAPI.swift */; };
+		1DC29BB21D3694B10041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
+		1DC29BB31D3694B10041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
+		1DC29BB41D3694B20041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
 		36CED1FF03F2BD97EFDFCC07 /* Pods_MoyaTests_Mac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8A2ED7FAC502C9DEFF05137 /* Pods_MoyaTests_Mac.framework */; };
 		5EC197E61A1BB16D00F4DFD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E51A1BB16D00F4DFD4 /* AppDelegate.swift */; };
 		5EC197E81A1BB16D00F4DFD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E71A1BB16D00F4DFD4 /* ViewController.swift */; };
@@ -92,6 +95,7 @@
 		2A8DC8111FB71E677393A238 /* Pods-Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		35B6A4A9827E42A94C22DCA0 /* Pods_MoyaTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoyaTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D2B50BE1D2ED44400F6CE90 /* GiphyAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GiphyAPI.swift; sourceTree = "<group>"; };
+		1DC29BB01D36949C0041B1DC /* TestPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPlugin.swift; sourceTree = "<group>"; };
 		286AAA5F0654F6F6A0CFF235 /* Pods_MoyaTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoyaTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BF06D5D3DD24C44F9301FB5 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		5E0646561BE7999C00E900DC /* Moya.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Moya.podspec; path = ../Moya.podspec; sourceTree = "<group>"; };
@@ -170,6 +174,7 @@
 				067D49721C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift */,
 				067D49731C0D3886005BBA79 /* SignalProducer+MoyaSpec.swift */,
 				067D49741C0D3886005BBA79 /* TestHelpers.swift */,
+				1DC29BB01D36949C0041B1DC /* TestPlugin.swift */,
 				067D49751C0D3886005BBA79 /* testImage.png */,
 				067D49A31C0D388E005BBA79 /* Supporting Files */,
 			);
@@ -626,6 +631,7 @@
 				067D498F1C0D3886005BBA79 /* Observable+MoyaSpec.swift in Sources */,
 				067D497A1C0D3886005BBA79 /* EndpointSpec.swift in Sources */,
 				067D499B1C0D3886005BBA79 /* SignalProducer+MoyaSpec.swift in Sources */,
+				1DC29BB31D3694B10041B1DC /* TestPlugin.swift in Sources */,
 				067D497D1C0D3886005BBA79 /* Error+MoyaSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -644,6 +650,7 @@
 				067D49901C0D3886005BBA79 /* Observable+MoyaSpec.swift in Sources */,
 				067D497B1C0D3886005BBA79 /* EndpointSpec.swift in Sources */,
 				067D499C1C0D3886005BBA79 /* SignalProducer+MoyaSpec.swift in Sources */,
+				1DC29BB41D3694B20041B1DC /* TestPlugin.swift in Sources */,
 				067D497E1C0D3886005BBA79 /* Error+MoyaSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -674,6 +681,7 @@
 				067D498E1C0D3886005BBA79 /* Observable+MoyaSpec.swift in Sources */,
 				067D49791C0D3886005BBA79 /* EndpointSpec.swift in Sources */,
 				067D499A1C0D3886005BBA79 /* SignalProducer+MoyaSpec.swift in Sources */,
+				1DC29BB21D3694B10041B1DC /* TestPlugin.swift in Sources */,
 				067D497C1C0D3886005BBA79 /* Error+MoyaSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/Tests/TestPlugin.swift
+++ b/Demo/Tests/TestPlugin.swift
@@ -1,0 +1,16 @@
+import Result
+import Moya
+
+final class TestingPlugin: PluginType {
+    var request: (RequestType, TargetType)?
+    var result: Result<Moya.Response, Moya.Error>?
+
+    func willSendRequest(request: RequestType, target: TargetType) {
+        self.request = (request, target)
+    }
+
+    func didReceiveResponse(result: Result<Moya.Response, Moya.Error>, target: TargetType) {
+        self.result = result
+    }
+    
+} 

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -2,6 +2,7 @@ import Foundation
 import Alamofire
 
 public typealias Manager = Alamofire.Manager
+internal typealias Request = Alamofire.Request
 
 /// Choice of parameter encoding.
 public typealias ParameterEncoding = Alamofire.ParameterEncoding
@@ -16,14 +17,14 @@ public typealias MultipartFormDataEncodingResult = Alamofire.Manager.MultipartFo
 extension Request: RequestType { }
 
 /// Internal token that can be used to cancel requests
-public final class CancellableToken: Cancellable, CustomDebugStringConvertible {
+internal final class CancellableToken: Cancellable, CustomDebugStringConvertible {
     let cancelAction: () -> Void
     let request: Request?
-    private(set) public var cancelled: Bool = false
+    private(set) var cancelled: Bool = false
 
     private var lock: dispatch_semaphore_t = dispatch_semaphore_create(1)
 
-    public func cancel() {
+    func cancel() {
         dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER)
         defer { dispatch_semaphore_signal(lock) }
         guard !cancelled else { return }
@@ -43,7 +44,7 @@ public final class CancellableToken: Cancellable, CustomDebugStringConvertible {
         }
     }
 
-    public var debugDescription: String {
+    var debugDescription: String {
         guard let request = self.request else {
             return "Empty Request"
         }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -169,6 +169,11 @@ public class MoyaProvider<Target: TargetType> {
         return endpointClosure(token)
     }
 
+    /// Designated request-making method. Returns a Cancellable token to cancel the request later.
+    public func request(target: Target, completion: Moya.Completion) -> Cancellable {
+        return self.request(target, queue: nil, completion: completion)
+    }
+
     /// Designated request-making method with queue option. Returns a Cancellable token to cancel the request later.
     public func request(target: Target, queue: dispatch_queue_t?, progress: Moya.ProgressBlock? = nil, completion: Moya.Completion) -> Cancellable {
         if target.isMultipartUpload {
@@ -306,10 +311,6 @@ public class MoyaProvider<Target: TargetType> {
         return cancellableToken
     }
 
-    /// Designated request-making method. Returns a Cancellable token to cancel the request later.
-    public func request(target: Target, completion: Moya.Completion) -> Cancellable {
-        return self.request(target, queue: nil, completion: completion)
-    }
 
     internal func cancelCompletion(completion: Moya.Completion, target: Target) {
         let error = Moya.Error.Underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))


### PR DESCRIPTION
In trying to add support for the `progress` handler to "normal" (not multipart) request, I found *lots* of repeated code.

- `if cancellableToken.cancelled { ... }` now uses `cancelCompletion` helper
- `requestNormal` and `requestMultipart` were almost identical, now they're combined
- `sendUpload` and `sendRequest` shared code that sends the alamoRequest and notifies plugins

So yeah, now it's all consistent!

No external changes to the API, all internal.