### PR TITLE
Allow plugins to modify requests and responses.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - **Breaking Change** Renamed `ReactiveCocoaMoyaProvider` to `ReactiveSwiftMoyaProvider`.
 - Renamed the `ReactiveCocoa` subspec to `ReactiveSwift`.
+- `PluginType` can now modify requests and responses through `prepareRequest` and `processResponse`
 
 # 8.0.0-beta.5
 

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -200,6 +200,16 @@ class MoyaProviderSpec: QuickSpec {
                 expect(receivedError).toNot( beNil() )
             }
 
+            it("prepares the request using plugins") {
+                waitUntil { done in
+                    let target: GitHub = .userProfile("ashfurrow")
+                    let token = provider.request(target) { _ in
+                        done()
+                    }
+                }
+                expect(plugin.didPrepare).to( beTrue() )
+            }
+
             it("returns success when request is not cancelled") {
                 var receivedError: Swift.Error?
 
@@ -214,6 +224,21 @@ class MoyaProviderSpec: QuickSpec {
                 }
 
                 expect(receivedError).to( beNil() )
+            }
+
+            it("processes the response with plugins") {
+                var receivedStatusCode: Int?
+                waitUntil { done in
+                    let target: GitHub = .userProfile("ashfurrow")
+                    let token = provider.request(target) { result in
+                        if case let .success(response) = result {
+                            receivedStatusCode = response.statusCode
+                        }
+                        done()
+                    }
+                }
+
+                expect(receivedStatusCode).to( equal(-1) )
             }
         }
 

--- a/Demo/Tests/TestPlugin.swift
+++ b/Demo/Tests/TestPlugin.swift
@@ -4,13 +4,35 @@ import Moya
 final class TestingPlugin: PluginType {
     var request: (RequestType, TargetType)?
     var result: Result<Moya.Response, Moya.Error>?
+    var didPrepare = false
+
+    func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
+        var request = request
+        request.addValue("yes", forHTTPHeaderField: "prepared")
+        return request
+    }
 
     func willSendRequest(_ request: RequestType, target: TargetType) {
         self.request = (request, target)
+
+        // We check for whether or not we did prepare here to make sure prepareRequest gets called
+        // before willSendRequest
+        didPrepare = request.request?.allHTTPHeaderFields?["prepared"] == "yes"
     }
 
     func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
         self.result = result
+    }
+
+    func processResponse(_ result: Result<Response, Moya.Error>, target: TargetType) -> Result<Response, Moya.Error> {
+        var result = result
+
+        if case .success(let response) = result {
+            let processedResponse = Response(statusCode: -1, data: response.data, request: response.request, response: response.response)
+            result = .success(processedResponse)
+        }
+
+        return result
     }
     
 } 

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -13,8 +13,7 @@ public extension MoyaProvider {
         let cancellableToken = CancellableWrapper()
 
         // Allow plugins to modify response
-        let pluginsWithCompletion: Moya.Completion = {
-            result in
+        let pluginsWithCompletion: Moya.Completion = { result in
             var result = result
             self.plugins.forEach { result = $0.processResponse(result, target: target) }
             completion(result)

--- a/Source/Plugin.swift
+++ b/Source/Plugin.swift
@@ -8,16 +8,24 @@ import Result
 ///     - hide and show a network activity indicator
 ///     - inject additional information into a request
 public protocol PluginType {
+    /// Called to modify a request before sending
+    func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest
+
     /// Called immediately before a request is sent over the network (or stubbed).
     func willSendRequest(_ request: RequestType, target: TargetType)
 
     /// Called after a response has been received, but before the MoyaProvider has invoked its completion handler.
     func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType)
+
+    /// Called to modify a result before completion
+    func processResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) -> Result<Moya.Response, Moya.Error>
 }
 
 public extension PluginType {
+    func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest { return request }
     func willSendRequest(_ request: RequestType, target: TargetType) { }
     func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) { }
+    func processResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) -> Result<Moya.Response, Moya.Error> { return result }
 }
 
 /// Request type used by `willSendRequest` plugin function.

--- a/docs/Examples/AuthPlugin.md
+++ b/docs/Examples/AuthPlugin.md
@@ -1,0 +1,64 @@
+# Creating an Authorization Plugin
+
+It is relatively common for API requests to be authorized via a JWT (JSON Web
+Token) or another type of access token. In this example we will create a plugin
+that can be used to add a jwt to requests. First let's look at a simple example
+of how we might add a jwt to a request via a plugin:
+
+```swift
+struct AuthPlugin: PluginType {
+  let token: String
+
+  func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
+    var request = request
+    request.addValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    return request
+  }
+}
+
+let provider = MoyaProvider<Target>(plugins: [AuthPlugin(token: "eyeAm.AJsoN.weBTOKen")])
+```
+
+Now let's look at a more complex example where we might not have access to the
+jwt when we create the plugin and not all requests need to be signed. We can
+accomplish this by extending the `TargetType` protocol to provide information on
+whether or not authorization is needed and also taking a closure for providing
+a token.
+
+```swift
+class TokenSource {
+  var token: String? = nil
+  init() { }
+}
+
+protocol AuthorizedTargetType: TargetType {
+  var needsAuth: Bool { get }
+}
+
+struct AuthPlugin: PluginType {
+  let tokenClosure: () -> String?
+
+  func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
+    guard
+      let token = tokenClosure(),
+      let target = target as? AuthorizedTargetType,
+      target.needsAuth
+    else {
+      return request
+    }
+
+    var request = request
+    request.addValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    return request
+  }
+}
+
+let source = TokenSource()
+let provider = MoyaProvider<Target>(
+  plugins: [
+    AuthPlugin(tokenClosure: { return source.token })
+  ]
+)
+
+source.token = "eyeAm.AJsoN.weBTOKen"
+```

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,12 +1,17 @@
 Plugins
 =======
 
-Moya plugins are used modify requests and responses or perform side-effects. A
-plugin is called when:
-- a request is being prepared.
-- a request is about to be sent.
-- a response has been received.
-- a response is being processed.
+Moya plugins are used to modify requests and responses or perform side-effects.
+A plugin is called:
+- (`prepareRequest`) after Moya has resolved the `TargetType` to a `URLRequest`.
+  This is an opportunity to modify the request before it is sent (e.g. add
+  headers).
+- (`willSendRequest`) before a request is about to be sent. This is an
+  opportunity to inspect the request and perform any side-effects (e.g. logging).
+- (`didReceiveResponse`) after a response has been received. This is an
+  opportunity to inspect the response and perform side-effects.
+- (`processResponse`) before `completion` is called with the `Result`. This is
+  an opportunity to make any modifications to the `Result` of the `request`.
 
 ## Built in plugins
 Moya ships with some default plugins which can be used for common functions: authentication, network activity indicator management and logging.

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,11 +1,14 @@
 Plugins
 =======
 
-Moya plugins are used to perform some side effect whenever a request is sent or received. Plugins are defined by the `PluginType` protocol, which can receive callbacks when:
-- a request is going to be sent;
+Moya plugins are used modify requests and responses or perform side-effects. A
+plugin is called when:
+- a request is being prepared.
+- a request is about to be sent.
 - a response has been received.
+- a response is being processed.
 
-##Built in plugins
+## Built in plugins
 Moya ships with some default plugins which can be used for common functions: authentication, network activity indicator management and logging.
 You can use a plugin simply declaring it during the initialization of the provider:
 
@@ -13,24 +16,24 @@ You can use a plugin simply declaring it during the initialization of the provid
 let provider = MoyaProvider<GitHub>(plugins: [NetworkLoggerPlugin(verbose: true)])
 ```
 
-####Authentication
+#### Authentication
 The authentication plugin allows a user to assign an optional `URLCredential` per request. There is no action when a request is received.
 
 The plugin can be found at [`Source/Plugins/CredentialsPlugin.swift`](../Source/Plugins/CredentialsPlugin.swift)
 
-####Network Activity Indicator
+#### Network Activity Indicator
 One very common task with iOS networking is to show a network activity indicator during network requests, and remove it when all requests have finished. The provided plugin adds callbacks which are called when a requests starts and finishes, which can be used to keep track of the number of requests in progress, and show / hide the network activity indicator accordingly.
 
 The plugin can be found at [`Source/Plugins/NetworkActivityPlugin.swift`](../Source/Plugins/NetworkActivityPlugin.swift)
 
-####Logging
+#### Logging
 During development it can be very useful to log network activity to the console. This can be anything from the URL of a request as sent and received, to logging full headers, method, request body on each request and response.
 
 The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initializing the plugin, you can choose options for verbosity, whether to log curl commands, and provide functions for outputting data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `String.Encoding.utf8` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in [`Demo/Demo/GitHubAPI.swift`](../Demo/Demo/GitHubAPI.swift) for an example that does exactly that)
 
 The plugin can be found at [`Source/Plugins/NetworkLoggerPlugin.swift`](../Source/Plugins/NetworkLoggerPlugin.swift)
 
-##Custom plugins
+## Custom plugins
 
 Every time you need to execute some pieces of code before a request is sent and/or immediately after a response, you can create a custom plugin, implementing the `PluginType` protocol.
-For an example of creating a new plugin, see [`docs/Examples/CustomPlugin.md`](Examples/CustomPlugin.md)
+For examples of creating plugins, see [`docs/Examples/CustomPlugin.md`](Examples/CustomPlugin.md) and [`docs/Examples/AuthPlugin.md`](Examples/AuthPlugin.md).


### PR DESCRIPTION
## Purpose

While the endpoint and request closures are useful for modifying requests, they
provide an inconvenient solution for many use cases--notably authentication--for
a number of reasons:
  * Only one closure of each type can be provided, making it less ideal when
    multiple atomic modifications need to be made to a request.
  * Overriding these closures require duplicating the work that the default
    closures do and knowledge of more internal Moya API.
  * It is sometimes ambiguous as to which closure you should choose for your
    task.

## Solution

Plugins can be extended with ability to modify requests and results. This would
bring the concept more in line with the concept of web framework middleware and
provide a convenient interface for Moya users and 3rd party plugin creators.
Ultimately, the ability to interact with requests and responses will make
Plugins much more useful.

To do this, we can add two functions to `PluginType`:
```swift
func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest
func processResponse(_ result: Result<Response, Error>, target: TargetType) -> Result<Response, Error>
```

*Note: function names were chosen to be consistent with existing interface but
there is an opportunity to better conform to the Swift API Guidelines*

These functions are called before `willSendRequest` and after `didReceiveResponse`
respectively. Like the other protocol functions, empty implementations are
provided by default.

## Example

The following is an example of supplying an access token via a plugin and only
authorizing targets that need it.

```swift
protocol AuthorizedTargetType: TargetType {
  var needsAuth: Bool { get }
}

struct AuthPlugin: PluginType {
  let token: String

  func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
    guard let target = target as? AuthorizedTargetType, target.needsAuth else {
      return request
    }

    var request = request
    request.addValue("Bearer " + token, forHTTPHeaderField: "Authorization")
    return request
  }
}

let provider = MoyaProvider<Target>(
  plugins: [
    AuthPlugin(token: "eyeAm.AJsoN.weBTOKen"),
    NetworkLoggerPlugin()
  ]
)
```

## Alternatives Considered

### *Add another closure for simpler request modification*

While this would solve the problem of request modification not being
straightforward, it still wouldn't be clean to chain modifications together.
Also, there wouldn't be a simple interface to encourage 3rd party plugin creation.

### *Make the existing plugin functions capable of modifying request/results*

This would not be easily possible due to the way the `willSendRequest` abstracts
Alamofire's `Request`. In addition, adding the extra lifecycle calls makes it
easier to create consistent behavior (e.g. always log requests after they have
been modified by plugins).
