### PR TITLE
updated info about which version to use when using Swift 3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,7 +66,7 @@ you should use for your Swift version.
 For Moya, use the following entry in your Podfile:
 
 ```rb
-pod 'Moya', '8.0.0-beta.2'
+pod 'Moya', '8.0.0-beta.4'
 ```
 
 In any file you'd like to use Moya in, don't forget to


### PR DESCRIPTION
the latest Moya version to use with Swift 3 is  `'8.0.0-beta.4'`, this is now reflected in the `Readme`