### PR TITLE
Update dangerfile to use scoped syntax

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,10 +1,10 @@
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-not_declared_trivial = !(pr_title.include? "#trivial")
+not_declared_trivial = !(github.pr_title.include? "#trivial")
 has_app_changes = !git.modified_files.grep(/Source/).empty?
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 
 # Warn when there is a big PR
 warn("Big PR") if lines_of_code > 500
@@ -13,7 +13,7 @@ warn("Big PR") if lines_of_code > 500
 fail("fit left in tests") if `grep -r "fit Demo/Tests/ `.length > 1
 
 # Changelog entries are required for changes to library files.
-no_changelog_entry = !modified_files.include?("Changelog.md")
+no_changelog_entry = !git.modified_files.include?("Changelog.md")
 if has_app_changes && no_changelog_entry && not_declared_trivial
   fail("Any changes to library code need a summary in the Changelog.")
 end


### PR DESCRIPTION
This has been in a few builds, but support for unscoped vars is going away soon.