### PR TITLE
Provide default empty implementations for PluginType

### DIFF
--- a/Source/Plugin.swift
+++ b/Source/Plugin.swift
@@ -17,7 +17,7 @@ public protocol PluginType {
 
 public extension PluginType {
     func willSendRequest(_ request: RequestType, target: TargetType) { }
-    func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType){ }
+    func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) { }
 }
 
 /// Request type used by `willSendRequest` plugin function.

--- a/Source/Plugin.swift
+++ b/Source/Plugin.swift
@@ -15,6 +15,11 @@ public protocol PluginType {
     func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType)
 }
 
+public extension PluginType {
+	func willSendRequest(_ request: RequestType, target: TargetType) { }
+	func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType){ }
+}
+
 /// Request type used by `willSendRequest` plugin function.
 public protocol RequestType {
 

--- a/Source/Plugin.swift
+++ b/Source/Plugin.swift
@@ -16,8 +16,8 @@ public protocol PluginType {
 }
 
 public extension PluginType {
-	func willSendRequest(_ request: RequestType, target: TargetType) { }
-	func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType){ }
+    func willSendRequest(_ request: RequestType, target: TargetType) { }
+    func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType){ }
 }
 
 /// Request type used by `willSendRequest` plugin function.


### PR DESCRIPTION
Sometimes a custom`PluginType` doesn't need to do anything in `willSendRequest` or `didReceiveResponse` but has to provide an empty implementation to conform. Adding a default implementation in an extension leaves the custom plugin free to implement either, none, or both functions.

Not quite sure if this is a good idea or not for the framework, but I've found it useful in my Moya-based projects.