### PR TITLE
Update Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "Alamofire/Alamofire" ~> 4.0.0
-github "ReactiveCocoa/ReactiveCocoa" "master" # waiting for a release, based on https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3172
+github "ReactiveCocoa/ReactiveSwift" "master" # waiting for a release, based on https://github.com/ReactiveCocoa/ReactiveCocoa/issues/3172
 github "ReactiveX/RxSwift" "3.0.0-beta.1"


### PR DESCRIPTION
This just changes ReactiveCocoa to ReactiveSwift. This should help Swift 3 carthage users continue to use Moya with ReactiveSwift rather than ReactiveCocoa.