### PR TITLE
[Alamofire] Use .default instead of inits in Parameter Encoding.

### DIFF
--- a/Demo/Tests/EndpointSpec.swift
+++ b/Demo/Tests/EndpointSpec.swift
@@ -11,7 +11,7 @@ class EndpointSpec: QuickSpec {
                 let target: GitHub = .zen
                 let parameters = ["Nemesis": "Harvey"]
                 let headerFields = ["Title": "Dominar"]
-                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, parameters: parameters, parameterEncoding: JSONEncoding(), httpHeaderFields: headerFields)
+                endpoint = Endpoint<GitHub>(URL: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, parameters: parameters, parameterEncoding: JSONEncoding.default, httpHeaderFields: headerFields)
             }
             
             it("returns a new endpoint for endpointByAddingParameters") {
@@ -51,7 +51,7 @@ class EndpointSpec: QuickSpec {
             }
 
             it ("returns a new endpoint for endpointByAddingParameterEncoding") {
-                let parameterEncoding = JSONEncoding()
+                let parameterEncoding = JSONEncoding.default
                 let newEndpoint = endpoint.adding(newParameterEncoding: parameterEncoding)
                 let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
                 let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
@@ -67,7 +67,7 @@ class EndpointSpec: QuickSpec {
             }
             
             it ("returns a new endpoint for endpointByAdding with all parameters") {
-                let parameterEncoding = URLEncoding()
+                let parameterEncoding = URLEncoding.default
                 let agent = "Zalbinian"
                 let message = "I hate it when villains quote Shakespeare."
                 let newEndpoint = endpoint.adding(

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -28,7 +28,7 @@ open class Endpoint<Target> {
         sampleResponseClosure: @escaping SampleResponseClosure,
         method: Moya.Method = Moya.Method.get,
         parameters: [String: Any]? = nil,
-        parameterEncoding: Moya.ParameterEncoding = URLEncoding(),
+        parameterEncoding: Moya.ParameterEncoding = URLEncoding.default,
         httpHeaderFields: [String: String]? = nil) {
 
         self.URL = URL


### PR DESCRIPTION
Hey guys! 🎉 So I've changed the way we use Alamofire's `ParameterEncoding` in Moya, because it seems like we should use the `.default` parameter of given type, rather than `init` (per docs [here](https://github.com/Alamofire/Alamofire/blob/master/README.md#parameter-encoding), also from implementation these are aliases, but who knows what brings the future!). I hope I didn't overlook anything and we are good to go! 😅