### PR TITLE
Throw dedicated error type if json parsing fails

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- **Breaking Change** Throw dedicated Error.jsonMapping when ```mapJSON``` fails to parse JSON
+
 # 8.0.0-beta.1
 
 - **Breaking Change** Support for `Swift 3` in favor of `Swift 2.x`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Next
 
-- **Breaking Change** Throw dedicated Error.jsonMapping when ```mapJSON``` fails to parse JSON
+- **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON
 
 # 8.0.0-beta.1
 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -66,7 +66,7 @@ public extension Response {
             if data.count < 1 && !failsOnEmptyData {
                 return NSNull()
             }
-            throw Error.underlying(error as NSError)
+            throw Error.jsonMapping(self)
         }
     }
 


### PR DESCRIPTION
As discussed in #662 Response.mapJSON() could throw Error.jsonMapping here.
Otherwise the dedicated error type isn't used at all.