### PR TITLE
Change Endpoint Helper Functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 - **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON
 - Removed the unused `StreamRequest` typealias that was causing watchOS failures.
+- **Breaking Change** Renamed `endpointByAddingHTTPHeaders` to `adding(newHttpHeaderFields:)`
+- **Breaking Change** Renamed `endpointByAddingParameters` to `adding(newParameters:)`
+- **Breaking Change** Renamed `endpointByAddingParameterEncoding` to `adding(newParameterEncoding:)`
+- **Breaking Change** Renamed `endpointByAdding(parameters:httpHeaderFields:parameterEncoding)` to `adding(parameters:httpHeaderFields:parameterEncoding)`
 
 # 8.0.0-beta.1
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - Alamofire (4.0.0)
-  - Moya (8.0.0-beta.1):
-    - Moya/Core (= 8.0.0-beta.1)
-  - Moya/Core (8.0.0-beta.1):
+  - Moya (8.0.0-beta.2):
+    - Moya/Core (= 8.0.0-beta.2)
+  - Moya/Core (8.0.0-beta.2):
     - Alamofire (~> 4.0.0)
     - Result
-  - Moya/ReactiveCocoa (8.0.0-beta.1):
+  - Moya/ReactiveCocoa (8.0.0-beta.2):
     - Moya/Core
     - ReactiveSwift
-  - Moya/RxSwift (8.0.0-beta.1):
+  - Moya/RxSwift (8.0.0-beta.2):
     - Moya/Core
-    - RxSwift (= 3.0.0-beta.1)
+    - RxSwift
   - Nimble (5.0.0-alpha.30p1)
   - OHHTTPStubs (5.2.1):
     - OHHTTPStubs/Default (= 5.2.1)
@@ -70,14 +70,14 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Alamofire: fef59f00388f267e52d9b432aa5d93dc97190f14
-  Moya: 63c4a59d2643c824df8c5a3b3a5f38dc2b48b055
+  Moya: 920d40f738e6f4ece84010cec701bb9693be8251
   Nimble: c5b995b4cd57789ec44b0cfb79640fc00e61a8c7
   OHHTTPStubs: 3a42f25c00563b71355ac73112ba2324e9e6cef4
   Quick: 31fb576b6cbb6b028cc5e0016e4366accbb346f5
   ReactiveSwift: 99bfc623cd1d5edc78e36e49a5ba74f7a77aad08
   Result: 1b3e431f37cbcd3ad89c6aa9ab0ae55515fae3b6
   RxCocoa: 8cecf331302b8ae5381bbab1bccba4ede2eae6a8
-  RxSwift: 0823e8d7969c23bfa9ddfb2afa4881e424a1a710
+  RxSwift: '0823e8d7969c23bfa9ddfb2afa4881e424a1a710'
 
 PODFILE CHECKSUM: 82bd3db85d8100c253516bc87abf238a726f041d
 

--- a/Demo/Tests/EndpointSpec.swift
+++ b/Demo/Tests/EndpointSpec.swift
@@ -16,7 +16,7 @@ class EndpointSpec: QuickSpec {
             
             it("returns a new endpoint for endpointByAddingParameters") {
                 let message = "I hate it when villains quote Shakespeare."
-                let newEndpoint = endpoint.endpointByAddingParameters(["message": message])
+                let newEndpoint = endpoint.adding(newParameters: ["message": message])
                 let newEndpointMessageObject: Any? = newEndpoint.parameters?["message"]
                 let newEndpointMessage = newEndpointMessageObject as? String
                 let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
@@ -35,7 +35,7 @@ class EndpointSpec: QuickSpec {
             
             it("returns a new endpoint for endpointByAddingHTTPHeaderFields") {
                 let agent = "Zalbinian"
-                let newEndpoint = endpoint.endpointByAddingHTTPHeaderFields(["User-Agent": agent])
+                let newEndpoint = endpoint.adding(newHttpHeaderFields: ["User-Agent": agent])
                 let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]
                 let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
                 let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
@@ -52,7 +52,7 @@ class EndpointSpec: QuickSpec {
 
             it ("returns a new endpoint for endpointByAddingParameterEncoding") {
                 let parameterEncoding = JSONEncoding()
-                let newEndpoint = endpoint.endpointByAddingParameterEncoding(parameterEncoding)
+                let newEndpoint = endpoint.adding(newParameterEncoding: parameterEncoding)
                 let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
                 let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest, with: newEndpoint.parameters)
 
@@ -70,7 +70,7 @@ class EndpointSpec: QuickSpec {
                 let parameterEncoding = URLEncoding()
                 let agent = "Zalbinian"
                 let message = "I hate it when villains quote Shakespeare."
-                let newEndpoint = endpoint.endpointByAdding(
+                let newEndpoint = endpoint.adding(
                     parameters: ["message": message],
                     httpHeaderFields: ["User-Agent": agent],
                     parameterEncoding: parameterEncoding

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -40,22 +40,22 @@ open class Endpoint<Target> {
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added parameters.
-    open func endpointByAddingParameters(_ parameters: [String: Any]) -> Endpoint<Target> {
-        return endpointByAdding(parameters: parameters)
+    open func adding(newParameters: [String: Any]) -> Endpoint<Target> {
+        return adding(parameters: newParameters)
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added HTTP header fields.
-    open func endpointByAddingHTTPHeaderFields(_ httpHeaderFields: [String: String]) -> Endpoint<Target> {
-        return endpointByAdding(httpHeaderFields: httpHeaderFields)
+    open func adding(newHttpHeaderFields: [String: String]) -> Endpoint<Target> {
+        return adding(httpHeaderFields: newHttpHeaderFields)
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with another parameter encoding.
-    open func endpointByAddingParameterEncoding(_ newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<Target> {
-        return endpointByAdding(parameterEncoding: newParameterEncoding)
+    open func adding(newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<Target> {
+        return adding(parameterEncoding: newParameterEncoding)
     }
 
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
-    open func endpointByAdding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
+    open func adding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
         let newParameters = addParameters(parameters)
         let newHTTPHeaderFields = addHTTPHeaderFields(httpHeaderFields)
         let newParameterEncoding = parameterEncoding ?? self.parameterEncoding

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -63,7 +63,7 @@ analytics.
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
     let endpoint: Endpoint<MyTarget> = Endpoint<MyTarget>(URL: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
-    return endpoint.endpointByAddingHTTPHeaderFields(["APP_NAME": "MY_AWESOME_APP"])
+    return endpoint.adding(newHttpHeaderFields: ["APP_NAME": "MY_AWESOME_APP"])
 }
 let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)
 ```
@@ -84,7 +84,7 @@ let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     case .authenticate:
         return endpoint
     default:
-        return endpoint.endpointByAddingHTTPHeaderFields(["AUTHENTICATION_TOKEN": GlobalAppStorage.authToken])
+        return endpoint.adding(newHttpHeaderFields: ["AUTHENTICATION_TOKEN": GlobalAppStorage.authToken])
     }
 }
 let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)
@@ -93,7 +93,7 @@ let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)
 Awesome.
 
 Note that we can rely on the existing behavior of Moya and extend – instead
-of replace – it. The `endpointByAddingParameters` and `endpointByAddingHTTPHeaderFields`
+of replace – it. The `adding(newParameters:)` and `adding(newHttpHeaderFields:)`
 functions allow you to rely on the existing Moya code and add your own custom
 values.
 


### PR DESCRIPTION
After looking at some of the documentation, I feel that Endpoints helper functions should be changed in response to Swift 3.0's new API design guidelines. This would be a breaking change

I ran into issues having a similar signature for `adding` helper functions that called the factory `adding(parameters:httpHeaderFields:parameterEncoding)`. To mitigate that, I prepended `new` to the helper function parameter.

Fixes #679 