### PR TITLE
Changed the type of parameters to [String: Any]

### DIFF
--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -19,7 +19,7 @@ open class Endpoint<Target> {
     open let URL: String
     open let method: Moya.Method
     open let sampleResponseClosure: SampleResponseClosure
-    open let parameters: [String: AnyObject]?
+    open let parameters: [String: Any]?
     open let parameterEncoding: Moya.ParameterEncoding
     open let httpHeaderFields: [String: String]?
 
@@ -27,7 +27,7 @@ open class Endpoint<Target> {
     public init(URL: String,
         sampleResponseClosure: @escaping SampleResponseClosure,
         method: Moya.Method = Moya.Method.GET,
-        parameters: [String: AnyObject]? = nil,
+        parameters: [String: Any]? = nil,
         parameterEncoding: Moya.ParameterEncoding = URLEncoding(),
         httpHeaderFields: [String: String]? = nil) {
 
@@ -40,7 +40,7 @@ open class Endpoint<Target> {
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added parameters.
-    open func endpointByAddingParameters(_ parameters: [String: AnyObject]) -> Endpoint<Target> {
+    open func endpointByAddingParameters(_ parameters: [String: Any]) -> Endpoint<Target> {
         return endpointByAdding(parameters: parameters)
     }
 
@@ -55,19 +55,19 @@ open class Endpoint<Target> {
     }
 
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
-    open func endpointByAdding(parameters: [String: AnyObject]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
+    open func endpointByAdding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
         let newParameters = addParameters(parameters)
         let newHTTPHeaderFields = addHTTPHeaderFields(httpHeaderFields)
         let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
         return Endpoint(URL: URL, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
     }
 
-    fileprivate func addParameters(_ parameters: [String: AnyObject]?) -> [String: AnyObject]? {
+    fileprivate func addParameters(_ parameters: [String: Any]?) -> [String: Any]? {
         guard let unwrappedParameters = parameters, unwrappedParameters.isEmpty == false else {
             return self.parameters
         }
 
-        var newParameters = self.parameters ?? [String: AnyObject]()
+        var newParameters = self.parameters ?? [String: Any]()
         unwrappedParameters.forEach { (key, value) in
             newParameters[key] = value
         }

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -247,14 +247,14 @@ private extension MoyaProvider {
 }
 
 /// Encode parameters for multipart/form-data
-private func multipartQueryComponents(_ key: String, _ value: AnyObject) -> [(String, String)] {
+private func multipartQueryComponents(_ key: String, _ value: Any) -> [(String, String)] {
     var components: [(String, String)] = []
 
-    if let dictionary = value as? [String: AnyObject] {
+    if let dictionary = value as? [String: Any] {
         for (nestedKey, value) in dictionary {
             components += multipartQueryComponents("\(key)[\(nestedKey)]", value)
         }
-    } else if let array = value as? [AnyObject] {
+    } else if let array = value as? [Any] {
         for value in array {
             components += multipartQueryComponents("\(key)[]", value)
         }

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -5,7 +5,7 @@ public protocol TargetType {
     var baseURL: URL { get }
     var path: String { get }
     var method: Moya.Method { get }
-    var parameters: [String: AnyObject]? { get }
+    var parameters: [String: Any]? { get }
     var sampleData: Data { get }
     var task: Task { get }
 }
@@ -29,7 +29,7 @@ public enum StructTarget: TargetType {
         return target.method
     }
 
-    public var parameters: [String: AnyObject]? {
+    public var parameters: [String: Any]? {
         return target.parameters
     }
 


### PR DESCRIPTION
Changed the type of parameters to `[String: Any]` instead of `[String: AnyObject]`. This matches how `Alamofire` treats parameters.

BTW, I also created a [branch](https://github.com/KelvinJin/Moya/tree/swift3) that merges the [PR](https://github.com/Moya/Moya/pull/613) so that Moya will compiles with Xcode 8 GM with Alamofire 4.0.0-beta.2. Feel free to try it out if you need Moya support now.