### PR TITLE
Alamofire automatic validation configuration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # Next
+# 8.0.0-beta.5
+
+- Added _validate_ option in `TargetType`, to allow enabling Alamofire automatic validation on requests.
 
 # 8.0.0-beta.4
 

--- a/Demo/Demo/GitHubAPI.swift
+++ b/Demo/Demo/GitHubAPI.swift
@@ -55,7 +55,7 @@ extension GitHub: TargetType {
     public var task: Task {
         return .request
     }
-    var validate: Bool {
+    public var validate: Bool {
         switch self {
         case .zen:
             return true

--- a/Demo/Demo/GitHubAPI.swift
+++ b/Demo/Demo/GitHubAPI.swift
@@ -55,6 +55,14 @@ extension GitHub: TargetType {
     public var task: Task {
         return .request
     }
+    var validate: Bool {
+        switch self {
+        case .zen:
+            return true
+        default:
+            return false
+        }
+    }
     public var sampleData: Data {
         switch self {
         case .zen:

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -174,17 +174,20 @@ private extension MoyaProvider {
     }
 
     func sendUploadFile(_ target: Target, request: URLRequest, queue: DispatchQueue?, file: URL, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
-        let alamoRequest = target.validate ? manager.upload(file, with: request).validate() : manager.upload(file, with: request)
+        let uploadRequest = manager.upload(file, with: request)
+        let alamoRequest = target.validate ? uploadRequest.validate() : uploadRequest
         return self.sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
     func sendDownloadRequest(_ target: Target, request: URLRequest, queue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
-        let alamoRequest = target.validate ? manager.download(request, to: destination).validate() : manager.download(request, to: destination)
+        let downloadRequest = manager.download(request, to: destination)
+        let alamoRequest = target.validate ? downloadRequest.validate() : downloadRequest
         return self.sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
     func sendRequest(_ target: Target, request: URLRequest, queue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
-        let alamoRequest = target.validate ? manager.request(request as URLRequestConvertible).validate() : manager.request(request as URLRequestConvertible)
+        let initialRequest = manager.request(request as URLRequestConvertible)
+        let alamoRequest = target.validate ? initialRequest.validate() : initialRequest
         return sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -174,17 +174,17 @@ private extension MoyaProvider {
     }
 
     func sendUploadFile(_ target: Target, request: URLRequest, queue: DispatchQueue?, file: URL, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
-        let alamoRequest = manager.upload(file, with: request)
+        let alamoRequest = target.validate ? manager.upload(file, with: request).validate() : manager.upload(file, with: request)
         return self.sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
     func sendDownloadRequest(_ target: Target, request: URLRequest, queue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
-        let alamoRequest = manager.download(request, to: destination)
+        let alamoRequest = target.validate ? manager.download(request, to: destination).validate() : manager.download(request, to: destination)
         return self.sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 
     func sendRequest(_ target: Target, request: URLRequest, queue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
-        let alamoRequest = manager.request(request as URLRequestConvertible)
+        let alamoRequest = target.validate ? manager.request(request as URLRequestConvertible).validate() : manager.request(request as URLRequestConvertible)
         return sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
     }
 

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -9,7 +9,7 @@ public protocol TargetType {
     var parameters: [String: Any]? { get }
     var sampleData: Data { get }
     var task: Task { get }
-    var validate: Bool { get } // Alamofire validation, optional (defaults to `false`)
+    var validate: Bool { get } // Alamofire validation (defaults to `false`)
 }
 
 public extension TargetType {

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -44,11 +44,11 @@ public enum StructTarget: TargetType {
     public var sampleData: Data {
         return target.sampleData
     }
-    
+
     public var task: Task {
         return target.task
     }
-    
+
     public var validate: Bool {
         return target.validate
     }

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -9,7 +9,7 @@ public protocol TargetType {
     var parameters: [String: Any]? { get }
     var sampleData: Data { get }
     var task: Task { get }
-    var validate: Bool { get } //Alamofire validation, optionnal (default to false)
+    var validate: Bool { get } // Alamofire validation, optional (defaults to `false`)
 }
 
 public extension TargetType {

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -9,6 +9,13 @@ public protocol TargetType {
     var parameters: [String: Any]? { get }
     var sampleData: Data { get }
     var task: Task { get }
+    var validate: Bool { get } //Alamofire validation, optionnal (default to false)
+}
+
+public extension TargetType {
+    var validate: Bool {
+        return false
+    }
 }
 
 public enum StructTarget: TargetType {
@@ -37,8 +44,13 @@ public enum StructTarget: TargetType {
     public var sampleData: Data {
         return target.sampleData
     }
+    
     public var task: Task {
         return target.task
+    }
+    
+    public var validate: Bool {
+        return target.validate
     }
 
     public var target: TargetType {

--- a/docs/Examples/Advanced.md
+++ b/docs/Examples/Advanced.md
@@ -1,0 +1,40 @@
+Advanced
+=======
+
+####Alamofire automatic validation
+Sometimes, you will want to use [Alamofire automatic validation](https://github.com/Alamofire/Alamofire#automatic-validation) for some requests.
+When a request is configured with Alamofire validation, Moya will internally call Alamofire's  `validate()` method on the concerned `DataRequest`.
+
+```swift
+// MARK: - TargetType Protocol Implementation
+extension MyService: TargetType {
+    var baseURL: URL { return URL(string: "https://api.myservice.com")! }
+    var path: String {
+        switch self {
+        case .zen:
+            return "/zen"
+        case .showUser(let id):
+            return "/users/\(id)"
+        case .createUser:
+            return "/users"
+        case .showAccounts:
+              return "/accounts"
+        }
+    }
+    
+    // Other needed configurations
+    // ...
+    
+    // Validate setup is not required; defaults to `false`
+    // for all requests unless specified otherwise.
+    var validate: Bool {
+        switch self {
+        case .zen, .showUser, .showAccounts:
+            return true
+        case .createUser(let firstName, let lastName):
+            return false
+        }
+    }
+}
+```
+Alamofire automatic validation can be useful, for example if you want to use the [Alamofire's `RequestRetrier` and `RequestAdapter`](https://github.com/Alamofire/Alamofire#requestretrier), for an oAuth 2 ready Moya Client.

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -215,6 +215,3 @@ catch {
     // show an error to your user
 }
 ```
-
-
-

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -217,6 +217,7 @@ catch {
 ```
 
 **Alamofire automatic validation**
+
 Sometimes, you will want to use [Alamofire automatic validation](https://github.com/Alamofire/Alamofire#automatic-validation) for some requests.
 When a request is configured with Alamofire validation, Moya will internally call Alamofire's  `validate()` method on the concerned `DataRequest`.
 

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -215,3 +215,40 @@ catch {
     // show an error to your user
 }
 ```
+
+**Alamofire automatic validation**
+Sometimes, you will want to use [Alamofire automatic validation](https://github.com/Alamofire/Alamofire#automatic-validation) for some requests.
+When a request is configured with Alamofire validation, Moya will internally call Alamofire's  `validate()` method on the concerned `DataRequest`.
+
+```swift
+// MARK: - TargetType Protocol Implementation
+extension MyService: TargetType {
+var baseURL: URL { return URL(string: "https://api.myservice.com")! }
+    var path: String {
+        switch self {
+        case .zen:
+            return "/zen"
+        case .showUser(let id):
+            return "/users/\(id)"
+        case .createUser(_, _):
+            return "/users"
+        case .showAccounts:
+              return "/accounts"
+        }
+    }
+    //Other needed configurations
+    //...
+    
+    //validate setup is not required
+    var validate: Bool {
+        switch self {
+        case .zen, .showUser, .showAccounts:
+            return true
+        case .createUser(let firstName, let lastName):
+            return false
+        }
+    }
+}
+```
+Alamofire automatic validation can be useful, for example if you want to use the [Alamofire's `RequestRetrier` and `RequestAdapter`](https://github.com/Alamofire/Alamofire#requestretrier), for an oAuth 2 ready Moya Client.
+

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -216,42 +216,5 @@ catch {
 }
 ```
 
-**Alamofire automatic validation**
 
-Sometimes, you will want to use [Alamofire automatic validation](https://github.com/Alamofire/Alamofire#automatic-validation) for some requests.
-When a request is configured with Alamofire validation, Moya will internally call Alamofire's  `validate()` method on the concerned `DataRequest`.
-
-```swift
-// MARK: - TargetType Protocol Implementation
-extension MyService: TargetType {
-    var baseURL: URL { return URL(string: "https://api.myservice.com")! }
-    var path: String {
-        switch self {
-        case .zen:
-            return "/zen"
-        case .showUser(let id):
-            return "/users/\(id)"
-        case .createUser:
-            return "/users"
-        case .showAccounts:
-              return "/accounts"
-        }
-    }
-    
-    // Other needed configurations
-    // ...
-    
-    // Validate setup is not required; defaults to `false`
-    // for all requests unless specified otherwise.
-    var validate: Bool {
-        switch self {
-        case .zen, .showUser, .showAccounts:
-            return true
-        case .createUser(let firstName, let lastName):
-            return false
-        }
-    }
-}
-```
-Alamofire automatic validation can be useful, for example if you want to use the [Alamofire's `RequestRetrier` and `RequestAdapter`](https://github.com/Alamofire/Alamofire#requestretrier), for an oAuth 2 ready Moya Client.
 

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -224,23 +224,25 @@ When a request is configured with Alamofire validation, Moya will internally cal
 ```swift
 // MARK: - TargetType Protocol Implementation
 extension MyService: TargetType {
-var baseURL: URL { return URL(string: "https://api.myservice.com")! }
+    var baseURL: URL { return URL(string: "https://api.myservice.com")! }
     var path: String {
         switch self {
         case .zen:
             return "/zen"
         case .showUser(let id):
             return "/users/\(id)"
-        case .createUser(_, _):
+        case .createUser:
             return "/users"
         case .showAccounts:
               return "/accounts"
         }
     }
-    //Other needed configurations
-    //...
     
-    //validate setup is not required
+    // Other needed configurations
+    // ...
+    
+    // Validate setup is not required; defaults to `false`
+    // for all requests unless specified otherwise.
     var validate: Bool {
         switch self {
         case .zen, .showUser, .showAccounts:


### PR DESCRIPTION
Sometimes, users will want to use alamofire's automatic validation on some requests. For exemple, when they want to take advantage of the new `RequestRetrier`.
This functionality will allow to optionally configure `Alamofire` validation on some requests (you can see an example in the documentation).
This also solves the `RequestRetrier` issue mentioned in #700 and opened as a separate issue here: #766.

The `Alamofire` validation configuration has been set to `false` by default so that `Moya` users don't have to change their current configuration.
And if `Alamofire` validation configuration is not set up, the behaviour remains the same.