### PR TITLE
Adds Download and Upload Task type support to Moya

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Next
 
+
+- **Breaking Change** Removes "multipartBody" from TargetType protocol and adds a "task" instead
+- **Breaking Change** Successful Responses that have no data with them are now being converted to .Success Results
+- Adds Download and Upload Task type support to Moya
+
 # 7.0.0
 
 - **Breaking Change** Drops support for `RACSignal`.

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		1DC29BB31D3694B10041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
 		1DC29BB41D3694B20041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
 		36CED1FF03F2BD97EFDFCC07 /* Pods_MoyaTests_Mac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A8A2ED7FAC502C9DEFF05137 /* Pods_MoyaTests_Mac.framework */; };
+		3A6F19A81D3B88530087A1D5 /* GitHubUserContentAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6F19A71D3B88530087A1D5 /* GitHubUserContentAPI.swift */; };
 		5EC197E61A1BB16D00F4DFD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E51A1BB16D00F4DFD4 /* AppDelegate.swift */; };
 		5EC197E81A1BB16D00F4DFD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E71A1BB16D00F4DFD4 /* ViewController.swift */; };
 		5EC197ED1A1BB16D00F4DFD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5EC197EB1A1BB16D00F4DFD4 /* Main.storyboard */; };
@@ -97,6 +98,7 @@
 		1D2B50BE1D2ED44400F6CE90 /* GiphyAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GiphyAPI.swift; sourceTree = "<group>"; };
 		1DC29BB01D36949C0041B1DC /* TestPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPlugin.swift; sourceTree = "<group>"; };
 		286AAA5F0654F6F6A0CFF235 /* Pods_MoyaTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoyaTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3A6F19A71D3B88530087A1D5 /* GitHubUserContentAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubUserContentAPI.swift; sourceTree = "<group>"; };
 		4BF06D5D3DD24C44F9301FB5 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		5E0646561BE7999C00E900DC /* Moya.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Moya.podspec; path = ../Moya.podspec; sourceTree = "<group>"; };
 		5E0646571BE799C500E900DC /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = License.md; path = ../License.md; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 			children = (
 				5EC198071A1BB24600F4DFD4 /* GitHubAPI.swift */,
 				1D2B50BE1D2ED44400F6CE90 /* GiphyAPI.swift */,
+				3A6F19A71D3B88530087A1D5 /* GitHubUserContentAPI.swift */,
 				5EC197E51A1BB16D00F4DFD4 /* AppDelegate.swift */,
 				5EC197E71A1BB16D00F4DFD4 /* ViewController.swift */,
 				5EC197EB1A1BB16D00F4DFD4 /* Main.storyboard */,
@@ -660,6 +663,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5E1B4EA21D146CDB007F9C4B /* Community.md in Sources */,
+				3A6F19A81D3B88530087A1D5 /* GitHubUserContentAPI.swift in Sources */,
 				5EC197E81A1BB16D00F4DFD4 /* ViewController.swift in Sources */,
 				5EC197E61A1BB16D00F4DFD4 /* AppDelegate.swift in Sources */,
 				5EC198081A1BB24600F4DFD4 /* GitHubAPI.swift in Sources */,

--- a/Demo/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Demo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="9fE-rm-iIL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="9fE-rm-iIL">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -26,7 +26,7 @@
                                             <rect key="frame" x="15" y="0.0" width="570" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -48,6 +48,11 @@
                             <barButtonItem title="Giphy" id="O45-Iq-njJ">
                                 <connections>
                                     <action selector="giphyWasPressed:" destination="iag-78-iuI" id="fNG-cI-scK"/>
+                                </connections>
+                            </barButtonItem>
+                            <barButtonItem title="Download" id="ofd-BP-GkV">
+                                <connections>
+                                    <action selector="downloadWasPressed:" destination="iag-78-iuI" id="xo5-T3-yJG"/>
                                 </connections>
                             </barButtonItem>
                         </leftBarButtonItems>

--- a/Demo/Demo/GiphyAPI.swift
+++ b/Demo/Demo/GiphyAPI.swift
@@ -27,10 +27,10 @@ extension Giphy: TargetType {
             return ["api_key": "dc6zaTOxFJmzC", "username": "Moya"]
         }
     }
-    public var multipartBody: [MultipartFormData]? {
+    public var task: Task {
         switch self {
         case let .Upload(data):
-            return [MultipartFormData(provider: .Data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]
+            return .Upload(.Multipart([MultipartFormData(provider: .Data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]))
         }
     }
     public var sampleData: NSData {

--- a/Demo/Demo/GitHubAPI.swift
+++ b/Demo/Demo/GitHubAPI.swift
@@ -52,8 +52,8 @@ extension GitHub: TargetType {
             return nil
         }
     }
-    public var multipartBody: [MultipartFormData]? {
-        return nil
+    public var task: Task {
+        return .Request
     }
     public var sampleData: NSData {
         switch self {

--- a/Demo/Demo/GitHubUserContentAPI.swift
+++ b/Demo/Demo/GitHubUserContentAPI.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Moya
+
+let GitHubUserContentProvider = MoyaProvider<GitHubUserContent>(plugins: [NetworkLoggerPlugin(verbose: true)])
+
+public enum GitHubUserContent {
+    case DownloadMoyaWebContent(String)
+}
+
+extension GitHubUserContent: TargetType {
+    public var baseURL: NSURL { return NSURL(string: "https://raw.githubusercontent.com")! }
+    public var path: String {
+        switch self {
+        case .DownloadMoyaWebContent(let contentPath):
+            return "/Moya/Moya/master/web/\(contentPath)"
+        }
+    }
+    public var method: Moya.Method {
+        switch self {
+        case .DownloadMoyaWebContent:
+            return .GET
+        }
+    }
+    public var parameters: [String: AnyObject]? {
+        switch self {
+        case .DownloadMoyaWebContent:
+            return nil
+        }
+    }
+    public var task: Task {
+        switch self {
+        case .DownloadMoyaWebContent:
+            return .Download(.Request(DefaultDownloadDestination))
+        }
+    }
+    public var sampleData: NSData {
+        switch self {
+        case .DownloadMoyaWebContent:
+            return animatedBirdData()
+        }
+    }
+
+}
+
+private let DefaultDownloadDestination: DownloadDestination = { temporaryURL, response -> NSURL in
+    let fileManager = NSFileManager.defaultManager()
+    let directoryURLs = fileManager.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask)
+    let destination = directoryURLs[0].URLByAppendingPathComponent(response.suggestedFilename!)
+    //overwriting
+    try! fileManager.removeItemAtURL(destination)
+    return destination
+}
+

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Moya
 
 class ViewController: UITableViewController {
     var progressView = UIView()
@@ -63,33 +64,50 @@ class ViewController: UITableViewController {
         let data = animatedBirdData()
         GiphyProvider.request(.Upload(gif: data),
             queue: dispatch_get_main_queue(),
-            progress: { response in
-                UIView.animateWithDuration(0.3) {
-                    self.progressView.frame.size.width = self.view.frame.size.width * CGFloat(response.progress)
-                }
-            },
-            completion: { result in
-                let color: UIColor
-                switch result {
-                case .Success:
-                    color = .greenColor()
-                case .Failure:
-                    color = .redColor()
-            }
-                
-            UIView.animateWithDuration(0.3) {
-                self.progressView.backgroundColor = color
-                self.progressView.frame.size.width = self.view.frame.size.width
-            }
-
-            UIView.animateWithDuration(0.3, delay: 1, options: [], animations: {
+            progress: progressClosure,
+            completion: progressCompletionClosure)
+    }
+    
+    func downloadMoyaLogo() {
+        GitHubUserContentProvider.request(.DownloadMoyaWebContent("moya_logo_github.png"),
+        queue: dispatch_get_main_queue(),
+        progress: progressClosure,
+        completion: progressCompletionClosure)
+    }
+    
+    // MARK: - Progress Helpers
+    
+    lazy var progressClosure: ProgressBlock = { response in
+        UIView.animateWithDuration(0.3) {
+            self.progressView.frame.size.width = self.view.frame.size.width * CGFloat(response.progress)
+        }
+    }
+    
+    lazy var progressCompletionClosure: Completion = { result in
+        let color: UIColor
+        switch result {
+        case .Success:
+            color = .greenColor()
+        case .Failure:
+            color = .redColor()
+        }
+        
+        UIView.animateWithDuration(0.3) {
+            self.progressView.backgroundColor = color
+            self.progressView.frame.size.width = self.view.frame.size.width
+        }
+        
+        UIView.animateWithDuration(0.3, delay: 1, options: [],
+            animations: {
                 self.progressView.alpha = 0
-            }, completion: { _ in
+            },
+            completion: { _ in
                 self.progressView.backgroundColor = .blueColor()
                 self.progressView.frame.size.width = 0
                 self.progressView.alpha = 1
-            })
-        })
+            }
+        )
+        
     }
 
     // MARK: - User Interaction
@@ -118,6 +136,10 @@ class ViewController: UITableViewController {
         downloadZen()
     }
 
+    @IBAction func downloadWasPressed(sender: UIBarButtonItem) {
+        downloadMoyaLogo()
+    }
+    
     // MARK: - Table View
 
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -419,7 +419,7 @@ class MoyaProviderSpec: QuickSpec {
                 var path = "/endpoint"
                 var method = Moya.Method.GET
                 var parameters: [String: AnyObject]? = ["key": "value"]
-                var multipartBody: [Moya.MultipartFormData]? = []
+                var task: Task = .Request
                 var sampleData = ("sample data" as NSString).dataUsingEncoding(NSUTF8StringEncoding)!
             }
 

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -31,8 +31,8 @@ extension GitHub: TargetType {
         return nil
     }
     
-    var multipartBody: [MultipartFormData]? {
-        return nil
+    var task: Task {
+        return .Request
     }
     
     var sampleData: NSData {
@@ -76,8 +76,8 @@ enum HTTPBin: TargetType {
         }
     }
     
-    var multipartBody: [MultipartFormData]? {
-        return nil
+    var task: Task {
+        return .Request
     }
     
     var sampleData: NSData {

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -12,6 +12,7 @@ public typealias RequestMultipartFormData = Alamofire.MultipartFormData
 
 /// Multipart form data encoding result.
 public typealias MultipartFormDataEncodingResult = Alamofire.Manager.MultipartFormDataEncodingResult
+public typealias DownloadDestination = Alamofire.Request.DownloadFileDestination
 
 /// Make the Alamofire Request type conform to our type, to prevent leaking Alamofire to plugins.
 extension Request: RequestType { }


### PR DESCRIPTION
- Adds Download.Request Download type
- Adds Upload.File Upload type
- Puts Multipart Upload type in UploadType enum
- Removes "**multipartBody**" from TargetType protocol and adds a "**task**" instead
- Adds new provider and and a button to Demo app to demonstrate download
- An _Alamofire_ response is now considered _Successful_ even if doesn't have any data with it and we return a _Moya_ response from it using an empty _NSData_ when converting