### PR TITLE
Lowercase class funcs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,8 @@
 # Next
 
-- **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON.
 # 8.0.0-beta.3
 
-- **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON
-- Removed the unused `StreamRequest` typealias that was causing watchOS failures.
+- **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON.
 - **Breaking Change** Renamed `endpointByAddingHTTPHeaders` to `adding(newHttpHeaderFields:)`.
 - **Breaking Change** Renamed `endpointByAddingParameters` to `adding(newParameters:)`.
 - **Breaking Change** Renamed `endpointByAddingParameterEncoding` to `adding(newParameterEncoding:)`.
@@ -13,10 +11,11 @@
 - `urlRequest` property of `Endpoint` is now truly optional. The request will fail if the `urlRequest` turns out to be nil and a `requestMapping` error will be returned together with the problematic url.
 - **Breaking Change** Made RxMoya & ReactiveMoya frameworks dependant on Moya framework, making them slimmer and not re-including Moya source in the Reactive extensions. ([PR](https://github.com/Moya/Moya/pull/563))
 - **Breaking Change** Made some `class func`s [mimicking enum cases](https://github.com/Moya/Moya/blob/master/Source/Moya.swift#L117-L133) lowercased.
+- Removed the unused `StreamRequest` typealias that was causing watchOS failures.
 - Fixes download requests never calling the completion block.
-- Adds new internal Requestable protocol.
+- Added a new internal Requestable protocol.
 - Added a new case to `SampleResponseClosure` which allows mocking of the whole `URLResponse`.
-- Adds test for new `SampleResponseClosure` case.
+- Added a test for new `SampleResponseClosure` case.
 
 # 8.0.0-beta.2
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - **Breaking Change** Changed HTTP verbs enum to lowercase
 - `urlRequest` property of `Endpoint` is now truly optional. The request will fail if the `urlRequest` turns out to be nil and a `requestMapping` error will be returned together with the problematic url.
 - **Breaking Change** Made RxMoya & ReactiveMoya frameworks dependant on Moya framework, making them slimmer and not re-including Moya source in the Reactive extensions. ([PR](https://github.com/Moya/Moya/pull/563))
+- **Breaking Change** Made some `class func`s [mimicking enum cases](https://github.com/Moya/Moya/blob/master/Source/Moya.swift#L117-L133) lowercased.
 - Fixes download requests never calling the completion block.
 - Adds new internal Requestable protocol.
 - Added a new case to `SampleResponseClosure` which allows mocking of the whole `URLResponse`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- **Breaking Change** Made some `class func`s [mimicking enum cases](https://github.com/Moya/Moya/blob/master/Source/Moya.swift#L117-L133) lowercased.
+
 # 8.0.0-beta.3
 
 - **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON.
@@ -10,7 +12,6 @@
 - **Breaking Change** Changed HTTP verbs enum to lowercase.
 - `urlRequest` property of `Endpoint` is now truly optional. The request will fail if the `urlRequest` turns out to be nil and a `requestMapping` error will be returned together with the problematic url.
 - **Breaking Change** Made RxMoya & ReactiveMoya frameworks dependant on Moya framework, making them slimmer and not re-including Moya source in the Reactive extensions. ([PR](https://github.com/Moya/Moya/pull/563))
-- **Breaking Change** Made some `class func`s [mimicking enum cases](https://github.com/Moya/Moya/blob/master/Source/Moya.swift#L117-L133) lowercased.
 - Removed the unused `StreamRequest` typealias that was causing watchOS failures.
 - Fixes download requests never calling the completion block.
 - Added a new internal Requestable protocol.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,12 +1,12 @@
 # Next
 
-- **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON
+- **Breaking Change** Throw dedicated `Error.jsonMapping` when `mapJSON` fails to parse JSON.
 - Removed the unused `StreamRequest` typealias that was causing watchOS failures.
-- **Breaking Change** Renamed `endpointByAddingHTTPHeaders` to `adding(newHttpHeaderFields:)`
-- **Breaking Change** Renamed `endpointByAddingParameters` to `adding(newParameters:)`
-- **Breaking Change** Renamed `endpointByAddingParameterEncoding` to `adding(newParameterEncoding:)`
-- **Breaking Change** Renamed `endpointByAdding(parameters:httpHeaderFields:parameterEncoding)` to `adding(parameters:httpHeaderFields:parameterEncoding)`
-- **Breaking Change** Changed HTTP verbs enum to lowercase
+- **Breaking Change** Renamed `endpointByAddingHTTPHeaders` to `adding(newHttpHeaderFields:)`.
+- **Breaking Change** Renamed `endpointByAddingParameters` to `adding(newParameters:)`.
+- **Breaking Change** Renamed `endpointByAddingParameterEncoding` to `adding(newParameterEncoding:)`.
+- **Breaking Change** Renamed `endpointByAdding(parameters:httpHeaderFields:parameterEncoding)` to `adding(parameters:httpHeaderFields:parameterEncoding)`.
+- **Breaking Change** Changed HTTP verbs enum to lowercase.
 - `urlRequest` property of `Endpoint` is now truly optional. The request will fail if the `urlRequest` turns out to be nil and a `requestMapping` error will be returned together with the problematic url.
 - **Breaking Change** Made RxMoya & ReactiveMoya frameworks dependant on Moya framework, making them slimmer and not re-including Moya source in the Reactive extensions. ([PR](https://github.com/Moya/Moya/pull/563))
 - **Breaking Change** Made some `class func`s [mimicking enum cases](https://github.com/Moya/Moya/blob/master/Source/Moya.swift#L117-L133) lowercased.
@@ -205,7 +205,7 @@
   - `Moya.StubbedBehavior` renamed to `Moya.StubBehavior`
   - `Moya.MoyaStubbedBehavior` renamed to `Moya.StubClosure`
   - `Moya.NoStubbingBehavior` -> `Moya.NeverStub`
-  - `Moya.ImmediateStubbingBehaviour` -> `Moya.NeverStub`
+  - `Moya.ImmediateStubbingBehaviour` -> `Moya.ImmediatelyStub`
   - `Moya.DelayedStubbingBehaviour` -> `Moya.DelayedStub`
 - Default class functions have been moved to extensions to prevent inadvertent subclassing.
 - Renamed other identifiers: **Breaking Change**

--- a/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
@@ -10,13 +10,13 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
     override func spec() {
         var provider: ReactiveCocoaMoyaProvider<GitHub>!
         beforeEach {
-            provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub)
+            provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaProvider.immediatelyStub)
         }
 
         describe("failing") {
             var provider: ReactiveCocoaMoyaProvider<GitHub>!
             beforeEach {
-                provider = ReactiveCocoaMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.ImmediatelyStub)
+                provider = ReactiveCocoaMoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.immediatelyStub)
             }
             
             it("returns the correct error message") {
@@ -60,10 +60,10 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             }
 
             class TestProvider<Target: TargetType>: ReactiveCocoaMoyaProvider<Target> {
-                init(endpointClosure: @escaping EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-                    requestClosure: @escaping RequestClosure = MoyaProvider.DefaultRequestMapping,
-                    stubClosure: @escaping StubClosure = MoyaProvider.NeverStub,
-                    manager: Manager = MoyaProvider<Target>.DefaultAlamofireManager(),
+                init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
+                    requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
+                    stubClosure: @escaping StubClosure = MoyaProvider.neverStub,
+                    manager: Manager = MoyaProvider<Target>.defaultAlamofireManager(),
                     plugins: [PluginType] = []) {
 
                         super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
@@ -78,13 +78,13 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             beforeEach {
                 TestCancellable.cancelled = false
 
-                provider = TestProvider<GitHub>(stubClosure: MoyaProvider.DelayedStub(1))
+                provider = TestProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(1))
             }
 
             it("cancels network request when subscription is cancelled") {
                 let target: GitHub = .zen
 
-                let disposable = provider.request(token: target).startWithCompleted { () -> Void in
+                let disposable = provider.request(token: target).startWithCompleted {
                     // Should never be executed
                     fail()
                 }
@@ -99,9 +99,9 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             it("returns a Response object") {
                 var called = false
                 
-                provider.request(token: .zen).startWithResult({ _ in
+                provider.request(token: .zen).startWithResult { _ in
                     called = true
-                })
+                }
                 
                 expect(called).to(beTruthy())
             }
@@ -110,7 +110,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 var message: String?
                 
                 let target: GitHub = .zen
-                provider.request(token: target).startWithResult { (result) -> Void in
+                provider.request(token: target).startWithResult { result in
                     if case .success(let response) = result {
                         message = String(data: response.data, encoding: .utf8)
                     }
@@ -147,10 +147,10 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 }
                 
                 class TestProvider<Target: TargetType>: ReactiveCocoaMoyaProvider<Target> {
-                    init(endpointClosure: @escaping EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-                        requestClosure: @escaping RequestClosure = MoyaProvider.DefaultRequestMapping,
-                        stubClosure: @escaping StubClosure = MoyaProvider.NeverStub,
-                        manager: Manager = MoyaProvider<Target>.DefaultAlamofireManager(),
+                    init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
+                        requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
+                        stubClosure: @escaping StubClosure = MoyaProvider.neverStub,
+                        manager: Manager = MoyaProvider<Target>.defaultAlamofireManager(),
                         plugins: [PluginType] = []) {
 
                             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
@@ -165,13 +165,13 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                 beforeEach {
                     TestCancellable.cancelled = false
                     
-                    provider = TestProvider<GitHub>(stubClosure: MoyaProvider.DelayedStub(1))
+                    provider = TestProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(1))
                 }
                 
                 it("cancels network request when subscription is cancelled") {
                     let target: GitHub = .zen
                     
-                    let disposable = provider.request(token: target).startWithCompleted { () -> Void in
+                    let disposable = provider.request(token: target).startWithCompleted {
                         // Should never be executed
                         fail()
                     }
@@ -186,7 +186,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
             var response: Moya.Response? = nil
             beforeEach {
                 testScheduler = TestScheduler()
-                provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaProvider.ImmediatelyStub, stubScheduler: testScheduler)
+                provider = ReactiveCocoaMoyaProvider<GitHub>(stubClosure: MoyaProvider.immediatelyStub, stubScheduler: testScheduler)
                 provider.request(token: .zen).startWithResult { result in
                     if case .success(let next) = result {
                         response = next
@@ -231,7 +231,7 @@ class ReactiveCocoaMoyaProviderSpec: QuickSpec {
                     }
                 }
 
-                signalProducer2.startWithResult { (result) -> Void in
+                signalProducer2.startWithResult { result in
                     if case .success(let response) = result {
                         expect(receivedResponse).toNot( beNil() )
                         expect(receivedResponse).to( beIdenticalToResponse(response) )

--- a/Source/Moya+Defaults.swift
+++ b/Source/Moya+Defaults.swift
@@ -2,12 +2,12 @@ import Alamofire
 
 /// These functions are default mappings to `MoyaProvider`'s properties: endpoints, requests, manager, etc.
 public extension MoyaProvider {
-    public final class func DefaultEndpointMapping(_ target: Target) -> Endpoint<Target> {
+    public final class func defaultEndpointMapping(_ target: Target) -> Endpoint<Target> {
         let url = target.baseURL.appendingPathComponent(target.path).absoluteString
         return Endpoint(URL: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
     }
 
-    public final class func DefaultRequestMapping(_ endpoint: Endpoint<Target>, closure: RequestResultClosure) {
+    public final class func defaultRequestMapping(_ endpoint: Endpoint<Target>, closure: RequestResultClosure) {
         if let urlRequest = endpoint.urlRequest {
             closure(.success(urlRequest))
         } else {
@@ -15,7 +15,7 @@ public extension MoyaProvider {
         }
     }
 
-    public final class func DefaultAlamofireManager() -> Manager {
+    public final class func defaultAlamofireManager() -> Manager {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = Manager.defaultHTTPHeaders
 

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -55,10 +55,10 @@ open class MoyaProvider<Target: TargetType> {
     open internal(set) var inflightRequests = Dictionary<Endpoint<Target>, [Moya.Completion]>()
 
     /// Initializes a provider.
-    public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-        requestClosure: @escaping RequestClosure = MoyaProvider.DefaultRequestMapping,
-        stubClosure: @escaping StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = MoyaProvider<Target>.DefaultAlamofireManager(),
+    public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
+        requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
+        stubClosure: @escaping StubClosure = MoyaProvider.neverStub,
+        manager: Manager = MoyaProvider<Target>.defaultAlamofireManager(),
         plugins: [PluginType] = [],
         trackInflights: Bool = false) {
 
@@ -119,15 +119,15 @@ public extension MoyaProvider {
     // Swift won't let us put the StubBehavior enum inside the provider class, so we'll
     // at least add some class functions to allow easy access to common stubbing closures.
 
-    public final class func NeverStub(_: Target) -> Moya.StubBehavior {
+    public final class func neverStub(_: Target) -> Moya.StubBehavior {
         return .never
     }
 
-    public final class func ImmediatelyStub(_: Target) -> Moya.StubBehavior {
+    public final class func immediatelyStub(_: Target) -> Moya.StubBehavior {
         return .immediate
     }
 
-    public final class func DelayedStub(_ seconds: TimeInterval) -> (Target) -> Moya.StubBehavior {
+    public final class func delayedStub(_ seconds: TimeInterval) -> (Target) -> Moya.StubBehavior {
         return { _ in return .delayed(seconds: seconds) }
     }
 }

--- a/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
+++ b/Source/ReactiveCocoa/Moya+ReactiveCocoa.swift
@@ -8,10 +8,10 @@ import Moya
 open class ReactiveCocoaMoyaProvider<Target>: MoyaProvider<Target> where Target: TargetType {
     private let stubScheduler: DateSchedulerProtocol?
     /// Initializes a reactive provider.
-    public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-        requestClosure: @escaping RequestClosure = MoyaProvider.DefaultRequestMapping,
-        stubClosure: @escaping StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = ReactiveCocoaMoyaProvider<Target>.DefaultAlamofireManager(),
+    public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
+        requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
+        stubClosure: @escaping StubClosure = MoyaProvider.neverStub,
+        manager: Manager = ReactiveCocoaMoyaProvider<Target>.defaultAlamofireManager(),
         plugins: [PluginType] = [], stubScheduler: DateSchedulerProtocol? = nil,
         trackInflights: Bool = false) {
             self.stubScheduler = stubScheduler

--- a/Source/RxSwift/Moya+RxSwift.swift
+++ b/Source/RxSwift/Moya+RxSwift.swift
@@ -7,10 +7,10 @@ import Moya
 /// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.
 open class RxMoyaProvider<Target>: MoyaProvider<Target> where Target: TargetType {
     /// Initializes a reactive provider.
-    override public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-        requestClosure: @escaping RequestClosure = MoyaProvider.DefaultRequestMapping,
-        stubClosure: @escaping StubClosure = MoyaProvider.NeverStub,
-        manager: Manager = RxMoyaProvider<Target>.DefaultAlamofireManager(),
+    override public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
+        requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
+        stubClosure: @escaping StubClosure = MoyaProvider.neverStub,
+        manager: Manager = RxMoyaProvider<Target>.defaultAlamofireManager(),
         plugins: [PluginType] = [],
         trackInflights: Bool = false) {
             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins, trackInflights: trackInflights)

--- a/docs/Examples/SubclassingProvider.md
+++ b/docs/Examples/SubclassingProvider.md
@@ -9,9 +9,9 @@ Used RxSwift.
 class OnlineProvider: RxMoyaProvider<MyService> {
 
     // First of all, we need to override designated initializer
-    override init(endpointClosure: MoyaProvider<MyService>.EndpointClosure = MoyaProvider.DefaultEndpointMapping,
-        requestClosure: MoyaProvider<MyService>.RequestClosure = MoyaProvider.DefaultRequestMapping,
-        stubClosure: MoyaProvider<MyService>.StubClosure = MoyaProvider.NeverStub,
+    override init(endpointClosure: MoyaProvider<MyService>.EndpointClosure = MoyaProvider.defaultEndpointMapping,
+        requestClosure: MoyaProvider<MyService>.RequestClosure = MoyaProvider.defaultRequestMapping,
+        stubClosure: MoyaProvider<MyService>.StubClosure = MoyaProvider.neverStub,
         manager: Manager = Alamofire.SessionManager.default,
         plugins: [PluginType] = []) {
 

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -53,7 +53,7 @@ initializer anymore, since Swift will infer it from the type of our
 `endpointClosure`. Neat!
 
 This `endpointClosure` is about as simple as you can get. It's actually the
-default implementation, too, stored in `MoyaProvider.DefaultEndpointMapping`.
+default implementation, too, stored in `MoyaProvider.defaultEndpointMapping`.
 Check out the [Endpoints](Endpoints.md) documentation for more on _why_ you
 might want to customize this.
 
@@ -65,7 +65,7 @@ documentation for how and why you'd do this.
 
 ### stubClosure:
 
-The next option is to provide a `stubClosure`. This returns one of either `.Never` (the
+The next option is to provide a `stubClosure`. This returns one of either `.never` (the
 default), `.immediate` or `.delayed(seconds)`, where you can delay the stubbed
 request by a certain number of seconds. For example, `.delayed(0.2)` would delay
 every stubbed request. This can be good for simulating network delays in unit tests.
@@ -85,9 +85,9 @@ But usually you want the same stubbing behavior for all your targets. There are
 three class methods on `MoyaProvider` you can use instead.
 
 ```swift
-MoyaProvider.NeverStub
-MoyaProvider.ImmediatelyStub
-MoyaProvider.DelayedStub(seconds)
+MoyaProvider.neverStub
+MoyaProvider.immediatelyStub
+MoyaProvider.delayedStub(seconds)
 ```
 
 So, in the above example, if you wanted immediate stubbing behavior for all
@@ -95,7 +95,7 @@ targets, either of the following would work.
 
 ```swift
 let provider = MoyaProvider<MyTarget>(stubClosure: { (_: MyTarget) -> Moya.StubBehavior in return .immediate })
-let provider = MoyaProvider<MyTarget>(stubClosure: MoyaProvider.ImmediatelyStub)
+let provider = MoyaProvider<MyTarget>(stubClosure: MoyaProvider.immediatelyStub)
 ```
 
 ### manager:
@@ -103,7 +103,7 @@ let provider = MoyaProvider<MyTarget>(stubClosure: MoyaProvider.ImmediatelyStub)
 Next, there's the `manager` parameter. By default you'll get a custom `Alamofire.Manager` instance with basic configurations.
 
 ```swift
-public final class func DefaultAlamofireManager() -> Manager {
+public final class func defaultAlamofireManager() -> Manager {
     let configuration = URLSessionConfiguration.default
     configuration.httpAdditionalHeaders = Alamofire.Manager.defaultHTTPHeaders
 


### PR DESCRIPTION
As discussed [here](https://github.com/Moya/Moya/pull/719#discussion_r83555707), class funcs mimicking enum cases have now been lowercased.

Please check if I missed any?

I also cleaned up the changelog a bit.