### PR TITLE
Replace remaining multipartBody with task in docs

### DIFF
--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -71,10 +71,6 @@ extension MyService: TargetType {
                 return .request
         }
     }
-    var multipartBody: [MultipartFormData]? {
-        // Optional
-        return nil
-    }
 }
 
 // MARK: - Helpers

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -106,8 +106,10 @@ Finally, our `TargetType` has a `task` property that represents how you are send
 
 ```swift
 public var task: Task {
-  // .request, .upload or .download
-	return .request
+    switch self {
+    case .zen, .userProfile, .userRepositories, .branches:
+        return .request
+    }
 }
 ```
 

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -102,14 +102,12 @@ public var sampleData: Data {
 }
 ```
 
-Finally, our `TargetType` has a `multipartBody` property that can be either
-`nil` or an array of `MultipartFormData`. This allows you to add data,
-files and streams to the request body.
+Finally, our `TargetType` has a `task` property that represents how you are sending / receiving data. This can be either `.request`, `.upload` or `.download`, and allows you to add data, files and streams to the request body.
 
 ```swift
-public var multipartBody: [MultipartFormData]? {
-	// Optional
-	return nil
+public var task: Task {
+  // .request, .upload or .download
+	return .request
 }
 ```
 


### PR DESCRIPTION
Some docs still assume that `TargetType` has a `multipartBody` parameter. This fixed it.