### PR TITLE
Documentation fixes

### DIFF
--- a/docs/Examples/CustomPlugin.md
+++ b/docs/Examples/CustomPlugin.md
@@ -28,34 +28,34 @@ Then we add some functionality to the function called when a request will be sen
 
 ```swift
 func willSendRequest(request: RequestType, target: TargetType) {
-        
-        //make sure we have a URL string to display
-        guard let requestURLString = request.request?.URL?.absoluteString else { return }
-        
-        //create alert view controller with a single action
-        let alertViewController = UIAlertController(title: "Sending Request", message: requestURLString, preferredStyle: .Alert)
-        alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
-        
-        //and present using the view controller we created at initialisation
-        viewController.presentViewController(alertViewController, animated: true, completion: nil)
-    }
+    
+    //make sure we have a URL string to display
+    guard let requestURLString = request.request?.URL?.absoluteString else { return }
+    
+    //create alert view controller with a single action
+    let alertViewController = UIAlertController(title: "Sending Request", message: requestURLString, preferredStyle: .Alert)
+    alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+    
+    //and present using the view controller we created at initialisation
+    viewController.presentViewController(alertViewController, animated: true, completion: nil)
+}
 ```
 
 Finally, let's implement `didReceiveResponse` to show an alert if the result was a failure
 
 ```swift
 func didReceiveResponse(result: Result<Response, Error>, target: TargetType) {
-        
-        //only continue if result is a failure
-        guard case Result.Failure(_) = result else { return }
-        
-        //create alert view controller with a single action and messing displaying status code
-        let alertViewController = UIAlertController(title: "Error", message: "Request failed with status code: \(error.response?.statusCode ?? 0)", preferredStyle: .Alert)
-        alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
-        
-        //and present using the view controller we created at initialisation
-        viewController.presentViewController(alertViewController, animated: true, completion: nil)
-    }
+    
+    //only continue if result is a failure
+    guard case Result.Failure(_) = result else { return }
+    
+    //create alert view controller with a single action and messing displaying status code
+    let alertViewController = UIAlertController(title: "Error", message: "Request failed with status code: \(error.response?.statusCode ?? 0)", preferredStyle: .Alert)
+    alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+    
+    //and present using the view controller we created at initialisation
+    viewController.presentViewController(alertViewController, animated: true, completion: nil)
+}
 ```
 
 And that's it, you now have very well informed, if slightly annoyed users.

--- a/docs/Examples/ErrorTypes.md
+++ b/docs/Examples/ErrorTypes.md
@@ -4,51 +4,44 @@ Handling different error types
 In case of an error you may need to handle it:
 
 ```swift
-    provider.request(target) { result in
-        switch result {
-        case let .Success(response):
-            // Do sg on success
-        case let .Failure(error):
-            // Handle error here
-        }
+provider.request(target) { result in
+    switch result {
+    case let .Success(response):
+        // Do sg on success
+    case let .Failure(error):
+        // Handle error here
     }
+}
 ```
 
 Or RxSwift way:
 
 ```swift
-    .doOnError{ error in
-        // Handle error here
-    }
+.doOnError { error in
+    // Handle error here
+}
 ```
 
 You can do that by a `switch` on different `cases` of `Moya.Error`. In case of an `.Underlying error` you can also get the original `NSError` and its properties, e.g. `code` to be informed about `NSURLError` types like `NSURLErrorTimedOut` or `NSURLErrorNotConnectedToInternet`
 
 ```swift
-
-        if let moyaError = error as? Moya.Error {
-            switch moyaError {
-            case .Data(let response):
-                print(response)
-                break
-            case .ImageMapping(let response):
-                print(response)
-                break
-            case .JSONMapping(let response):
-                print(response)
-                break
-            case .StatusCode(let response):
-                print(response)
-                break
-            case .StringMapping(let response):
-                print(response)
-                break
-            case .Underlying(let nsError):
-                // now can access NSError error.code or whatever
-                // e.g. NSURLErrorTimedOut or NSURLErrorNotConnectedToInternet
-                print(nsError.code)
-                print(nsError.domain)
-            }
-        }
-
+if let moyaError = error as? Moya.Error {
+    switch moyaError {
+    case .Data(let response):
+        print(response)
+    case .ImageMapping(let response):
+        print(response)
+    case .JSONMapping(let response):
+        print(response)
+    case .StatusCode(let response):
+        print(response)
+    case .StringMapping(let response):
+        print(response)
+    case .Underlying(let nsError):
+        // now can access NSError error.code or whatever
+        // e.g. NSURLErrorTimedOut or NSURLErrorNotConnectedToInternet
+        print(nsError.code)
+        print(nsError.domain)
+    }
+}
 ```

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -11,15 +11,15 @@ public enum MyService {
 extension MyService: TargetType {
 //...
 	public var parameters: [String: AnyObject]? {
-	        switch self {
-	        case .Users(let limit):
-	            var params: [String : AnyObject] = [:]
-				params["limit"] = limit
-	            return params
-	        default:
-	            return nil
-	        }
-	    }
+	    switch self {
+	    case .Users(let limit):
+	        var params: [String : AnyObject] = [:]
+	        params["limit"] = limit
+	        return params
+        default:
+            return nil
+        }
+    }
 //...
 }
 ```

--- a/docs/Examples/SubclassingProvider.md
+++ b/docs/Examples/SubclassingProvider.md
@@ -15,7 +15,7 @@ class OnlineProvider: RxMoyaProvider<MyService> {
         manager: Manager = Alamofire.Manager.sharedInstance,
         plugins: [PluginType] = []) {
             
-            super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
+        super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
     }
     
     // Request to fetch and store new XApp token if the current token is missing or expired.

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -144,7 +144,7 @@ all network activity (`NetworkLoggerPlugin`), and another for [HTTP Authenticati
 
 For example you can enable the logger plugin by simply passing `[NetworkLoggerPlugin()]` alongside the `plugins` parameter of your `Endpoint`. Note that a plugin can also be configurable, for example the already included `NetworkActivityPlugin` requires a `networkActivityClosure` parameter. The configurable plugin implementation looks like this:
 
-```
+```swift
 public final class NetworkActivityPlugin: PluginType {
     
     public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -31,16 +31,16 @@ This protocol specifies the locations of
 your API endpoints, relative to its base URL (more on that below). 
 
 ```swift
-    public var path: String {
-        switch self {
-        case .Zen:
-            return "/zen"
-        case .UserProfile(let name):
-            return "/users/\(name.URLEscapedString)"
-        case .UserRepositories(let name):
-            return "/users/\(name.URLEscapedString)/repos"
-        }
+public var path: String {
+    switch self {
+    case .Zen:
+        return "/zen"
+    case .UserProfile(let name):
+        return "/users/\(name.URLEscapedString)"
+    case .UserRepositories(let name):
+        return "/users/\(name.URLEscapedString)/repos"
     }
+}
 ```
 
 Note: we're cheating here and using a `URLEscapedString` extension on String. 
@@ -50,9 +50,9 @@ OK, cool. So now we need to have a `method` for our enum values. In our case, we
 are always using the GET HTTP method, so this is pretty easy:
 
 ```swift
-    public var method: Moya.Method {
-        return .GET
-    }
+public var method: Moya.Method {
+    return .GET
+}
 ```
 
 Nice. If some of your endpoints require POST or another method, then you can switch
@@ -63,14 +63,14 @@ Our `TargetType` is shaping up, but we're not done yet. We also need a `paramete
 computed property that returns parameters defined by the enum case. Here's an example:
 
 ```swift
-    public var parameters: [String: AnyObject]? {
-        switch self {
-        case .UserRepositories(_):
-            return ["sort": "pushed"]
-        default:
-            return nil
-        }
+public var parameters: [String: AnyObject]? {
+    switch self {
+    case .UserRepositories(_):
+        return ["sort": "pushed"]
+    default:
+        return nil
     }
+}
 ```
 
 Unlike our `path` property earlier, we don't actually care about the associated values
@@ -82,16 +82,16 @@ the `TargetType` protocol. Any target you want to hit must provide some non-nil
 for providing offline support for developers. This *should* depend on `self`. 
 
 ```swift
-    public var sampleData: NSData {
-        switch self {
-        case .Zen:
-            return "Half measures are as bad as nothing at all.".dataUsingEncoding(NSUTF8StringEncoding)!
-        case .UserProfile(let name):
-            return "{\"login\": \"\(name)\", \"id\": 100}".dataUsingEncoding(NSUTF8StringEncoding)!
-        case .UserRepositories(let name):
-            return "[{\"name\": \"Repo Name\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
-        }
+public var sampleData: NSData {
+    switch self {
+    case .Zen:
+        return "Half measures are as bad as nothing at all.".dataUsingEncoding(NSUTF8StringEncoding)!
+    case .UserProfile(let name):
+        return "{\"login\": \"\(name)\", \"id\": 100}".dataUsingEncoding(NSUTF8StringEncoding)!
+    case .UserRepositories(let name):
+        return "[{\"name\": \"Repo Name\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
     }
+}
 ```
 
 After this setup, creating our [Provider](Providers.md) is as easy as the following:


### PR DESCRIPTION
This PR mainly fixes indentation errors for the code blocks in the documentation.
I have also added the Swift syntax to a code block where it was missing, as well as removed some unnecessary `break`s in a `switch` statement.