### PR TITLE
Update Changelog for 7.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,10 +11,13 @@
 - Added `supportsMultipart` to the `Method` type, which helps determine whether to use `multipart/form-data` encoding.
 - Added `PATCH` and `CONNECT` to the `Method` cases which support multipart encoding.
 
+# 7.0.2
+
+- Swift 2.3 support.
+
 # 7.0.1
 
-- Added support for Swift 2.3
-- Updated dependencies versions
+- Identical to 7.0.0, see [#594](https://github.com/Moya/Moya/pull/594) for an explanation.
 
 # 7.0.0
 


### PR DESCRIPTION
7.0.2's history doesn't exist in master, so I'm moving the changelog updates over manually. See #594 for details.