### PR TITLE
Adds support for PATCH and CONNECT to upload files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@
 - Adds Download and Upload Task type support to Moya.
 - Corrects SwiftLint warnings.
 - Separates `Moya.swift` into multiple files.
+- Added `supportsMultipart` to the `Method` type, which helps determine whether to use `multipart/form-data` encoding.
+- Added `PATCH` and `CONNECT` to the `Method` cases which support multipart encoding.
 
 # 7.0.0
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -45,6 +45,9 @@
 		067D49A21C0D3886005BBA79 /* testImage.png in Resources */ = {isa = PBXBuildFile; fileRef = 067D49751C0D3886005BBA79 /* testImage.png */; };
 		0E0D2E00A181E393B2E47B4D /* Pods_MoyaTests_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6595C3F3DB028ABB25108C2 /* Pods_MoyaTests_tvOS.framework */; };
 		1D2B50BF1D2ED44400F6CE90 /* GiphyAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2B50BE1D2ED44400F6CE90 /* GiphyAPI.swift */; };
+		1D9CF9A81D4BD593004A95B7 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9CF9A61D4BD4A3004A95B7 /* MethodSpec.swift */; };
+		1D9CF9A91D4BD594004A95B7 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9CF9A61D4BD4A3004A95B7 /* MethodSpec.swift */; };
+		1D9CF9AA1D4BD594004A95B7 /* MethodSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9CF9A61D4BD4A3004A95B7 /* MethodSpec.swift */; };
 		1DC29BB21D3694B10041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
 		1DC29BB31D3694B10041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
 		1DC29BB41D3694B20041B1DC /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC29BB01D36949C0041B1DC /* TestPlugin.swift */; };
@@ -88,6 +91,7 @@
 		067D49741C0D3886005BBA79 /* TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		067D49751C0D3886005BBA79 /* testImage.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testImage.png; sourceTree = "<group>"; };
 		1D2B50BE1D2ED44400F6CE90 /* GiphyAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GiphyAPI.swift; sourceTree = "<group>"; };
+		1D9CF9A61D4BD4A3004A95B7 /* MethodSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodSpec.swift; sourceTree = "<group>"; };
 		1DC29BB01D36949C0041B1DC /* TestPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPlugin.swift; sourceTree = "<group>"; };
 		286AAA5F0654F6F6A0CFF235 /* Pods_MoyaTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoyaTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A6F19A71D3B88530087A1D5 /* GitHubUserContentAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubUserContentAPI.swift; sourceTree = "<group>"; };
@@ -160,6 +164,7 @@
 				067D49681C0D3886005BBA79 /* EndpointSpec.swift */,
 				067D49691C0D3886005BBA79 /* Error+MoyaSpec.swift */,
 				067D496A1C0D3886005BBA79 /* ErrorTests.swift */,
+				1D9CF9A61D4BD4A3004A95B7 /* MethodSpec.swift */,
 				067D496C1C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift */,
 				067D496D1C0D3886005BBA79 /* MoyaProviderSpec.swift */,
 				067D496E1C0D3886005BBA79 /* NetworkLogginPluginSpec.swift */,
@@ -618,6 +623,7 @@
 			files = (
 				067D49951C0D3886005BBA79 /* ReactiveCocoaMoyaProviderTests.swift in Sources */,
 				067D49981C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
+				1D9CF9A91D4BD594004A95B7 /* MethodSpec.swift in Sources */,
 				067D498C1C0D3886005BBA79 /* NetworkLogginPluginSpec.swift in Sources */,
 				067D49861C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift in Sources */,
 				067D49801C0D3886005BBA79 /* ErrorTests.swift in Sources */,
@@ -637,6 +643,7 @@
 			files = (
 				067D49961C0D3886005BBA79 /* ReactiveCocoaMoyaProviderTests.swift in Sources */,
 				067D49991C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
+				1D9CF9AA1D4BD594004A95B7 /* MethodSpec.swift in Sources */,
 				067D498D1C0D3886005BBA79 /* NetworkLogginPluginSpec.swift in Sources */,
 				067D49871C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift in Sources */,
 				067D49811C0D3886005BBA79 /* ErrorTests.swift in Sources */,
@@ -668,6 +675,7 @@
 			files = (
 				067D49941C0D3886005BBA79 /* ReactiveCocoaMoyaProviderTests.swift in Sources */,
 				067D49971C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
+				1D9CF9A81D4BD593004A95B7 /* MethodSpec.swift in Sources */,
 				067D498B1C0D3886005BBA79 /* NetworkLogginPluginSpec.swift in Sources */,
 				067D49851C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift in Sources */,
 				067D497F1C0D3886005BBA79 /* ErrorTests.swift in Sources */,

--- a/Demo/Tests/MethodSpec.swift
+++ b/Demo/Tests/MethodSpec.swift
@@ -1,0 +1,26 @@
+import Quick
+import Moya
+import Nimble
+
+class MethodSpec: QuickSpec {
+    override func spec() {
+        describe("supportsMultipart") {
+            let expectations: [(Moya.Method, Bool)] = [
+                (.GET, false),
+                (.POST, true),
+                (.PUT, true),
+                (.DELETE, false),
+                (.OPTIONS, false),
+                (.HEAD, false),
+                (.PATCH, true),
+                (.TRACE, false),
+                (.CONNECT, true),
+            ]
+            for (method, expected) in expectations {
+                it("\(method) should \(expected ? "" : "not") support multipart") {
+                    expect(method.supportsMultipart) == expected
+                }
+            }
+        }
+    }
+}

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -63,7 +63,7 @@ internal extension MoyaProvider {
                 case .Upload(.File(let file)):
                     cancellableToken.innerCancellable = self.sendUploadFile(target, request: request, queue: queue, file: file, progress: progress, completion: networkCompletion)
                 case .Upload(.Multipart(let multipartBody)):
-                    guard !multipartBody.isEmpty && (target.method == .POST || target.method == .PUT) else {
+                    guard !multipartBody.isEmpty && target.method.supportsMultipart else {
                         fatalError("\(target) is not a multipart upload target.")
                     }
                     cancellableToken.innerCancellable = self.sendUploadMultipart(target, request: request, queue: queue, multipartBody: multipartBody, progress: progress, completion: networkCompletion)

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -50,6 +50,18 @@ public enum StructTarget: TargetType {
 /// Represents an HTTP method.
 public enum Method: String {
     case GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH, TRACE, CONNECT
+
+    public var supportsMultipart: Bool {
+        switch self {
+        case .POST,
+             .PUT,
+             .PATCH,
+             .CONNECT:
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 public enum StubBehavior {


### PR DESCRIPTION
Uses new `supportsMultipart` property on `Method` to determine compatibility.

No breaking changes to API.
Added specs on `Method` to guarantee expected values for `supportsMultipart`.