### PR TITLE
[CI] Caches pods repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ dependencies:
     - brew install swiftlint
     - bundle install
     - cd Demo ; bundle exec pod install --verbose # Verbose to keep CI alive during long Specs repo setups.
+  cache_directories:
+    - "~/.cocoapods/repos/master"
 
 test:
   pre:


### PR DESCRIPTION
We've been facing a lot of time-out issues when running `bundle exec pod install` in Circle CI.
This is an attempt to fix it (or at least make it happen less often).

Suggested in https://discuss.circleci.com/t/cocoapods-timing-out/7494