### PR TITLE
Update docs for Swift 3/Moya interface

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -12,8 +12,8 @@ itself. If you need to use HTTP auth, you can provide a `CredentialsPlugin`
 when initializing your provider.
 
 ```swift
-let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { _ -> NSURLCredential? in
-    return NSURLCredential(user: "user", password: "passwd", persistence: .None)
+let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { _ -> URLCredential? in
+    return URLCredential(user: "user", password: "passwd", persistence: .none)
   }
 ])
 ```
@@ -22,10 +22,10 @@ This specific examples shows a use of HTTP that authenticates _every_ request,
 which is usually not necessary. This might be a better idea:
 
 ```swift
-let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { target -> NSURLCredential? in
+let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { target -> URLCredential? in
     switch target {
       case .targetThatNeedsAuthentication:
-        return NSURLCredential(user: "user", password: "passwd", persistence: .None)
+        return URLCredential(user: "user", password: "passwd", persistence: .none)
       default:
         return nil
     }
@@ -47,7 +47,7 @@ itself sometimes require network requests be performed _first_, so signing
 a request for Moya is an asynchronous process. Let's see an example.
 
 ```swift
-let requestClosure = { (endpoint: Endpoint<YourAPI>, done: NSURLRequest -> Void) in
+let requestClosure = { (endpoint: Endpoint<YourAPI>, done: URLRequest -> Void) in
     let request = endpoint.urlRequest // This is the request Moya generates
     YourAwesomeOAuthProvider.signRequest(request, completion: { signedRequest in
       // The OAuth provider can make its own network calls to sign your request.

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -24,7 +24,7 @@ which is usually not necessary. This might be a better idea:
 ```swift
 let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { target -> NSURLCredential? in
     switch target {
-      case .TargetThatNeedsAuthentication:
+      case .targetThatNeedsAuthentication:
         return NSURLCredential(user: "user", password: "passwd", persistence: .None)
       default:
         return nil

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -81,7 +81,7 @@ let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
 
     // Sign all non-authenticating requests
     switch target {
-    case .Authenticate:
+    case .authenticate:
         return endpoint
     default:
         return endpoint.endpointByAddingHTTPHeaderFields(["AUTHENTICATION_TOKEN": GlobalAppStorage.authToken])

--- a/docs/Examples/ArrayAsRootContainer.md
+++ b/docs/Examples/ArrayAsRootContainer.md
@@ -9,8 +9,8 @@ in [#467](https://github.com/Moya/Moya/issues/467)):
 Define JsonArrayEncoding closure:
 
 ```swift
-let JsonArrayEncodingClosure: (URLRequestConvertible, [String:AnyObject]?) -> (NSMutableURLRequest, NSError?) = { request, data in
     var req = request.URLRequest as NSMutableURLRequest
+let JsonArrayEncodingClosure: (URLRequestConvertible, [String: Any]?) -> (URLRequest, Error?) = { request, data in
 
     do {
         let json = try NSJSONSerialization.dataWithJSONObject(data!["jsonArray"]!, options: NSJSONWritingOptions.PrettyPrinted)
@@ -25,7 +25,7 @@ let JsonArrayEncodingClosure: (URLRequestConvertible, [String:AnyObject]?) -> (N
 
 Configure target :
 ```swift
-  var parameters: [String:AnyObject]? {
+  var parameters: [String: Any]? {
         switch self {
         case .someAPI:
             return ["jsonArray": ["Yes", "What", "Abc"]]

--- a/docs/Examples/ArrayAsRootContainer.md
+++ b/docs/Examples/ArrayAsRootContainer.md
@@ -27,7 +27,7 @@ Configure target :
 ```swift
   var parameters: [String:AnyObject]? {
         switch self {
-        case .SomeAPI:
+        case .someAPI:
             return ["jsonArray": ["Yes", "What", "Abc"]]
         default:
             return nil
@@ -36,7 +36,7 @@ Configure target :
 
     var parameterEncoding: Moya.ParameterEncoding {
         switch self {
-        case .SomeAPI:
+        case .someAPI:
             return ParameterEncoding.Custom(JsonArrayEncodingClosure)
         default:
             return ParameterEncoding.JSON

--- a/docs/Examples/ArrayAsRootContainer.md
+++ b/docs/Examples/ArrayAsRootContainer.md
@@ -3,19 +3,19 @@ Use Array instead of Dictionary as JSON root container
 
 Moya is using dictionary as a root container for JSON data. But
 sometimes you will need to send JSON array as a root element instead.
-Here is solution by using `.Custom` parameter encoding (see discussion
+Here is solution by using `.custom` parameter encoding (see discussion
 in [#467](https://github.com/Moya/Moya/issues/467)):
 
 Define JsonArrayEncoding closure:
 
 ```swift
-    var req = request.URLRequest as NSMutableURLRequest
+    var req = request.URLRequest
 let JsonArrayEncodingClosure: (URLRequestConvertible, [String: Any]?) -> (URLRequest, Error?) = { request, data in
 
     do {
-        let json = try NSJSONSerialization.dataWithJSONObject(data!["jsonArray"]!, options: NSJSONWritingOptions.PrettyPrinted)
+        let json = try JSONSerialization.data(withJSONObject: data!["jsonArray"]!, options: .prettyPrinted)
         req.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
-        req.HTTPBody = json
+        req.httpBody = json
     } catch {
         return (req, nil)
     }
@@ -37,11 +37,11 @@ Configure target :
     var parameterEncoding: Moya.ParameterEncoding {
         switch self {
         case .someAPI:
-            return ParameterEncoding.Custom(JsonArrayEncodingClosure)
+            return ParameterEncoding.custom(JsonArrayEncodingClosure)
         default:
-            return ParameterEncoding.JSON
+            return ParameterEncoding.json
         }
     }
 ```
 
-This will send data as JSON array `["Yes", "What", "Abc"]` for `.SomeAPI` endpoint.
+This will send data as JSON array `["Yes", "What", "Abc"]` for `.someAPI` endpoint.

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -7,9 +7,9 @@ can include information as part of your enum. Let's look at a common example. Fi
 
 ```swift
 enum MyService {
-    case Zen
-    case ShowUser(id: Int)
-    case CreateUser(firstName: String, lastName: String)
+    case zen
+    case showUser(id: Int)
+    case createUser(firstName: String, lastName: String)
 }
 ```
 
@@ -22,41 +22,41 @@ extension MyService: TargetType {
     var baseURL: NSURL { return NSURL(string: "https://api.myservice.com")! }
     var path: String {
         switch self {
-        case .Zen:
+        case .zen:
             return "/zen"
-        case .ShowUser(let id):
+        case .showUser(let id):
             return "/users/\(id)"
-        case .CreateUser(_, _):
+        case .createUser(_, _):
             return "/users"
-        case .ShowAccounts:
+        case .showAccounts:
         	  return "/accounts"
         }
     }
     var method: Moya.Method {
         switch self {
-        case .Zen, .ShowUser, .ShowAccounts:
+        case .zen, .showUser, .showAccounts:
             return .GET
-        case .CreateUser:
+        case .createUser:
             return .POST
         }
     }
     var parameters: [String: AnyObject]? {
         switch self {
-        case .Zen, .ShowUser, .ShowAccounts:
+        case .zen, .showUser, .showAccounts:
             return nil
-        case .CreateUser(let firstName, let lastName):
+        case .createUser(let firstName, let lastName):
             return ["first_name": firstName, "last_name": lastName]
         }
     }
     var sampleData: NSData {
         switch self {
-        case .Zen:
+        case .zen:
             return "Half measures are as bad as nothing at all.".UTF8EncodedData
-        case .ShowUser(let id):
+        case .showUser(let id):
             return "{\"id\": \(id), \"first_name\": \"Harry\", \"last_name\": \"Potter\"}".UTF8EncodedData
-        case .CreateUser(let firstName, let lastName):
+        case .createUser(let firstName, let lastName):
             return "{\"id\": 100, \"first_name\": \"\(firstName)\", \"last_name\": \"\(lastName)\"}".UTF8EncodedData
-        case .ShowAccounts:
+        case .showAccounts:
             // Provided you have a file named accounts.json in your bundle.
             guard let path = NSBundle.mainBundle().pathForResource("accounts", ofType: "json"),
                       data = NSData(contentsOfFile: path) else {
@@ -90,7 +90,7 @@ Note that at this point you have added enough information for a basic API networ
 
 ```swift
 let provider = MoyaProvider<MyService>()
-provider.request(.CreateUser(firstName: "James", lastName: "Potter")) { result in
+provider.request(.createUser(firstName: "James", lastName: "Potter")) { result in
     // do something with the result (read on for more details)
 }
 
@@ -110,7 +110,7 @@ public func url(route: TargetType) -> String {
 }
 
 let endpointClosure = { (target: MyService) -> Endpoint<MyService> in
-    return Endpoint<MyService>(URL: url(target), sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
+    return Endpoint<MyService>(URL: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 }
 ```
 
@@ -131,9 +131,9 @@ whatever you want. Say you want to test network error conditions like timeouts, 
 let failureEndpointClosure = { (target: MyService) -> Endpoint<MyService> in
     let sampleResponseClosure = { () -> (EndpointSampleResponse) in
         if shouldTimeout {
-            return .NetworkError(NSError())
+            return .networkError(NSError())
         } else {
-            return .NetworkResponse(200, target.sampleData)
+            return .networkResponse(200, target.sampleData)
         }
     }
     return Endpoint<MyService>(URL: url(target), sampleResponseClosure: sampleResponseClosure, method: target.method, parameters: target.parameters)
@@ -157,12 +157,12 @@ let provider = MoyaProvider(endpointClosure: endpointClosure)
 Neato. Now how do we make a request?
 
 ```swift
-provider.request(.Zen) { result in
+provider.request(.zen) { result in
     // do something with `result`
 }
 ```
 
-The `request` method is given a `MyService` value (`.Zen`), which contains *all the
+The `request` method is given a `MyService` value (`.zen`), which contains *all the
 information necessary* to create the `Endpoint` – or to return a stubbed
 response during testing.
 
@@ -175,26 +175,26 @@ success or failure in a `Result` enum.  `result` is either
 You will need to unpack the data and status code from `Moya.Response`.
 
 ```swift
-provider.request(.Zen) { result in
+provider.request(.zen) { result in
     switch result {
-    case let .Success(moyaResponse):
+    case let .success(moyaResponse):
         let data = moyaResponse.data // NSData, your JSON response is probably in here!
         let statusCode = moyaResponse.statusCode // Int - 200, 401, 500, etc
 
         // do something in your app
-    case let .Failure(error):
+    case let .failure(error):
         // TODO: handle the error ==  best. comment. ever.
     }
 }
 ```
 
-Take special note: a `.Failure` means that the server either didn't *receive the
+Take special note: a `.failure` means that the server either didn't *receive the
 request* (e.g. reachability/connectivity error) or it didn't send a response
 (e.g. the request timed out).  If you get a `.Failure`, you probably want to
 re-send the request after a time delay or when an internet connection is
 established.
 
-Once you have a `.Success(response)` you might want to filter on status codes or
+Once you have a `.success(response)` you might want to filter on status codes or
 convert the response data to JSON. `Moya.Response` can help!
 
 ###### see more at <https://github.com/Moya/Moya/blob/master/Source/Response.swift>

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -40,7 +40,7 @@ extension MyService: TargetType {
             return .POST
         }
     }
-    var parameters: [String: AnyObject]? {
+    var parameters: [String: Any]? {
         switch self {
         case .zen, .showUser, .showAccounts:
             return nil

--- a/docs/Examples/CustomPlugin.md
+++ b/docs/Examples/CustomPlugin.md
@@ -33,11 +33,11 @@ func willSendRequest(request: RequestType, target: TargetType) {
     guard let requestURLString = request.request?.URL?.absoluteString else { return }
 
     //create alert view controller with a single action
-    let alertViewController = UIAlertController(title: "Sending Request", message: requestURLString, preferredStyle: .Alert)
-    alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+    let alertViewController = UIAlertController(title: "Sending Request", message: requestURLString, preferredStyle: .alert)
+    alertViewController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
 
     //and present using the view controller we created at initialization
-    viewController.presentViewController(alertViewController, animated: true, completion: nil)
+    viewController.present(viewControllerToPresent: alertViewController, animated: true, completion: nil)
 }
 ```
 
@@ -47,14 +47,14 @@ Finally, let's implement `didReceiveResponse` to show an alert if the result was
 func didReceiveResponse(result: Result<Response, Error>, target: TargetType) {
 
     //only continue if result is a failure
-    guard case Result.Failure(_) = result else { return }
+    guard case Result.failure(_) = result else { return }
 
     //create alert view controller with a single action and messing displaying status code
-    let alertViewController = UIAlertController(title: "Error", message: "Request failed with status code: \(error.response?.statusCode ?? 0)", preferredStyle: .Alert)
-    alertViewController.addAction(UIAlertAction(title: "OK", style: .Default, handler: nil))
+    let alertViewController = UIAlertController(title: "Error", message: "Request failed with status code: \(error.response?.statusCode ?? 0)", preferredStyle: .alert)
+    alertViewController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
 
     //and present using the view controller we created at initialization
-    viewController.presentViewController(alertViewController, animated: true, completion: nil)
+    viewController.present(viewControllerToPresent: alertViewController, animated: true, completion: nil)
 }
 ```
 

--- a/docs/Examples/CustomPlugin.md
+++ b/docs/Examples/CustomPlugin.md
@@ -30,7 +30,7 @@ Then we add some functionality to the function called when a request will be sen
 func willSendRequest(request: RequestType, target: TargetType) {
 
     //make sure we have a URL string to display
-    guard let requestURLString = request.request?.URL?.absoluteString else { return }
+    guard let requestURLString = request.request?.url?.absoluteString else { return }
 
     //create alert view controller with a single action
     let alertViewController = UIAlertController(title: "Sending Request", message: requestURLString, preferredStyle: .alert)

--- a/docs/Examples/ErrorTypes.md
+++ b/docs/Examples/ErrorTypes.md
@@ -6,9 +6,9 @@ In case of an error you may need to handle it:
 ```swift
 provider.request(target) { result in
     switch result {
-    case let .Success(response):
+    case let .success(response):
         // Do sg on success
-    case let .Failure(error):
+    case let .failure(error):
         // Handle error here
     }
 }
@@ -26,17 +26,17 @@ You can do that by a `switch` on different `cases` of `Moya.Error`. In case of a
 
 ```swift
 switch error {
-case .Data(let response):
+case .data(let response):
     print(response)
-case .ImageMapping(let response):
+case .imageMapping(let response):
     print(response)
-case .JSONMapping(let response):
+case .jsonMapping(let response):
     print(response)
-case .StatusCode(let response):
+case .statusCode(let response):
     print(response)
-case .StringMapping(let response):
+case .stringMapping(let response):
     print(response)
-case .Underlying(let nsError):
+case .underlying(let nsError):
     // now can access NSError error.code or whatever
     // e.g. NSURLErrorTimedOut or NSURLErrorNotConnectedToInternet
     print(nsError.code)

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -5,14 +5,14 @@ Suppose you want to call `api/users?limit=10` but also `api/users`:
 
 ```swift
 public enum MyService {
-	case Users(limit: Int?)
+	case users(limit: Int?)
 }
 
 extension MyService: TargetType {
 //...
 	public var parameters: [String: AnyObject]? {
 	    switch self {
-	    case .Users(let limit):
+	    case .users(let limit):
 	        var params: [String : AnyObject] = [:]
 	        params["limit"] = limit
 	        return params
@@ -33,7 +33,7 @@ extension MyService: TargetType {
 //...
     public var method: Moya.Method {
         switch self {
-        case .EmailAuth:
+        case .emailAuth:
             return .POST
         default:
             return .GET

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -10,10 +10,10 @@ public enum MyService {
 
 extension MyService: TargetType {
 //...
-	public var parameters: [String: AnyObject]? {
+	public var parameters: [String: Any]? {
 	    switch self {
 	    case .users(let limit):
-	        var params: [String : AnyObject] = [:]
+	        var params: [String : Any] = [:]
 	        params["limit"] = limit
 	        return params
         default:

--- a/docs/Examples/ReactiveCocoa.md
+++ b/docs/Examples/ReactiveCocoa.md
@@ -11,11 +11,11 @@ let GitHubProvider = ReactiveCocoaMoyaProvider<GitHub>()
 After that simple setup, you're off to the races:
 
 ```swift
-provider.request(.Zen).start { (event) -> Void in
+provider.request(.zen).start { (event) -> Void in
     switch event {
-    case .Next(let response):
+    case .next(let response):
         // do something with the data
-    case .Failed(let error):
+    case .failed(let error):
         // handle the error
     default:
         break

--- a/docs/Examples/RxSwift.md
+++ b/docs/Examples/RxSwift.md
@@ -31,10 +31,10 @@ provider.request(.allUsers)
 	.mapJSON()
     .doOn { event in
         guard case Event.next(let element) = event else { return }
-		guard let usersCount = element["usersCount"], usersArray = Mapper<User>().mapArray(element["users"]) else { return }
+        guard let usersCount = element["usersCount"], usersArray = Mapper<User>().mapArray(element["users"]) else { return }
 
         self.usersCount = usersCount
-		self.usersArray = usersArray
+        self.usersArray = usersArray
     }
     .subscribeNext { results in
         self.tableView.reloadData()
@@ -77,13 +77,13 @@ dismissed automatically.
 Usage:
 
 ```swift
-SVProgressHUD.show()			
+SVProgressHUD.show()
 MyService.request(.resetPassword(email: textField.text!))
-		    .filterSuccessfulStatusCodes()
-		    .showErrorHUD()
-		    .subscribeNext { response in
-		        SVProgressHUD.dismiss()
+        .filterSuccessfulStatusCodes()
+        .showErrorHUD()
+        .subscribeNext { response in
+          SVProgressHUD.dismiss()
 
-		        showAlert(title: "Your password has been reset.", message: "An email will be sent to you with a new password shortly.")
-		    }
+          showAlert(title: "Your password has been reset.", message: "An email will be sent to you with a new password shortly.")
+        }
 ```

--- a/docs/Examples/RxSwift.md
+++ b/docs/Examples/RxSwift.md
@@ -11,11 +11,11 @@ let GitHubProvider = RxMoyaProvider<GitHub>()
 After that simple setup, you're off to the races:
 
 ```swift
-provider.request(.Zen).subscribe { (event) -> Void in
+provider.request(.zen).subscribe { (event) -> Void in
     switch event {
-    case .Next(let response):
+    case .next(let response):
         // do something with the data
-    case .Error(let error):
+    case .error(let error):
         // handle the error
     default:
         break
@@ -26,11 +26,11 @@ provider.request(.Zen).subscribe { (event) -> Void in
 Request with filtering successful status codes, JSON parsing and model mapping (with [ObjectMapper](https://github.com/Hearst-DD/ObjectMapper)):
 
 ```swift
-provider.request(.AllUsers)
+provider.request(.allUsers)
 	.filterSuccessfulStatusCodes()
 	.mapJSON()
     .doOn { event in
-        guard case Event.Next(let element) = event else { return }
+        guard case Event.next(let element) = event else { return }
 		guard let usersCount = element["usersCount"], usersArray = Mapper<User>().mapArray(element["users"]) else { return }
 
         self.usersCount = usersCount
@@ -49,10 +49,10 @@ extension Observable {
     func showErrorHUD() -> Observable<Element> {
         return self.doOn { event in
             switch event {
-            case .Error(let e):
+            case .error(let e):
                 // Unwrap underlying error
                 guard let error = e as? Moya.Error else { throw e }
-                guard case .StatusCode(let response) = error else { throw e }
+                guard case .statusCode(let response) = error else { throw e }
 
                 // Check statusCode and handle desired errors
                 if response.statusCode == 401 {
@@ -78,7 +78,7 @@ Usage:
 
 ```swift
 SVProgressHUD.show()			
-MyService.request(.ResetPassword(email: textField.text!))
+MyService.request(.resetPassword(email: textField.text!))
 		    .filterSuccessfulStatusCodes()
 		    .showErrorHUD()
 		    .subscribeNext { response in

--- a/docs/Examples/SubclassingProvider.md
+++ b/docs/Examples/SubclassingProvider.md
@@ -12,7 +12,7 @@ class OnlineProvider: RxMoyaProvider<MyService> {
     override init(endpointClosure: MoyaProvider<MyService>.EndpointClosure = MoyaProvider.DefaultEndpointMapping,
         requestClosure: MoyaProvider<MyService>.RequestClosure = MoyaProvider.DefaultRequestMapping,
         stubClosure: MoyaProvider<MyService>.StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = Alamofire.Manager.sharedInstance,
+        manager: Manager = Alamofire.SessionManager.default,
         plugins: [PluginType] = []) {
 
         super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)

--- a/docs/Examples/WrappingInAdapter.md
+++ b/docs/Examples/WrappingInAdapter.md
@@ -18,7 +18,7 @@ struct Network {
     ) {
         provider.request(target) { result in
             switch result {
-            case let .Success(response):
+            case let .success(response):
                 do {
                     try response.filterSuccessfulStatusCodes()
                     let json = try JSON(response.mapJSON())
@@ -27,7 +27,7 @@ struct Network {
                 catch error {
                     errorCallback(error)
                 }
-            case let .Failure(error):
+            case let .failure(error):
                 if target.shouldRetry {
                     retryWhenReachable(target, successCallback, errorCallback, failureCallback)
                 }
@@ -40,7 +40,7 @@ struct Network {
 }
 
 // usage:
-Network.request(.Zen, success: { zen in
+Network.request(.zen, success: { zen in
     showMessage(zen)
 }, error: { err in
     showError(err)

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -14,7 +14,7 @@ let provider = MoyaProvider<GitHub>(plugins: [NetworkLoggerPlugin(verbose: true)
 ```
 
 ####Authentication
-The authentication plugin allows a user to assign an optional `NSURLCredential` per request. There is no action when a request is received.
+The authentication plugin allows a user to assign an optional `URLCredential` per request. There is no action when a request is received.
 
 The plugin can be found at [`Source/Plugins/CredentialsPlugin.swift`](../Source/Plugins/CredentialsPlugin.swift)
 
@@ -26,7 +26,7 @@ The plugin can be found at [`Source/Plugins/NetworkActivityPlugin.swift`](../Sou
 ####Logging
 During development it can be very useful to log network activity to the console. This can be anything from the URL of a request as sent and received, to logging full headers, method, request body on each request and response.
 
-The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initializing the plugin, you can choose options for verbosity, whether to log curl commands, and provide functions for outputting data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `NSUTF8StringEncoding` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in [`Demo/Demo/GitHubAPI.swift`](../Demo/Demo/GitHubAPI.swift) for an example that does exactly that)
+The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initializing the plugin, you can choose options for verbosity, whether to log curl commands, and provide functions for outputting data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `String.Encoding.utf8` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in [`Demo/Demo/GitHubAPI.swift`](../Demo/Demo/GitHubAPI.swift) for an example that does exactly that)
 
 The plugin can be found at [`Source/Plugins/NetworkLoggerPlugin.swift`](../Source/Plugins/NetworkLoggerPlugin.swift)
 

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -60,7 +60,7 @@ might want to customize this.
 ### requestClosure:
 
 The next optional initializer parameter is `requestClosure`, which resolves
-an `Endpoint` to an actual `NSURLRequest`. Again, check out the [Endpoints](Endpoints.md)
+an `Endpoint` to an actual `URLRequest`. Again, check out the [Endpoints](Endpoints.md)
 documentation for how and why you'd do this.
 
 ### stubClosure:
@@ -104,8 +104,8 @@ Next, there's the `manager` parameter. By default you'll get a custom `Alamofire
 
 ```swift
 public final class func DefaultAlamofireManager() -> Manager {
-    let configuration = NSURLSessionConfiguration.defaultSessionConfiguration()
-    configuration.HTTPAdditionalHeaders = Alamofire.Manager.defaultHTTPHeaders
+    let configuration = URLSessionConfiguration.default
+    configuration.httpAdditionalHeaders = Alamofire.Manager.defaultHTTPHeaders
 
     let manager = Alamofire.Manager(configuration: configuration)
     manager.startRequestsImmediately = false
@@ -128,7 +128,7 @@ let policies: [String: ServerTrustPolicy] = [
 ]
 
 let manager = Manager(
-    configuration: NSURLSessionConfiguration.defaultSessionConfiguration(),
+    configuration: URLSessionConfiguration.default,
     serverTrustPolicyManager: ServerTrustPolicyManager(policies: policies)
 )
 
@@ -162,7 +162,7 @@ public final class NetworkActivityPlugin: PluginType {
     }
 
     /// Called by the provider as soon as a response arrives
-    public func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, target: TargetType) {
+    public func didReceiveResponse(data: Data?, statusCode: Int?, response: URLResponse?, error: ErrorType?, target: TargetType) {
         networkActivityClosure(change: .ended)
     }
 }

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -13,7 +13,7 @@ let provider = MoyaProvider<MyService>()
 After that simple setup, you're off to the races:
 
 ```swift
-provider.request(.Zen) { result in
+provider.request(.zen) { result in
     // `result` is either .Success(response) or .Failure(error)
 }
 ```
@@ -43,7 +43,7 @@ concrete `Endpoint` instance. Let's take a look at what one might look like.
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = target.baseURL.URLByAppendingPathComponent(target.path).absoluteString
-    return Endpoint(URL: url, sampleResponseClosure: {.NetworkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
+    return Endpoint(URL: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 }
 let provider = MoyaProvider(endpointClosure: endpointClosure)
 ```
@@ -66,8 +66,8 @@ documentation for how and why you'd do this.
 ### stubClosure:
 
 The next option is to provide a `stubClosure`. This returns one of either `.Never` (the
-default), `.Immediate` or `.Delayed(seconds)`, where you can delay the stubbed
-request by a certain number of seconds. For example, `.Delayed(0.2)` would delay
+default), `.immediate` or `.delayed(seconds)`, where you can delay the stubbed
+request by a certain number of seconds. For example, `.delayed(0.2)` would delay
 every stubbed request. This can be good for simulating network delays in unit tests.
 
 What's nice is that if you need to stub some requests differently than others,
@@ -94,7 +94,7 @@ So, in the above example, if you wanted immediate stubbing behavior for all
 targets, either of the following would work.
 
 ```swift
-let provider = MoyaProvider<MyTarget>(stubClosure: { (_: MyTarget) -> Moya.StubBehavior in return .Immediate })
+let provider = MoyaProvider<MyTarget>(stubClosure: { (_: MyTarget) -> Moya.StubBehavior in return .immediate })
 let provider = MoyaProvider<MyTarget>(stubClosure: MoyaProvider.ImmediatelyStub)
 ```
 
@@ -158,12 +158,12 @@ public final class NetworkActivityPlugin: PluginType {
 
     /// Called by the provider as soon as the request is about to start
     public func willSendRequest(request: RequestType, target: TargetType) {
-        networkActivityClosure(change: .Began)
+        networkActivityClosure(change: .began)
     }
 
     /// Called by the provider as soon as a response arrives
     public func didReceiveResponse(data: NSData?, statusCode: Int?, response: NSURLResponse?, error: ErrorType?, target: TargetType) {
-        networkActivityClosure(change: .Ended)
+        networkActivityClosure(change: .ended)
     }
 }
 ```
@@ -171,5 +171,5 @@ public final class NetworkActivityPlugin: PluginType {
 The `networkActivityClosure` is a closure that you can provide to be notified whenever a network request begins or
 ends. This is useful for working with the [network activity indicator](https://github.com/thoughtbot/BOTNetworkActivityIndicator).
 Note that signature of this closure is `(change: NetworkActivityChangeType) -> ()`,
-so you will only be notified when a request has `.Began` or `.Ended` –
+so you will only be notified when a request has `.began` or `.ended` –
 you aren't provided any other details about the request itself.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ You _should not_ have to reference Alamofire directly. It's an _awesome_
 library, but the point of Moya is that you don't have to deal with details
 that are that low-level.
 
-(If you _need_ to use Alamofire, you can pass in a `Manager` instance to the
+(If you _need_ to use Alamofire, you can pass in a `SessionManager` instance to the
 `MoyaProvider` initializer.)
 
 If there is something you want to change about the behaviour of Moya, there is

--- a/docs/ReactiveCocoa.md
+++ b/docs/ReactiveCocoa.md
@@ -17,7 +17,7 @@ let provider = ReactiveCocoaMoyaProvider<GitHub>()
 After that simple setup, you're off to the races:
 
 ```swift
-provider.request(.Zen).start { (event) -> Void in
+provider.request(.zen).start { (event) -> Void in
     switch event {
     case .Next(let response):
         // do something with the data

--- a/docs/ReactiveCocoa.md
+++ b/docs/ReactiveCocoa.md
@@ -19,9 +19,9 @@ After that simple setup, you're off to the races:
 ```swift
 provider.request(.zen).start { (event) -> Void in
     switch event {
-    case .Next(let response):
+    case .next(let response):
         // do something with the data
-    case .Failed(let error):
+    case .failed(let error):
         // handle the error
     default:
         break
@@ -43,7 +43,7 @@ then it sends an error, instead. The error's `code` is the failing
 request's status code, if any, and the response data, if any.
 
 The `Moya.Response` class contains a `statusCode`, some `data`,
-and a(n optional) `NSURLResponse`. You can use these values however
+and a(n optional) `URLResponse`. You can use these values however
 you like in `startWithNext` or `map` calls.
 
 To make things even awesomer, Moya provides some extensions to

--- a/docs/ReactiveCocoa.md
+++ b/docs/ReactiveCocoa.md
@@ -38,7 +38,7 @@ If the request completes normally, two things happen:
 1. The signal sends a value, a `Moya.Response` instance.
 2. The signal completes.
 
-If the request produces an error (typically a NSURLSession error),
+If the request produces an error (typically a URLSession error),
 then it sends an error, instead. The error's `code` is the failing
 request's status code, if any, and the response data, if any.
 

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -37,12 +37,12 @@ If the request completes normally, two things happen:
 1. The observable sends a value, a `Moya.Response` instance.
 2. The observable completes.
 
-If the request produces an error (typically a NSURLSession error),
+If the request produces an error (typically a `URLSession` error),
 then it sends an error, instead. The error's `code` is the failing
 request's status code, if any, and the response data, if any.
 
 The `Moya.Response` class contains a `statusCode`, some `data`,
-and a(n optional) `NSURLResponse`. You can use these values however
+and a(n optional) `URLResponse`. You can use these values however
 you like in `subscribeNext` or `map` calls.
 
 To make things even awesomer, Moya provides some extensions to

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -16,11 +16,11 @@ let provider = RxMoyaProvider<GitHub>()
 After that simple setup, you're off to the races:
 
 ```swift
-provider.request(.Zen).subscribe { (event) -> Void in
+provider.request(.zen).subscribe { (event) -> Void in
     switch event {
-    case .Next(let response):
+    case .next(let response):
         // do something with the data
-    case .Error(let error):
+    case .error(let error):
         // handle the error
     default:
         break

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -25,7 +25,7 @@ providers). Here's the beginning of our extension:
 
 ```swift
 extension GitHub: TargetType {
-    public var baseURL: NSURL { return NSURL(string: "https://api.github.com")! }
+    public var baseURL: URL { return URL(string: "https://api.github.com")! }
 ```
 
 This protocol specifies the locations of
@@ -46,7 +46,7 @@ public var path: String {
 }
 ```
 
-Notice that we're ignoring the second associated value of our `Branches` Target using the Swift `_` ignored-value symbol. That's because we don't need it to define the `Branches` path.
+Notice that we're ignoring the second associated value of our `branches` Target using the Swift `_` ignored-value symbol. That's because we don't need it to define the `branches` path.
 Note: we're cheating here and using a `URLEscapedString` extension on String.
 A sample implementation is given at the end of this document.
 
@@ -84,20 +84,20 @@ Let's take a look at the `branches` case: we'll use our `Bool` associated value 
 
 Notice the `sampleData` property on the enum. This is a requirement of
 the `TargetType` protocol. Any target you want to hit must provide some non-nil
-`NSData` that represents a sample response. This can be used later for tests or
+`Data` that represents a sample response. This can be used later for tests or
 for providing offline support for developers. This *should* depend on `self`.
 
 ```swift
-public var sampleData: NSData {
+public var sampleData: Data {
     switch self {
     case .zen:
-        return "Half measures are as bad as nothing at all.".dataUsingEncoding(NSUTF8StringEncoding)!
+        return "Half measures are as bad as nothing at all.".data(using: String.Encoding.utf8)!
     case .userProfile(let name):
-        return "{\"login\": \"\(name)\", \"id\": 100}".dataUsingEncoding(NSUTF8StringEncoding)!
+        return "{\"login\": \"\(name)\", \"id\": 100}".data(using: String.Encoding.utf8)!
     case .userRepositories(let name):
-        return "[{\"name\": \"Repo Name\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
+        return "[{\"name\": \"Repo Name\"}]".data(using: String.Encoding.utf8)!
     case .branches:
-        return "[{\"name\": \"master\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
+        return "[{\"name\": \"master\"}]".data(using: String.Encoding.utf8)!
     }
 }
 ```

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -67,7 +67,7 @@ Our `TargetType` is shaping up, but we're not done yet. We also need a `paramete
 computed property that returns parameters defined by the enum case. Here's an example:
 
 ```swift
-public var parameters: [String: AnyObject]? {
+public var parameters: [String: Any]? {
     switch self {
     case .userRepositories(_):
         return ["sort": "pushed"]

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -127,8 +127,8 @@ Here's an example extension that allows you to easily escape normal strings
 
 ```swift
 extension String {
-    var URLEscapedString: String {
-        return self.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLHostAllowedCharacterSet())!
+    var urlEscapedString: String {
+        return self.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
     }
 }
 ```

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -4,16 +4,16 @@ Targets
 Using Moya starts with defining a target – typically some `enum` that conforms
 to the `TargetType` protocol. Then, the rest of your app deals *only* with
 those targets. Targets are some action that you want to take on the API,
-like "`FavoriteTweet(tweetID: String)`".
+like "`favoriteTweet(tweetID: String)`".
 
 Here's an example:
 
 ```swift
 public enum GitHub {
-    case Zen
-    case UserProfile(String)
-    case UserRepositories(String)
-    case Branches(String, Bool)
+    case zen
+    case userProfile(String)
+    case userRepositories(String)
+    case branches(String, Bool)
 }
 ```
 
@@ -34,13 +34,13 @@ your API endpoints, relative to its base URL (more on that below).
 ```swift
 public var path: String {
     switch self {
-    case .Zen:
+    case .zen:
         return "/zen"
-    case .UserProfile(let name):
+    case .userProfile(let name):
         return "/users/\(name.URLEscapedString)"
-    case .UserRepositories(let name):
+    case .userRepositories(let name):
         return "/users/\(name.URLEscapedString)/repos"
-    case .Branches(let repo, _)
+    case .branches(let repo, _)
         return "/repos/\(repo.URLEscapedString)/branches"
     }
 }
@@ -69,9 +69,9 @@ computed property that returns parameters defined by the enum case. Here's an ex
 ```swift
 public var parameters: [String: AnyObject]? {
     switch self {
-    case .UserRepositories(_):
+    case .userRepositories(_):
         return ["sort": "pushed"]
-    case .Branches(_, let protected):
+    case .branches(_, let protected):
         return ["protected": "\(protected)"]
     default:
         return nil
@@ -79,8 +79,8 @@ public var parameters: [String: AnyObject]? {
 }
 ```
 
-Unlike our `path` property earlier, we don't actually care about the associated values of our `UserRepositories` case, so we use the Swift `_` ignored-value symbol.
-Let's take a look at the `Branches` case: we'll use our `Bool` associated value (`protected`) as a request parameter by assigning it to the `"protected"` key. We're parsing our `Bool` value to `String`. (Alamofire does not encode `Bool` parameters automatically, so we need to do it by our own).
+Unlike our `path` property earlier, we don't actually care about the associated values of our `userRepositories` case, so we use the Swift `_` ignored-value symbol.
+Let's take a look at the `branches` case: we'll use our `Bool` associated value (`protected`) as a request parameter by assigning it to the `"protected"` key. We're parsing our `Bool` value to `String`. (Alamofire does not encode `Bool` parameters automatically, so we need to do it by our own).
 
 Notice the `sampleData` property on the enum. This is a requirement of
 the `TargetType` protocol. Any target you want to hit must provide some non-nil
@@ -90,13 +90,13 @@ for providing offline support for developers. This *should* depend on `self`.
 ```swift
 public var sampleData: NSData {
     switch self {
-    case .Zen:
+    case .zen:
         return "Half measures are as bad as nothing at all.".dataUsingEncoding(NSUTF8StringEncoding)!
-    case .UserProfile(let name):
+    case .userProfile(let name):
         return "{\"login\": \"\(name)\", \"id\": 100}".dataUsingEncoding(NSUTF8StringEncoding)!
-    case .UserRepositories(let name):
+    case .userRepositories(let name):
         return "[{\"name\": \"Repo Name\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
-    case .Branches:
+    case .branches:
         return "[{\"name\": \"master\"}]".dataUsingEncoding(NSUTF8StringEncoding)!
     }
 }


### PR DESCRIPTION
Currently a WIP to gauge interest. Updates docs to reflect the new Swift 3 interface as well as Moya's interface.

- [x] Update enum usage
- [x] Match Swift 3 interface changes (e.g. NSURLSession -> URLSession)
- [x] Change usage of `AnyObject` to `Any`
- [x] Reflect interface changes in Moya
