### PR TITLE
Swift package manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Carthage
 Demo/Pods
 .ruby-version
 .ruby-gemset
+# Swift Package Manager
+.build
+Packages

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Re-add `MultiTarget` to project.
 - Adopted an SPM-compatible project structure.
 - Moved tests to Moya.xcodeproj.
+- Supported the swift package manager
 
 # 8.0.0-beta.6
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,12 @@ let package = Package(
             name: "Moya"
         ),
         Target(
+            name: "ReactiveMoya",
+            dependencies: [
+                .Target(name: "Moya")
+            ]
+        ),
+        Target(
             name: "RxMoya",
             dependencies: [
                 .Target(name: "Moya")
@@ -14,10 +20,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .Package(url: "https://github.com/AndrewSB/RxSwift", versions: Version(3, 0, 2)...Version(4, 0, 0)),
-        .Package(url: "https://github.com/Alamofire/Alamofire", versions: Version(4, 0, 0)...Version(5, 0, 0))
+        .Package(url: "https://github.com/Alamofire/Alamofire", majorVersion: 4),
+        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", "1.0.0-alpha.3"),
+        .Package(url: "https://github.com/ReactiveX/RxSwift", majorVersion: 3)
     ],
     exclude: [
         ".build",
+        "Demo",
+        "Tests"
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+import PackageDescription
+
+let package = Package(
+    name: "Moya",
+    targets: [
+        Target(
+            name: "Moya"
+        ),
+        Target(
+            name: "RxMoya",
+            dependencies: [
+                .Target(name: "Moya")
+            ]
+        )
+    ],
+    dependencies: [
+        .Package(url: "https://github.com/AndrewSB/RxSwift", versions: Version(3, 0, 2)...Version(4, 0, 0)),
+        .Package(url: "https://github.com/Alamofire/Alamofire", versions: Version(4, 0, 0)...Version(5, 0, 0))
+    ],
+    exclude: [
+        ".build",
+    ]
+)

--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,34 @@ you should use for your Swift version.
 | 2.3           | 7.0.2 - 7.0.3   |
 | 2.2           | <= 7.0.1        |
 
+### Swift Package Manager
+
+To integrate using Apple's swift package manager, add the following as a dependency to your Package.swift:
+
+```swift
+.Package(url: "https://github.com/Moya/Moya", majorVersion: 8)
+```
+
+and then specify `.Target(name: "Moya")` as a dependency of the Target in which you wish to use Moya.
+Here's an example PackageDescription:
+
+```swift
+import PackageDescription
+
+let package = Package(
+  name: "MyApp",
+  targets: [
+    Target(
+      name: "MyApp",
+      dependencies: [.Target(name: "Moya")]  
+    )
+  ],
+  dependencies: [
+    .Package(url: "https://github.com/Moya/Moya", majorVersion: 8)
+  ]
+)
+```
+
 ### CocoaPods
 
 For Moya, use the following entry in your Podfile:

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Alamofire
 
 /// These functions are default mappings to `MoyaProvider`'s properties: endpoints, requests, manager, etc.


### PR DESCRIPTION
Things we're still waiting for:

- [x] Ability to explicitly import Foundation (**pushing this off** for a future PR/release)
- [x] Ability to import libraries through dynamic/static libraries (currently spm doesn't build dependencies, it just embeds the source files in the Moya xcodeproj (**pushing this off** for a future spm release, spm doesn't support this as of now)
- [x] Merging https://github.com/Moya/Moya/pull/698, so Moya has a swift package manager compatible layout
- [x] Alamofire fixing their swift package manager installation (https://github.com/Alamofire/Alamofire/issues/1815)