### PR TITLE
Changes HTTP verbs enum to lowercase

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - **Breaking Change** Renamed `endpointByAddingParameters` to `adding(newParameters:)`
 - **Breaking Change** Renamed `endpointByAddingParameterEncoding` to `adding(newParameterEncoding:)`
 - **Breaking Change** Renamed `endpointByAdding(parameters:httpHeaderFields:parameterEncoding)` to `adding(parameters:httpHeaderFields:parameterEncoding)`
+- **Breaking Change** Changed HTTP verbs enum to lowercase
 
 # 8.0.0-beta.1
 

--- a/Demo/Demo/GiphyAPI.swift
+++ b/Demo/Demo/GiphyAPI.swift
@@ -18,7 +18,7 @@ extension Giphy: TargetType {
     public var method: Moya.Method {
         switch self {
         case .upload:
-            return .POST
+            return .post
         }
     }
     public var parameters: [String: Any]? {

--- a/Demo/Demo/GitHubAPI.swift
+++ b/Demo/Demo/GitHubAPI.swift
@@ -42,7 +42,7 @@ extension GitHub: TargetType {
         }
     }
     public var method: Moya.Method {
-        return .GET
+        return .get
     }
     public var parameters: [String: Any]? {
         switch self {

--- a/Demo/Demo/GitHubUserContentAPI.swift
+++ b/Demo/Demo/GitHubUserContentAPI.swift
@@ -18,7 +18,7 @@ extension GitHubUserContent: TargetType {
     public var method: Moya.Method {
         switch self {
         case .downloadMoyaWebContent:
-            return .GET
+            return .get
         }
     }
     public var parameters: [String: Any]? {

--- a/Demo/Tests/EndpointSpec.swift
+++ b/Demo/Tests/EndpointSpec.swift
@@ -11,7 +11,7 @@ class EndpointSpec: QuickSpec {
                 let target: GitHub = .zen
                 let parameters = ["Nemesis": "Harvey"]
                 let headerFields = ["Title": "Dominar"]
-                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.GET, parameters: parameters, parameterEncoding: JSONEncoding(), httpHeaderFields: headerFields)
+                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, parameters: parameters, parameterEncoding: JSONEncoding(), httpHeaderFields: headerFields)
             }
             
             it("returns a new endpoint for endpointByAddingParameters") {

--- a/Demo/Tests/MethodSpec.swift
+++ b/Demo/Tests/MethodSpec.swift
@@ -6,15 +6,15 @@ class MethodSpec: QuickSpec {
     override func spec() {
         describe("supportsMultipart") {
             let expectations: [(Moya.Method, Bool)] = [
-                (.GET, false),
-                (.POST, true),
-                (.PUT, true),
-                (.DELETE, false),
-                (.OPTIONS, false),
-                (.HEAD, false),
-                (.PATCH, true),
-                (.TRACE, false),
-                (.CONNECT, true),
+                (.get, false),
+                (.post, true),
+                (.put, true),
+                (.delete, false),
+                (.options, false),
+                (.head, false),
+                (.patch, true),
+                (.trace, false),
+                (.connect, true),
             ]
             for (method, expected) in expectations {
                 it("\(method) should \(expected ? "" : "not") support multipart") {

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -427,7 +427,7 @@ class MoyaProviderSpec: QuickSpec {
             struct StructAPI: TargetType {
                 var baseURL = URL(string: "http://example.com")!
                 var path = "/endpoint"
-                var method = Moya.Method.GET
+                var method = Moya.Method.get
                 var parameters: [String: Any]? = ["key": "value"]
                 var task: Task = .request
                 var sampleData = "sample data".data(using: .utf8)!
@@ -481,7 +481,7 @@ class MoyaProviderSpec: QuickSpec {
                     }
                 }
 
-                expect(requestMethod) == .GET
+                expect(requestMethod) == .get
             }
 
             it("uses correct sample data") {

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -24,7 +24,7 @@ extension GitHub: TargetType {
     }
     
     var method: Moya.Method {
-        return .GET
+        return .get
     }
     
     var parameters: [String: Any]? {
@@ -66,7 +66,7 @@ enum HTTPBin: TargetType {
     }
 
     var method: Moya.Method {
-        return .GET
+        return .get
     }
     
     var parameters: [String: Any]? {

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -26,7 +26,7 @@ open class Endpoint<Target> {
     /// Main initializer for `Endpoint`.
     public init(URL: String,
         sampleResponseClosure: @escaping SampleResponseClosure,
-        method: Moya.Method = Moya.Method.GET,
+        method: Moya.Method = Moya.Method.get,
         parameters: [String: Any]? = nil,
         parameterEncoding: Moya.ParameterEncoding = URLEncoding(),
         httpHeaderFields: [String: String]? = nil) {

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -49,14 +49,23 @@ public enum StructTarget: TargetType {
 
 /// Represents an HTTP method.
 public enum Method: String {
-    case GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH, TRACE, CONNECT
+
+    case options = "OPTIONS"
+    case get     = "GET"
+    case head    = "HEAD"
+    case post    = "POST"
+    case put     = "PUT"
+    case patch   = "PATCH"
+    case delete  = "DELETE"
+    case trace   = "TRACE"
+    case connect = "CONNECT"
 
     public var supportsMultipart: Bool {
         switch self {
-        case .POST,
-             .PUT,
-             .PATCH,
-             .CONNECT:
+        case .post,
+             .put,
+             .patch,
+             .connect:
             return true
         default:
             return false

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Alamofire
 
 /// Protocol to define the base URL, path, method, parameters and sample data for a target.
 public protocol TargetType {
@@ -48,18 +49,9 @@ public enum StructTarget: TargetType {
 }
 
 /// Represents an HTTP method.
-public enum Method: String {
+public typealias Method = Alamofire.HTTPMethod
 
-    case options = "OPTIONS"
-    case get     = "GET"
-    case head    = "HEAD"
-    case post    = "POST"
-    case put     = "PUT"
-    case patch   = "PATCH"
-    case delete  = "DELETE"
-    case trace   = "TRACE"
-    case connect = "CONNECT"
-
+extension Method {
     public var supportsMultipart: Bool {
         switch self {
         case .post,

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -35,9 +35,9 @@ extension MyService: TargetType {
     var method: Moya.Method {
         switch self {
         case .zen, .showUser, .showAccounts:
-            return .GET
+            return .get
         case .createUser:
-            return .POST
+            return .post
         }
     }
     var parameters: [String: Any]? {

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -34,9 +34,9 @@ extension MyService: TargetType {
     public var method: Moya.Method {
         switch self {
         case .emailAuth:
-            return .POST
+            return .post
         default:
-            return .GET
+            return .get
         }
     }
 //...

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -55,7 +55,7 @@ are always using the GET HTTP method, so this is pretty easy:
 
 ```swift
 public var method: Moya.Method {
-    return .GET
+    return .get
 }
 ```
 


### PR DESCRIPTION
As discussed in #684

```swift
public enum Method: String {

    case options = "OPTIONS"
    case get     = "GET"
    case head    = "HEAD"
    case post    = "POST"
    case put     = "PUT"
    case patch   = "PATCH"
    case delete  = "DELETE"
    case trace   = "TRACE"
    case connect = "CONNECT"
```