### PR TITLE
A better typed urlRequest property of an Endpoint?

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON
 - Removed the unused `StreamRequest` typealias that was causing watchOS failures.
+- `urlRequest` property of `Endpoint` is now truly optional. The request will fail if the `urlRequest` turns out to be nil and a `requestMapping` error will be returned together with the problematic url.
 
 # 8.0.0-beta.1
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - Alamofire (4.0.0)
-  - Moya (8.0.0-beta.1):
-    - Moya/Core (= 8.0.0-beta.1)
-  - Moya/Core (8.0.0-beta.1):
+  - Moya (8.0.0-beta.2):
+    - Moya/Core (= 8.0.0-beta.2)
+  - Moya/Core (8.0.0-beta.2):
     - Alamofire (~> 4.0.0)
     - Result
-  - Moya/ReactiveCocoa (8.0.0-beta.1):
+  - Moya/ReactiveCocoa (8.0.0-beta.2):
     - Moya/Core
     - ReactiveSwift
-  - Moya/RxSwift (8.0.0-beta.1):
+  - Moya/RxSwift (8.0.0-beta.2):
     - Moya/Core
-    - RxSwift (= 3.0.0-beta.1)
+    - RxSwift
   - Nimble (5.0.0-alpha.30p1)
   - OHHTTPStubs (5.2.1):
     - OHHTTPStubs/Default (= 5.2.1)
@@ -65,16 +65,16 @@ CHECKOUT OPTIONS:
     :commit: 8f2bc636ecfa2cc20696f62548b38d4ab943e299
     :git: https://github.com/Quick/Quick
   ReactiveSwift:
-    :commit: 3f2daac74e4bd230fa9806de60a473db6b959073
+    :commit: 3dc5b89068dc97fedd70de0c0cc9023bed554b1f
     :git: https://github.com/ReactiveCocoa/ReactiveSwift.git
 
 SPEC CHECKSUMS:
   Alamofire: fef59f00388f267e52d9b432aa5d93dc97190f14
-  Moya: 63c4a59d2643c824df8c5a3b3a5f38dc2b48b055
+  Moya: 920d40f738e6f4ece84010cec701bb9693be8251
   Nimble: c5b995b4cd57789ec44b0cfb79640fc00e61a8c7
   OHHTTPStubs: 3a42f25c00563b71355ac73112ba2324e9e6cef4
   Quick: 31fb576b6cbb6b028cc5e0016e4366accbb346f5
-  ReactiveSwift: 99bfc623cd1d5edc78e36e49a5ba74f7a77aad08
+  ReactiveSwift: 0a2ef4a2f4443dfbcc47de600ab77e2d01b49994
   Result: 1b3e431f37cbcd3ad89c6aa9ab0ae55515fae3b6
   RxCocoa: 8cecf331302b8ae5381bbab1bccba4ede2eae6a8
   RxSwift: 0823e8d7969c23bfa9ddfb2afa4881e424a1a710

--- a/Demo/Tests/EndpointSpec.swift
+++ b/Demo/Tests/EndpointSpec.swift
@@ -19,8 +19,8 @@ class EndpointSpec: QuickSpec {
                 let newEndpoint = endpoint.endpointByAddingParameters(["message": message])
                 let newEndpointMessageObject: Any? = newEndpoint.parameters?["message"]
                 let newEndpointMessage = newEndpointMessageObject as? String
-                let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
+                let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
+                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
                 
                 
                 // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
@@ -37,8 +37,8 @@ class EndpointSpec: QuickSpec {
                 let agent = "Zalbinian"
                 let newEndpoint = endpoint.endpointByAddingHTTPHeaderFields(["User-Agent": agent])
                 let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]
-                let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
+                let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
+                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
                 
                 // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
                 expect(newEndpointAgent).to(equal(agent))
@@ -53,8 +53,8 @@ class EndpointSpec: QuickSpec {
             it ("returns a new endpoint for endpointByAddingParameterEncoding") {
                 let parameterEncoding = JSONEncoding()
                 let newEndpoint = endpoint.endpointByAddingParameterEncoding(parameterEncoding)
-                let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
+                let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
+                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
 
                 // Make sure we updated the parameter encoding
                 expect(newEncodedRequest).to(equal(encodedRequest))
@@ -75,8 +75,8 @@ class EndpointSpec: QuickSpec {
                     httpHeaderFields: ["User-Agent": agent],
                     parameterEncoding: parameterEncoding
                 )
-                let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
+                let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
+                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
                 
                 
                 let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]

--- a/Demo/Tests/Error+MoyaSpec.swift
+++ b/Demo/Tests/Error+MoyaSpec.swift
@@ -51,6 +51,13 @@ public func beOfSameErrorType(_ expectedValue: Moya.Error) -> MatcherFunc<Moya.E
                 default:
                     return false
                 }
+            case .requestMapping:
+                switch expectedValue {
+                case .requestMapping:
+                    return true
+                default:
+                    return false
+                }
             }
         } catch {
             return false;

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -58,6 +58,7 @@ class MoyaProviderSpec: QuickSpec {
             
             let endpoint1 = provider.endpoint(target)
             let endpoint2 = provider.endpoint(target)
+            expect(endpoint1.urlRequest).toNot(beNil())
             expect(endpoint1.urlRequest).to(equal(endpoint2.urlRequest))
         }
 
@@ -234,7 +235,7 @@ class MoyaProviderSpec: QuickSpec {
                         if let urlRequest = endpoint.urlRequest {
                             done(.success(urlRequest))
                         } else {
-                            done(.failure(Moya.Error.requestMapping))
+                            done(.failure(Moya.Error.requestMapping(endpoint.URL)))
                         }
                     }
                 }
@@ -334,7 +335,7 @@ class MoyaProviderSpec: QuickSpec {
                     if let urlRequest = endpoint.urlRequest {
                         done(.success(urlRequest))
                     } else {
-                        done(.failure(Moya.Error.requestMapping))
+                        done(.failure(Moya.Error.requestMapping(endpoint.URL)))
                     }
                 }
                 provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
@@ -448,7 +449,7 @@ class MoyaProviderSpec: QuickSpec {
                     if let urlRequest = endpoint.urlRequest {
                         done(.success(urlRequest))
                     } else {
-                        done(.failure(Moya.Error.requestMapping))
+                        done(.failure(Moya.Error.requestMapping(endpoint.URL)))
                     }
                 }
                 let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
@@ -469,7 +470,7 @@ class MoyaProviderSpec: QuickSpec {
                     if let urlRequest = endpoint.urlRequest {
                         done(.success(urlRequest))
                     } else {
-                        done(.failure(Moya.Error.requestMapping))
+                        done(.failure(Moya.Error.requestMapping(endpoint.URL)))
                     }
                 }
                 let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
@@ -490,7 +491,7 @@ class MoyaProviderSpec: QuickSpec {
                     if let urlRequest = endpoint.urlRequest {
                         done(.success(urlRequest))
                     } else {
-                        done(.failure(Moya.Error.requestMapping))
+                        done(.failure(Moya.Error.requestMapping(endpoint.URL)))
                     }
                 }
                 let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -231,7 +231,11 @@ class MoyaProviderSpec: QuickSpec {
             beforeEach {
                 let endpointResolution: MoyaProvider<GitHub>.RequestClosure = { endpoint, done in
                     delay(requestTime) {
-                        done(.success(endpoint.urlRequest))
+                        if let urlRequest = endpoint.urlRequest {
+                            done(.success(urlRequest))
+                        } else {
+                            done(.failure(Moya.Error.requestMapping))
+                        }
                     }
                 }
                 provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.DelayedStub(responseTime))
@@ -327,7 +331,11 @@ class MoyaProviderSpec: QuickSpec {
                 executed = false
                 let endpointResolution: MoyaProvider<GitHub>.RequestClosure = { endpoint, done in
                     executed = true
-                    done(.success(endpoint.urlRequest))
+                    if let urlRequest = endpoint.urlRequest {
+                        done(.success(urlRequest))
+                    } else {
+                        done(.failure(Moya.Error.requestMapping))
+                    }
                 }
                 provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
             }
@@ -437,7 +445,11 @@ class MoyaProviderSpec: QuickSpec {
                 var requestedURL: String?
                 let endpointResolution: MoyaProvider<StructTarget>.RequestClosure = { endpoint, done in
                     requestedURL = endpoint.URL
-                    done(.success(endpoint.urlRequest))
+                    if let urlRequest = endpoint.urlRequest {
+                        done(.success(urlRequest))
+                    } else {
+                        done(.failure(Moya.Error.requestMapping))
+                    }
                 }
                 let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
 
@@ -454,7 +466,11 @@ class MoyaProviderSpec: QuickSpec {
                 var requestParameters: [String: Any]?
                 let endpointResolution: MoyaProvider<StructTarget>.RequestClosure = { endpoint, done in
                     requestParameters = endpoint.parameters
-                    done(.success(endpoint.urlRequest))
+                    if let urlRequest = endpoint.urlRequest {
+                        done(.success(urlRequest))
+                    } else {
+                        done(.failure(Moya.Error.requestMapping))
+                    }
                 }
                 let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
 
@@ -471,7 +487,11 @@ class MoyaProviderSpec: QuickSpec {
                 var requestMethod: Moya.Method?
                 let endpointResolution: MoyaProvider<StructTarget>.RequestClosure = { endpoint, done in
                     requestMethod = endpoint.method
-                    done(.success(endpoint.urlRequest))
+                    if let urlRequest = endpoint.urlRequest {
+                        done(.success(urlRequest))
+                    } else {
+                        done(.failure(Moya.Error.requestMapping))
+                    }
                 }
                 let provider = MoyaProvider<StructTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.ImmediatelyStub)
 

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -87,10 +87,12 @@ open class Endpoint<Target> {
     }
 }
 
-/// Extension for converting an `Endpoint` into an `NSURLRequest`.
+/// Extension for converting an `Endpoint` into an optional `URLRequest`.
 extension Endpoint {
-    public var urlRequest: URLRequest! {
-        var request: URLRequest = URLRequest(url: Foundation.URL(string: URL)!) // swiftlint:disable:this force_unwrapping
+    public var urlRequest: URLRequest? {
+        guard let requestURL = Foundation.URL(string: URL) else { return nil }
+        
+        var request: URLRequest = URLRequest(url: requestURL)
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = httpHeaderFields
 
@@ -100,12 +102,15 @@ extension Endpoint {
 
 /// Required for making `Endpoint` conform to `Equatable`.
 public func == <T>(lhs: Endpoint<T>, rhs: Endpoint<T>) -> Bool {
+    if let _ = lhs.urlRequest, rhs.urlRequest == nil { return false }
+    if lhs.urlRequest == nil, let _ = rhs.urlRequest { return false }
+    if lhs.urlRequest == nil, rhs.urlRequest == nil { return lhs.hashValue == rhs.hashValue }
     return (lhs.urlRequest == rhs.urlRequest)
 }
 
 /// Required for using `Endpoint` as a key type in a `Dictionary`.
 extension Endpoint: Equatable, Hashable {
     public var hashValue: Int {
-        return (urlRequest as NSURLRequest).hash
+        return urlRequest?.hashValue ?? URL.hashValue
     }
 }

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -91,7 +91,7 @@ open class Endpoint<Target> {
 extension Endpoint {
     public var urlRequest: URLRequest? {
         guard let requestURL = Foundation.URL(string: URL) else { return nil }
-        
+
         var request: URLRequest = URLRequest(url: requestURL)
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = httpHeaderFields

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -7,7 +7,7 @@ public enum Error: Swift.Error {
     case statusCode(Response)
     case data(Response)
     case underlying(Swift.Error)
-    case requestMapping
+    case requestMapping(String)
 }
 
 public extension Moya.Error {

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -7,6 +7,7 @@ public enum Error: Swift.Error {
     case statusCode(Response)
     case data(Response)
     case underlying(Swift.Error)
+    case requestMapping
 }
 
 public extension Moya.Error {
@@ -19,6 +20,7 @@ public extension Moya.Error {
         case .statusCode(let response): return response
         case .data(let response): return response
         case .underlying: return nil
+        case .requestMapping: return nil
         }
     }
 }

--- a/Source/Moya+Defaults.swift
+++ b/Source/Moya+Defaults.swift
@@ -8,7 +8,11 @@ public extension MoyaProvider {
     }
 
     public final class func DefaultRequestMapping(_ endpoint: Endpoint<Target>, closure: RequestResultClosure) {
-        return closure(.success(endpoint.urlRequest))
+        if let urlRequest = endpoint.urlRequest {
+            closure(.success(urlRequest))
+        } else {
+            closure(.failure(Error.requestMapping))
+        }
     }
 
     public final class func DefaultAlamofireManager() -> Manager {

--- a/Source/Moya+Defaults.swift
+++ b/Source/Moya+Defaults.swift
@@ -11,7 +11,7 @@ public extension MoyaProvider {
         if let urlRequest = endpoint.urlRequest {
             closure(.success(urlRequest))
         } else {
-            closure(.failure(Error.requestMapping))
+            closure(.failure(Error.requestMapping(endpoint.URL)))
         }
     }
 


### PR DESCRIPTION
Currently the `urlRequest` [property](https://github.com/Moya/Moya/blob/master/Source/Endpoint.swift#L92) of a `Endpoint` is a IUO (Implicitly Unwrapped Optional). But this doesn't seems to be correct. Let's say if we think the `urlRequest` definitely exists (not true) then we should delete the `excalmatory mark` to make it non-optional at all. On the other hand, if we think the `urlRequest` might not exist (sometimes when the url is invalid or the encoding fails), then we should explicitly mark it as optional.

Although we could assume the user should be responsible for the risks, I like the latter assumption better. This PR made the `urlRequest` optional. And because the `hashValue` relies on the property, I have to change that as well. ATM, I'm using the URL as a backup if the request doesn't exist. (Might need to consider the parameters/parameterEncoding as well. method/headers won't effect.)

We can discuss the problem here or in a separate issue.