### PR TITLE
Added Important Note

### DIFF
--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -53,7 +53,7 @@ You **have to** add optional parameters like shown above, one per line. Optional
 	public var parameters: [String: Any]? {
 	    switch self {
 	    case .users(let limit):
-	        let params: [String: Any] = ["limit" = limit]
+	        let params: [String: Any] = ["limit": limit]
 	        return params
         default:
             return nil

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -50,6 +50,7 @@ You **have to** add optional parameters like shown above, one per line. Optional
 
 ```swift
 //...
+	// This won't work!
 	public var parameters: [String: Any]? {
 	    switch self {
 	    case .users(let limit):

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -13,13 +13,13 @@ extension MyService: TargetType {
 	public var parameters: [String: Any]? {
 	    switch self {
 	    case .users(let limit):
-	        var params: [String: Any] = [:]
-	        params["limit"] = limit
-	        return params
-        default:
-            return nil
-        }
-    }
+		var params: [String: Any] = [:]
+		params["limit"] = limit
+		return params
+	    default:
+	        return nil
+	}
+}
 //...
 }
 ```

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -42,3 +42,24 @@ extension MyService: TargetType {
 //...
 }
 ```
+
+
+Important Note
+--------------
+You **have to** add optional parameters like shown above, one per line. Optional parameters won't be removed in case of ```nil``` if you try to initialize them within one line, e.g.:
+
+```swift
+//...
+	public var parameters: [String: Any]? {
+	    switch self {
+	    case .users(let limit):
+	        let params: [String: Any] = ["limit" = limit]
+	        return params
+        default:
+            return nil
+        }
+    }
+//...
+```
+
+In this case the URL request would contain a parameter like ```api/users?limit=nil``` if limit is ```nil```.


### PR DESCRIPTION
When I initially tried to initialize all parameters within one line, I found out that the parameters won't be removed from the request if their value is ```nil```, nor unwrapped if they contain a value.
Added a hint to the example to avoid that wrong implementation for others.