### PR TITLE
Fix download progress bug

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- Fixes download requests never calling the completion block
+- Adds new internal Requestable protocol
 - **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON
 - Removed the unused `StreamRequest` typealias that was causing watchOS failures.
 - **Breaking Change** Renamed `endpointByAddingHTTPHeaders` to `adding(newHttpHeaderFields:)`

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -593,8 +593,8 @@ class MoyaProviderSpec: QuickSpec {
             beforeEach {
                 
                 //delete downloaded filed before each test
-                let directory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-                let file = directory.appendingPathComponent("logo_github.png")
+                let directoryURLs = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+                let file = directoryURLs.first!.appendingPathComponent("logo_github.png")
                 try? FileManager.default.removeItem(at: file)
                 
                 //`responseTime(-4)` equals to 1000 bytes at a time. The sample data is 4000 bytes.

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -601,7 +601,7 @@ class MoyaProviderSpec: QuickSpec {
                 OHHTTPStubs.stubRequests(passingTest: {$0.url!.path.hasSuffix("logo_github.png")}) { _ in
                     return OHHTTPStubsResponse(data: GitHubUserContent.downloadMoyaWebContent("logo_github.png").sampleData, statusCode: 200, headers: nil).responseTime(-4)
                 }
-                provider = MoyaProvidesr<GitHubUserContent>()
+                provider = MoyaProvider<GitHubUserContent>()
             }
             
             it("tracks progress of request") {

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -87,3 +87,52 @@ enum HTTPBin: TargetType {
         }
     }
 }
+
+public enum GitHubUserContent {
+    case downloadMoyaWebContent(String)
+}
+
+extension GitHubUserContent: TargetType {
+    public var baseURL: URL { return URL(string: "https://raw.githubusercontent.com")! }
+    public var path: String {
+        switch self {
+        case .downloadMoyaWebContent(let contentPath):
+            return "/Moya/Moya/master/web/\(contentPath)"
+        }
+    }
+    public var method: Moya.Method {
+        switch self {
+        case .downloadMoyaWebContent:
+            return .get
+        }
+    }
+    public var parameters: [String: Any]? {
+        switch self {
+        case .downloadMoyaWebContent:
+            return nil
+        }
+    }
+    public var task: Task {
+        switch self {
+        case .downloadMoyaWebContent:
+            return .download(.request(DefaultDownloadDestination))
+        }
+    }
+    public var sampleData: Data {
+        switch self {
+        case .downloadMoyaWebContent:
+            return Data(count: 4000)
+        }
+    }
+   
+}
+
+private let DefaultDownloadDestination: DownloadDestination = { temporaryURL, response in
+    let directoryURLs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+    
+    if !directoryURLs.isEmpty {
+        return (directoryURLs[0].appendingPathComponent(response.suggestedFilename!), [])
+    }
+    
+    return (temporaryURL, [])
+}

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -128,10 +128,10 @@ extension GitHubUserContent: TargetType {
 }
 
 private let DefaultDownloadDestination: DownloadDestination = { temporaryURL, response in
-    let directoryURLs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-    
+    let directoryURLs = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+
     if !directoryURLs.isEmpty {
-        return (directoryURLs[0].appendingPathComponent(response.suggestedFilename!), [])
+        return (directoryURLs.first!.appendingPathComponent(response.suggestedFilename!), [])
     }
     
     return (temporaryURL, [])

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -61,3 +61,25 @@ public final class CancellableToken: Cancellable, CustomDebugStringConvertible {
     }
 
 }
+
+internal typealias RequestableCompletion = (HTTPURLResponse?, URLRequest?, Data?, Swift.Error?) -> Void
+
+internal protocol Requestable {
+    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Requestable
+}
+
+extension DataRequest: Requestable {
+    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Requestable {
+        return response(queue: queue, completionHandler: { handler  in
+            completionHandler(handler.response, handler.request, handler.data, handler.error)
+        })
+    }
+}
+
+extension DownloadRequest: Requestable {
+    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Requestable {
+        return response(queue: queue, completionHandler: { handler  in
+            completionHandler(handler.response, handler.request, nil, handler.error)
+        })
+    }
+}

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -65,11 +65,11 @@ public final class CancellableToken: Cancellable, CustomDebugStringConvertible {
 internal typealias RequestableCompletion = (HTTPURLResponse?, URLRequest?, Data?, Swift.Error?) -> Void
 
 internal protocol Requestable {
-    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Requestable
+    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Self
 }
 
 extension DataRequest: Requestable {
-    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Requestable {
+    internal func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Self {
         return response(queue: queue, completionHandler: { handler  in
             completionHandler(handler.response, handler.request, handler.data, handler.error)
         })
@@ -77,7 +77,7 @@ extension DataRequest: Requestable {
 }
 
 extension DownloadRequest: Requestable {
-    func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Requestable {
+    internal func response(queue: DispatchQueue?, completionHandler: @escaping RequestableCompletion) -> Self {
         return response(queue: queue, completionHandler: { handler  in
             completionHandler(handler.response, handler.request, nil, handler.error)
         })

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -224,7 +224,7 @@ private extension MoyaProvider {
             progressCompletion?(ProgressResponse(response: result.value))
             completion(result)
         }
-        
+
         progressAlamoRequest = progressAlamoRequest.response(queue: queue, completionHandler: completionHandler)
 
         progressAlamoRequest.resume()

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -228,6 +228,18 @@ private extension MoyaProvider {
             if let dataRequest = dataRequest as? T {
                 progressAlamoRequest = dataRequest
             }
+        } else if var dataRequest = progressAlamoRequest as? DownloadRequest {
+            dataRequest = dataRequest.response(queue: queue, completionHandler: { handler in
+                let result = convertResponseToResult(handler.response, request: handler.request, data: nil, error: handler.error)
+                // Inform all plugins about the response
+                plugins.forEach { $0.didReceiveResponse(result, target: target) }
+                progressCompletion?(ProgressResponse(response: result.value))
+                completion(result)
+            })
+            
+            if let dataRequest = dataRequest as? T {
+                progressAlamoRequest = dataRequest
+            }
         }
 
         progressAlamoRequest.resume()

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -184,7 +184,7 @@ private extension MoyaProvider {
         return sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
-    func sendAlamofireRequest<T where T: Requestable, T: Request>(_ alamoRequest: T, target: Target, queue: DispatchQueue?, progress progressCompletion: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
+    func sendAlamofireRequest<T>(_ alamoRequest: T, target: Target, queue: DispatchQueue?, progress progressCompletion: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken where T: Requestable, T: Request {
         // Give plugins the chance to alter the outgoing request
         let plugins = self.plugins
         plugins.forEach { $0.willSendRequest(alamoRequest, target: target) }


### PR DESCRIPTION
Closes #715

As detailed in #715, the callbacks of the download requests were never being called because the `DownloadRequest` does not inherit from the `DataRequest`.

What was changed was that there is now an different cast for download requests. This is based on the [code that is found in the Alamofire example] (https://github.com/Alamofire/Alamofire/blob/master/Example/Source/DetailViewController.swift#L104-L112). The second casts fixes the completion block never getting called issue but the progress is still wrong.

I noticed when trying to write tests for this that the progress object will never have its completed property be true since it requires a response to be present. In all the code for progress tracking a response is never set so what I did is that on request completion update the progress object to have a response. Doing so has the desired effect of having the progress object returning completed.

This also contributes to increasing the code coverage from #668.