### PR TITLE
Call appropriate Alamoefire RequestMultipartFormData append method

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- **Breaking Change** `fileName` and `mimeType` are now optional properties on a MultipartFormData object.
+- Correct Alamofire `appendBodyPart` method id called in MultipartFormData.
 - **Breaking Change** Removes `multipartBody` from TargetType protocol and adds a `task` instead.
 - **Breaking Change** Successful Response instances that have no data with them are now being converted to `.Success` `Result`s.
 - Adds Download and Upload Task type support to Moya.

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -134,11 +134,11 @@ private extension MoyaProvider {
             for bodyPart in multipartBody {
                 switch bodyPart.provider {
                 case .Data(let data):
-                    form.appendBodyPart(data: data, name: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
+                    self.append(data: data, bodyPart: bodyPart, to: form)
                 case .File(let url):
-                    form.appendBodyPart(fileURL: url, name: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
+                    self.append(fileURL: url, bodyPart: bodyPart, to: form)
                 case .Stream(let stream, let length):
-                    form.appendBodyPart(stream: stream, length: length, name: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
+                    self.append(stream: stream, length: length, bodyPart: bodyPart, to: form)
                 }
             }
 
@@ -217,6 +217,36 @@ private extension MoyaProvider {
         alamoRequest.resume()
 
         return CancellableToken(request: alamoRequest)
+    }
+}
+
+// MARK: - RequestMultipartFormData appending
+
+private extension MoyaProvider {
+    private func append(data data: NSData, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {
+        
+        if let mimeType = bodyPart.mimeType {
+            if let fileName = bodyPart.fileName {
+                form.appendBodyPart(data: data, name: bodyPart.name, fileName: fileName, mimeType: mimeType)
+            } else {
+                form.appendBodyPart(data: data, name: bodyPart.name, mimeType: mimeType)
+            }
+        } else {
+            form.appendBodyPart(data: data, name: bodyPart.name)
+        }
+    }
+    
+    private func append(fileURL url: NSURL, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {
+        if let fileName = bodyPart.fileName,
+            let mimeType = bodyPart.mimeType {
+            form.appendBodyPart(fileURL: url, name: bodyPart.name, fileName: fileName, mimeType: mimeType)
+        } else {
+            form.appendBodyPart(fileURL: url, name: bodyPart.name)
+        }
+    }
+    
+    private func append(stream stream: NSInputStream, length: UInt64, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {
+        form.appendBodyPart(stream: stream, length: length, name: bodyPart.name, fileName: bodyPart.fileName ?? "", mimeType: bodyPart.mimeType ?? "")
     }
 }
 

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -224,7 +224,6 @@ private extension MoyaProvider {
 
 private extension MoyaProvider {
     private func append(data data: NSData, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {
-        
         if let mimeType = bodyPart.mimeType {
             if let fileName = bodyPart.fileName {
                 form.appendBodyPart(data: data, name: bodyPart.name, fileName: fileName, mimeType: mimeType)
@@ -235,16 +234,13 @@ private extension MoyaProvider {
             form.appendBodyPart(data: data, name: bodyPart.name)
         }
     }
-    
     private func append(fileURL url: NSURL, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {
-        if let fileName = bodyPart.fileName,
-            let mimeType = bodyPart.mimeType {
+        if let fileName = bodyPart.fileName, mimeType = bodyPart.mimeType {
             form.appendBodyPart(fileURL: url, name: bodyPart.name, fileName: fileName, mimeType: mimeType)
         } else {
             form.appendBodyPart(fileURL: url, name: bodyPart.name)
         }
     }
-    
     private func append(stream stream: NSInputStream, length: UInt64, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {
         form.appendBodyPart(stream: stream, length: length, name: bodyPart.name, fileName: bodyPart.fileName ?? "", mimeType: bodyPart.mimeType ?? "")
     }

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -92,7 +92,7 @@ public struct MultipartFormData {
         case Stream(NSInputStream, UInt64)
     }
 
-    public init(provider: FormDataProvider, name: String, fileName: String = "", mimeType: String = "") {
+    public init(provider: FormDataProvider, name: String, fileName: String? = nil, mimeType: String? = nil) {
         self.provider = provider
         self.name = name
         self.fileName = fileName
@@ -101,6 +101,6 @@ public struct MultipartFormData {
 
     public let provider: FormDataProvider
     public let name: String
-    public let fileName: String
-    public let mimeType: String
+    public let fileName: String?
+    public let mimeType: String?
 }


### PR DESCRIPTION
MultipartFormData objects in Moya will call an AlamoFire method `appendData` to build the form for the request. The `appendBodyPart` method in AlamoFire is not overloaded with nil defaults for mimeTypes or filenames, rather it calls a different `appendBodyPart` method that never assigns them to the form. However, when adding a mimeType (even if it's an empty String) AlamoFire places the content in the "files" section of the request. JSON and String data belong in the "fields" section. This means anything added in a MultipartFormData are added to "files". 

### Fix 

- `mimeType` and `fileName` were made into optionals and the default values were set to `nil`, rather than `""`. The loop that iterates over the array of MultipartFormData will call the appropriate AlamoFire function based on the mimetype and filename. This will case a **break** when a consumer is reading the mimeType property. 
- A helper append function was crated for each data type (data, file, stream) that checks the values of the mimeType and fileName before calling the AlamoFire method. 

I brought this up in Issue #580 
