### PR TITLE
Test our Carthage support in CI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,3 +104,17 @@ task :release, :version do |task, args|
                    name: version,
                    body: changelog.split(/^# /)[2].strip)
 end
+
+desc 'Run a local copy of Carthage on this current directory.'
+task :carthage_test do
+  # make a folder, put a cartfile in and make it a consumer
+  # of the root dir
+
+  Dir.mkdir("carthage_test")
+  File.write(File.join("carthage_test", "Cartfile"), "git \"file://#{Dir.pwd}\"")
+  Dir.chdir "carthage_test" do
+    sh "carthage bootstrap --platform 'iOS'"
+    has_artifacts = Dir.glob("Carthage/Build/*").count > 0
+    raise("Carthage did not succedd") unless has_artifacts
+  end
+end

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ test:
     - sleep 15
   override: 
     - rake test
+    - rake carthage_test
   post: 
     - bundle exec danger
     - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
We should get the CI to keep track of our Carthage support, I debated putting this in danger but it takes a very long time to run, and when I ran it locally Xcode crashed :-/

![screen shot 2016-09-14 at 6 11 16 pm](https://cloud.githubusercontent.com/assets/49038/18531892/acab1520-7aa6-11e6-824f-0a63b47c55a2.png)
