### PR TITLE
Modifies mapJSON to take optional failsOnEmptyData parameter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Adds Download and Upload Task type support to Moya.
 - Corrects SwiftLint warnings.
 - Separates `Moya.swift` into multiple files.
+- Updated `mapJSON` API to include an optional named parameter `failsOnEmptyData:` that when overriden returns an empty `NSNull()` result instead of throwing an error when the response data is empty.
 
 # 7.0.0
 

--- a/Demo/Tests/ErrorTests.swift
+++ b/Demo/Tests/ErrorTests.swift
@@ -52,6 +52,32 @@ class ErrorTests: QuickSpec {
             }
         }
 
+        describe("mapping a result with empty data") {
+            let response = Response(statusCode: 200, data: NSData())
+
+            it("fails on mapJSON with default parameter") {
+                var succeeded = false
+                do {
+                    let _ = try response.mapJSON()
+                } catch {
+                    succeeded = true
+                }
+
+                expect(succeeded).to(beTruthy())
+            }
+
+            it("returns default non-nil value on mapJSON with overridden parameter") {
+                var succeeded = true
+                do {
+                    let _ = try response.mapJSON(failsOnEmptyData: false)
+                } catch {
+                    succeeded = false
+                }
+
+                expect(succeeded).to(beTruthy())
+            }
+        }
+
         describe("Alamofire responses should return the errors where appropriate") {
             it("should return the underlying error in spite of having a response and data") {
                 let underlyingError = NSError(domain: "", code: 0, userInfo: nil)

--- a/Demo/Tests/ErrorTests.swift
+++ b/Demo/Tests/ErrorTests.swift
@@ -56,14 +56,14 @@ class ErrorTests: QuickSpec {
             let response = Response(statusCode: 200, data: NSData())
 
             it("fails on mapJSON with default parameter") {
-                var succeeded = false
+                var mapJSONFailed = false
                 do {
                     let _ = try response.mapJSON()
                 } catch {
-                    succeeded = true
+                    mapJSONFailed = true
                 }
 
-                expect(succeeded).to(beTruthy())
+                expect(mapJSONFailed).to(beTruthy())
             }
 
             it("returns default non-nil value on mapJSON with overridden parameter") {

--- a/Source/ReactiveCocoa/SignalProducer+Moya.swift
+++ b/Source/ReactiveCocoa/SignalProducer+Moya.swift
@@ -37,9 +37,9 @@ extension SignalProducerType where Value == Response, Error == Moya.Error {
     }
 
     /// Maps data received from the signal into a JSON object. If the conversion fails, the signal errors.
-    public func mapJSON() -> SignalProducer<AnyObject, Error> {
+    public func mapJSON(failsOnEmptyData failsOnEmptyData: Bool = true) -> SignalProducer<AnyObject, Error> {
         return producer.flatMap(.Latest) { response -> SignalProducer<AnyObject, Error> in
-            return unwrapThrowable { try response.mapJSON() }
+            return unwrapThrowable { try response.mapJSON(failsOnEmptyData: failsOnEmptyData) }
         }
     }
 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -57,10 +57,13 @@ public extension Response {
     }
 
     /// Maps data received from the signal into a JSON object.
-    func mapJSON() throws -> AnyObject {
+    func mapJSON(failsOnEmptyData failsOnEmptyData: Bool = true) throws -> AnyObject {
         do {
             return try NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments)
         } catch {
+            if data.length < 1 && !failsOnEmptyData {
+                return NSNull()
+            }
             throw Error.Underlying(error as NSError)
         }
     }

--- a/Source/RxSwift/Observable+Moya.swift
+++ b/Source/RxSwift/Observable+Moya.swift
@@ -37,9 +37,9 @@ extension ObservableType where E == Response {
     }
 
     /// Maps data received from the signal into a JSON object. If the conversion fails, the signal errors.
-    public func mapJSON() -> Observable<AnyObject> {
+    public func mapJSON(failsOnEmptyData failsOnEmptyData: Bool = true) -> Observable<AnyObject> {
         return flatMap { response -> Observable<AnyObject> in
-            return Observable.just(try response.mapJSON())
+            return Observable.just(try response.mapJSON(failsOnEmptyData: failsOnEmptyData))
         }
     }
 


### PR DESCRIPTION
[Enhancement (bug? fix)] modified function `Response.mapJSON` to take an optional paramenter "failsOnEmptyData:" to give users control if they want to get an empty response or throw an error if the response data is empty.

fixes #494