### PR TITLE
Add required TargetType protocol method to Basic.md

### DIFF
--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -66,7 +66,10 @@ extension MyService: TargetType {
         }
     }
     var task: Task {
-        return .request
+        switch self {
+            case .zen, .showUser, .createUser, .showAccounts:
+                return .request
+        }
     }
     var multipartBody: [MultipartFormData]? {
         // Optional

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -65,6 +65,9 @@ extension MyService: TargetType {
             return data
         }
     }
+    var task: Task {
+        return .request
+    }
     var multipartBody: [MultipartFormData]? {
         // Optional
         return nil


### PR DESCRIPTION
`public var task: Moya.Task { get }` is now required, this adds it to the setup documentation.