### PR TITLE
Fix for Alamofire deprecation of (Int64,Int64,Int64) style progress blocks and Alamofire 4.0.0 readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Carthage/Build
 Carthage/Checkouts
 Cartfile.resolved
 Demo/Pods
+.ruby-version
+.ruby-gemset

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -121,7 +121,7 @@ internal extension MoyaProvider {
 
     /// Notify all plugins that a stub is about to be performed. You must call this if overriding `stubRequest`.
     final func notifyPluginsOfImpendingStub(_ request: URLRequest, target: Target) {
-        let alamoRequest = manager.request(resource: request as URLRequestConvertible)
+        let alamoRequest = manager.request(request as URLRequestConvertible)
         plugins.forEach { $0.willSendRequest(alamoRequest, target: target) }
     }
 }
@@ -175,12 +175,12 @@ private extension MoyaProvider {
     }
 
     func sendDownloadRequest(_ target: Target, request: URLRequest, queue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
-        let alamoRequest = manager.download(resource: request, to: destination)
+        let alamoRequest = manager.download(request, to: destination)
         return self.sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
     func sendRequest(_ target: Target, request: URLRequest, queue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
-        let alamoRequest = manager.request(resource: request as URLRequestConvertible)
+        let alamoRequest = manager.request(request as URLRequestConvertible)
         return sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -203,7 +203,7 @@ private extension MoyaProvider {
         }
 
         // Perform the actual request
-        if let progress = progress {
+        if let progress = progressCompletion {
             switch progressAlamoRequest {
             case let downloadRequest as DownloadRequest:
                 if let downloadRequest = downloadRequest.downloadProgress(closure: progressClosure) as? T {

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -184,17 +184,17 @@ private extension MoyaProvider {
         return sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
-    func sendAlamofireRequest<T: Request>(_ alamoRequest: T, target: Target, queue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
+    func sendAlamofireRequest<T: Request>(_ alamoRequest: T, target: Target, queue: DispatchQueue?, progress progressCompletion: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
         // Give plugins the chance to alter the outgoing request
         let plugins = self.plugins
         plugins.forEach { $0.willSendRequest(alamoRequest, target: target) }
 
         var progressAlamoRequest = alamoRequest
-        let progressClosure: (Int64, Int64, Int64) -> Void = { (bytesWritten, totalBytesWritten, totalBytesExpected) in
+        let progressClosure: (Progress) -> Void = { (progress) in
             let sendProgress: () -> () = {
-                progress?(ProgressResponse(totalBytes: totalBytesWritten, bytesExpected: totalBytesExpected))
+                progressCompletion?(ProgressResponse(progress: progress))
             }
-
+            
             if let queue = queue {
                 queue.async(execute: sendProgress)
             } else {

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -194,7 +194,7 @@ private extension MoyaProvider {
             let sendProgress: () -> () = {
                 progressCompletion?(ProgressResponse(progress: progress))
             }
-            
+
             if let queue = queue {
                 queue.async(execute: sendProgress)
             } else {

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -9,17 +9,17 @@ public typealias ProgressBlock = (_ progress: ProgressResponse) -> Void
 
 public struct ProgressResponse {
     public let response: Response?
-    public let progressObject : Progress
-    
+    public let progressObject: Progress
+
     init(progress: Progress, response: Response? = nil) {
         self.progressObject = progress
         self.response = response
     }
-    
+
     public var progress: Double {
         return self.progressObject.fractionCompleted
     }
-    
+
     public var completed: Bool {
         return self.progressObject.fractionCompleted == 1.0 && response != nil
     }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -8,24 +8,23 @@ public typealias Completion = (_ result: Result<Moya.Response, Moya.Error>) -> (
 public typealias ProgressBlock = (_ progress: ProgressResponse) -> Void
 
 public struct ProgressResponse {
-    public let totalBytes: Int64
-    public let bytesExpected: Int64
     public let response: Response?
-
-    init(totalBytes: Int64 = 0, bytesExpected: Int64 = 0, response: Response? = nil) {
-        self.totalBytes = totalBytes
-        self.bytesExpected = bytesExpected
+    public let progressObject : Progress
+    
+    init(progress: Progress, response: Response? = nil) {
+        self.progressObject = progress
         self.response = response
     }
-
+    
     public var progress: Double {
-        return bytesExpected > 0 ? min(Double(totalBytes) / Double(bytesExpected), 1.0) : 1.0
+        return self.progressObject.fractionCompleted
     }
-
+    
     public var completed: Bool {
-        return totalBytes >= bytesExpected && response != nil
+        return self.progressObject.fractionCompleted == 1.0 && response != nil
     }
 }
+
 
 /// Request provider class. Requests should be made through this class only.
 open class MoyaProvider<Target: TargetType> {


### PR DESCRIPTION
This PR fixes the progress handlers to use Progress instead of the [now deprecated by Alamofire]-style (Int64,Int64,Int64) variant.