### PR TITLE
Restarts failed code 65 xcodebuild commands.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - brew update ; brew update # Due to a problem with Homebrew, see: https://github.com/Homebrew/brew/issues/991
     - brew install swiftlint
     - bundle install
-    - cd Demo ; bundle exec pod install
+    - cd Demo ; bundle exec pod install --verbose # Verbose to keep CI alive during long Specs repo setups.
 
 test:
   pre:


### PR DESCRIPTION
Every time `xcodebuild` is run on CI, there's a chance the simulator won't start ([example build](https://circleci.com/gh/Moya/Moya/709)). Here's the error message:

```
2016-10-17 11:36:18.717 xcodebuild[8123:27968] Connection peer refused channel request for "dtxproxy:XCTestManager_IDEInterface:XCTestManager_DaemonConnectionInterface"; channel canceled <DTXChannel: 0x7fabb343a9e0>
2016-10-17 11:36:18.721 xcodebuild[8123:26958] Error Domain=IDETestOperationsObserverErrorDomain Code=3 "The operation couldn’t be completed. (DTXProxyChannel error 1.) If you believe this error represents a bug, please attach the log file at /Users/distiller/Library/Developer/Xcode/DerivedData/Demo-eajasjdonmwjombqexluhpxvsaae/Logs/Test/AC08A4B2-3E7C-4F34-9902-1D51939369F7/Session-MoyaTests-iOS-2016-10-17_113457-EHKzKv.log" UserInfo={NSLocalizedDescription=The operation couldn’t be completed. (DTXProxyChannel error 1.) If you believe this error represents a bug, please attach the log file at /Users/distiller/Library/Developer/Xcode/DerivedData/Demo-eajasjdonmwjombqexluhpxvsaae/Logs/Test/AC08A4B2-3E7C-4F34-9902-1D51939369F7/Session-MoyaTests-iOS-2016-10-17_113457-EHKzKv.log}
** TEST FAILED **
```

We run this kind of command several times on CI, compounding the likelihood that someone has to restart it. So let's automate it :tada:

This PR changes the CI script to look for code 65 and retries a build up to three times.