### PR TITLE
Swift 3.0 - update deployment targets to work with alamofire 4

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -13,8 +13,8 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "License.md" }
   s.author             = { "Ash Furrow" => "ash@ashfurrow.com" }
   s.social_media_url   = "http://twitter.com/ashfurrow"
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.9'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.11'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   s.source       = { :git => "https://github.com/Moya/Moya.git", :tag => s.version }


### PR DESCRIPTION
since alamofire 4 requires ios 9++ I believe we need to increase the deployment target of Moya to 9.0 as well 