### PR TITLE
Added correlated request for Moya.Response.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@
 - Updated `mapJSON` API to include an optional named parameter `failsOnEmptyData:` that when overriden returns an empty `NSNull()` result instead of throwing an error when the response data is empty.
 - Added `supportsMultipart` to the `Method` type, which helps determine whether to use `multipart/form-data` encoding.
 - Added `PATCH` and `CONNECT` to the `Method` cases which support multipart encoding.
-- Added `request` for `Rsponse`.
+- Added `request` for `Response`.
 
 # 7.0.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
 - Updated `mapJSON` API to include an optional named parameter `failsOnEmptyData:` that when overriden returns an empty `NSNull()` result instead of throwing an error when the response data is empty.
 - Added `supportsMultipart` to the `Method` type, which helps determine whether to use `multipart/form-data` encoding.
 - Added `PATCH` and `CONNECT` to the `Method` cases which support multipart encoding.
+- Added `request` for `Rsponse`.
 
 # 7.0.3
 

--- a/Demo/Tests/ErrorTests.swift
+++ b/Demo/Tests/ErrorTests.swift
@@ -9,7 +9,7 @@ class ErrorTests: QuickSpec {
         var response: Response!
 
         beforeEach {
-            response = Response(statusCode: 200, data: NSData(), response: nil)
+            response = Response(statusCode: 200, data: NSData(), request: nil, response: nil)
         }
 
         describe("response computed variable") {
@@ -81,9 +81,10 @@ class ErrorTests: QuickSpec {
         describe("Alamofire responses should return the errors where appropriate") {
             it("should return the underlying error in spite of having a response and data") {
                 let underlyingError = NSError(domain: "", code: 0, userInfo: nil)
+                let request = NSURLRequest()
                 let response = NSHTTPURLResponse()
                 let data = NSData()
-                let result = convertResponseToResult(response, data: data, error: underlyingError)
+                let result = convertResponseToResult(response, request: request, data: data, error: underlyingError)
                 switch result {
                 case let .Failure(error):
                     switch error {

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -24,7 +24,20 @@ class MoyaProviderSpec: QuickSpec {
             let sampleData = target.sampleData as NSData
             expect(message).to(equal(NSString(data: sampleData, encoding: NSUTF8StringEncoding)))
         }
-        
+
+        it("returns response with request for stubbed zen request") {
+            var request: NSURLRequest?
+
+            let target: GitHub = .Zen
+            provider.request(target) { result in
+                if case let .Success(response) = result {
+                    request = response.request
+                }
+            }
+
+            expect(request).toNot(beNil())
+        }
+
         it("returns stubbed data for user profile request") {
             var message: String?
             
@@ -46,16 +59,16 @@ class MoyaProviderSpec: QuickSpec {
             let endpoint2 = provider.endpoint(target)
             expect(endpoint1.urlRequest).to(equal(endpoint2.urlRequest))
         }
-        
+
         it("returns a cancellable object when a request is made") {
             let target: GitHub = .UserProfile("ashfurrow")
-            
+
             let cancellable: Cancellable = provider.request(target) { _ in  }
-            
+
             expect(cancellable).toNot(beNil())
-            
+
         }
-        
+
         it("uses a custom manager by default, startRequestsImmediately should be false") {
             expect(provider.manager).toNot(beNil())
             expect(provider.manager.startRequestsImmediately) == false

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -92,7 +92,7 @@ public class MoyaProvider<Target: TargetType> {
         let cancellableToken = CancellableToken { }
         notifyPluginsOfImpendingStub(request, target: target)
         let plugins = self.plugins
-        let stub: () -> () = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins)
+        let stub: () -> () = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
         switch stubBehavior {
         case .Immediate:
             stub()
@@ -130,11 +130,11 @@ public extension MoyaProvider {
     }
 }
 
-public func convertResponseToResult(response: NSHTTPURLResponse?, data: NSData?, error: NSError?) ->
+public func convertResponseToResult(response: NSHTTPURLResponse?, request: NSURLRequest?, data: NSData?, error: NSError?) ->
     Result<Moya.Response, Moya.Error> {
     switch (response, data, error) {
     case let (.Some(response), data, .None):
-        let response = Moya.Response(statusCode: response.statusCode, data: data ?? NSData(), response: response)
+        let response = Moya.Response(statusCode: response.statusCode, data: data ?? NSData(), request: request, response: response)
         return .Success(response)
     case let (_, _, .Some(error)):
         let error = Moya.Error.Underlying(error)

--- a/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -46,7 +46,7 @@ public class ReactiveCocoaMoyaProvider<Target where Target: TargetType>: MoyaPro
         let token = CancellableToken {
             dis?.dispose()
         }
-        let stub = createStubFunction(token, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins)
+        let stub = createStubFunction(token, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
 
         switch stubBehavior {
         case .Immediate:

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -3,11 +3,13 @@ import Foundation
 public final class Response: CustomDebugStringConvertible, Equatable {
     public let statusCode: Int
     public let data: NSData
+    public let request: NSURLRequest?
     public let response: NSURLResponse?
 
-    public init(statusCode: Int, data: NSData, response: NSURLResponse? = nil) {
+    public init(statusCode: Int, data: NSData, request: NSURLRequest? = nil, response: NSURLResponse? = nil) {
         self.statusCode = statusCode
         self.data = data
+        self.request = request
         self.response = response
     }
 


### PR DESCRIPTION
PR addresses issue discussed in #473. It is non-breaking change. Appropriate unit-test added to ensure that request is provided upon receiving a response.