### PR TITLE
Rename functions in PluginType to comply with design guidelines

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 # Next
 
 - **Breaking Change** Renamed `ReactiveCocoaMoyaProvider` to `ReactiveSwiftMoyaProvider`.
+- **Breaking Change** Renamed `PluginType` functions to comply with Swift 3 design guideline:
+  - `willSendRequest` renamed to `willSend`.
+  - `didReceiveResponse` renamed to `didReceive`.
 - Renamed the `ReactiveCocoa` subspec to `ReactiveSwift`.
-- `PluginType` can now modify requests and responses through `prepareRequest` and `processResponse`
+- `PluginType` can now modify requests and responses through `prepare` and `process`
 
 # 8.0.0-beta.5
 

--- a/Demo/Tests/NetworkLogginPluginSpec.swift
+++ b/Demo/Tests/NetworkLogginPluginSpec.swift
@@ -93,9 +93,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
         }
 
         it("outputs cURL representation of request") {
-
             pluginWithCurl.willSend(TestCurlBodyRequest(), target: GitHub.zen)
-            print(log)
 
             expect(log).to( contain("$ curl -i") )
             expect(log).to( contain("-H \"Content-Type: application/json\"") )

--- a/Demo/Tests/NetworkLogginPluginSpec.swift
+++ b/Demo/Tests/NetworkLogginPluginSpec.swift
@@ -36,7 +36,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
 
         it("outputs all request fields with body") {
 
-            plugin.willSendRequest(TestBodyRequest(), target: GitHub.zen)
+            plugin.willSend(TestBodyRequest(), target: GitHub.zen)
 
             expect(log).to( contain("Request: https://api.github.com/zen") )
             expect(log).to( contain("Request Headers: [\"Content-Type\": \"application/json\"]") )
@@ -46,7 +46,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
 
         it("outputs all request fields with stream") {
 
-            plugin.willSendRequest(TestStreamRequest(), target: GitHub.zen)
+            plugin.willSend(TestStreamRequest(), target: GitHub.zen)
 
             expect(log).to( contain("Request: https://api.github.com/zen") )
             expect(log).to( contain("Request Headers: [\"Content-Type\": \"application/json\"]") )
@@ -56,7 +56,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
 
         it("will output invalid request when reguest is nil") {
 
-            plugin.willSendRequest(TestNilRequest(), target: GitHub.zen)
+            plugin.willSend(TestNilRequest(), target: GitHub.zen)
 
             expect(log).to( contain("Request: (invalid request)") )
         }
@@ -65,7 +65,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
             let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: URLResponse(url: URL(string: url(GitHub.zen))!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
             let result: Result<Moya.Response, Moya.Error> = .success(response)
 
-            plugin.didReceiveResponse(result, target: GitHub.zen)
+            plugin.didReceive(result, target: GitHub.zen)
 
             expect(log).to( contain("Response:") )
             expect(log).to( contain("{ URL: https://api.github.com/zen }") )
@@ -76,7 +76,7 @@ final class NetworkLogginPluginSpec: QuickSpec {
             let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: URLResponse(url: URL(string: url(GitHub.zen))!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
             let result: Result<Moya.Response, Moya.Error> = .success(response)
 
-            pluginWithResponseDataFormatter.didReceiveResponse(result, target: GitHub.zen)
+            pluginWithResponseDataFormatter.didReceive(result, target: GitHub.zen)
 
             expect(log).to( contain("Response:") )
             expect(log).to( contain("{ URL: https://api.github.com/zen }") )
@@ -87,14 +87,14 @@ final class NetworkLogginPluginSpec: QuickSpec {
             let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: nil)
             let result: Result<Moya.Response, Moya.Error> = .failure(Moya.Error.data(response))
 
-            plugin.didReceiveResponse(result, target: GitHub.zen)
+            plugin.didReceive(result, target: GitHub.zen)
 
             expect(log).to( contain("Response: Received empty network response for zen.") )
         }
 
         it("outputs cURL representation of request") {
 
-            pluginWithCurl.willSendRequest(TestCurlBodyRequest(), target: GitHub.zen)
+            pluginWithCurl.willSend(TestCurlBodyRequest(), target: GitHub.zen)
             print(log)
 
             expect(log).to( contain("$ curl -i") )

--- a/Demo/Tests/TestPlugin.swift
+++ b/Demo/Tests/TestPlugin.swift
@@ -6,25 +6,25 @@ final class TestingPlugin: PluginType {
     var result: Result<Moya.Response, Moya.Error>?
     var didPrepare = false
 
-    func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
+    func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
         var request = request
         request.addValue("yes", forHTTPHeaderField: "prepared")
         return request
     }
 
-    func willSendRequest(_ request: RequestType, target: TargetType) {
+    func willSend(_ request: RequestType, target: TargetType) {
         self.request = (request, target)
 
-        // We check for whether or not we did prepare here to make sure prepareRequest gets called
-        // before willSendRequest
+        // We check for whether or not we did prepare here to make sure prepare gets called
+        // before willSend
         didPrepare = request.request?.allHTTPHeaderFields?["prepared"] == "yes"
     }
 
-    func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
+    func didReceive(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
         self.result = result
     }
 
-    func processResponse(_ result: Result<Response, Moya.Error>, target: TargetType) -> Result<Response, Moya.Error> {
+    func process(_ result: Result<Response, Moya.Error>, target: TargetType) -> Result<Response, Moya.Error> {
         var result = result
 
         if case .success(let response) = result {

--- a/Source/Plugin.swift
+++ b/Source/Plugin.swift
@@ -9,26 +9,26 @@ import Result
 ///     - inject additional information into a request
 public protocol PluginType {
     /// Called to modify a request before sending
-    func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest
+    func prepare(_ request: URLRequest, target: TargetType) -> URLRequest
 
     /// Called immediately before a request is sent over the network (or stubbed).
-    func willSendRequest(_ request: RequestType, target: TargetType)
+    func willSend(_ request: RequestType, target: TargetType)
 
     /// Called after a response has been received, but before the MoyaProvider has invoked its completion handler.
-    func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType)
+    func didReceive(_ result: Result<Moya.Response, Moya.Error>, target: TargetType)
 
     /// Called to modify a result before completion
-    func processResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) -> Result<Moya.Response, Moya.Error>
+    func process(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) -> Result<Moya.Response, Moya.Error>
 }
 
 public extension PluginType {
-    func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest { return request }
-    func willSendRequest(_ request: RequestType, target: TargetType) { }
-    func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) { }
-    func processResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) -> Result<Moya.Response, Moya.Error> { return result }
+    func prepare(_ request: URLRequest, target: TargetType) -> URLRequest { return request }
+    func willSend(_ request: RequestType, target: TargetType) { }
+    func didReceive(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) { }
+    func process(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) -> Result<Moya.Response, Moya.Error> { return result }
 }
 
-/// Request type used by `willSendRequest` plugin function.
+/// Request type used by `willSend` plugin function.
 public protocol RequestType {
 
     // Note:

--- a/Source/Plugins/CredentialsPlugin.swift
+++ b/Source/Plugins/CredentialsPlugin.swift
@@ -13,13 +13,9 @@ public final class CredentialsPlugin: PluginType {
 
     // MARK: Plugin
 
-    public func willSendRequest(_ request: RequestType, target: TargetType) {
+    public func willSend(_ request: RequestType, target: TargetType) {
         if let credentials = credentialsClosure(target) {
             _ = request.authenticate(usingCredential: credentials)
         }
-    }
-
-    public func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
-
     }
 }

--- a/Source/Plugins/NetworkActivityPlugin.swift
+++ b/Source/Plugins/NetworkActivityPlugin.swift
@@ -19,12 +19,12 @@ public final class NetworkActivityPlugin: PluginType {
     // MARK: Plugin
 
     /// Called by the provider as soon as the request is about to start
-    public func willSendRequest(_ request: RequestType, target: TargetType) {
+    public func willSend(_ request: RequestType, target: TargetType) {
         networkActivityClosure(.began)
     }
 
     /// Called by the provider as soon as a response arrives, even if the request is cancelled.
-    public func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
+    public func didReceive(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
         networkActivityClosure(.ended)
     }
 }

--- a/Source/Plugins/NetworkLoggerPlugin.swift
+++ b/Source/Plugins/NetworkLoggerPlugin.swift
@@ -23,7 +23,7 @@ public final class NetworkLoggerPlugin: PluginType {
         self.responseDataFormatter = responseDataFormatter
     }
 
-    public func willSendRequest(_ request: RequestType, target: TargetType) {
+    public func willSend(_ request: RequestType, target: TargetType) {
         if let request = request as? CustomDebugStringConvertible, cURL {
             output(separator, terminator, request.debugDescription)
             return
@@ -31,7 +31,7 @@ public final class NetworkLoggerPlugin: PluginType {
         outputItems(logNetworkRequest(request.request as URLRequest?))
     }
 
-    public func didReceiveResponse(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
+    public func didReceive(_ result: Result<Moya.Response, Moya.Error>, target: TargetType) {
         if case .success(let response) = result {
             outputItems(logNetworkResponse(response.response, data: response.data, target: target))
         } else {

--- a/docs/Examples/AuthPlugin.md
+++ b/docs/Examples/AuthPlugin.md
@@ -9,7 +9,7 @@ of how we might add a jwt to a request via a plugin:
 struct AuthPlugin: PluginType {
   let token: String
 
-  func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
+  func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
     var request = request
     request.addValue("Bearer " + token, forHTTPHeaderField: "Authorization")
     return request
@@ -38,7 +38,7 @@ protocol AuthorizedTargetType: TargetType {
 struct AuthPlugin: PluginType {
   let tokenClosure: () -> String?
 
-  func prepareRequest(_ request: URLRequest, target: TargetType) -> URLRequest {
+  func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
     guard
       let token = tokenClosure(),
       let target = target as? AuthorizedTargetType,

--- a/docs/Examples/CustomPlugin.md
+++ b/docs/Examples/CustomPlugin.md
@@ -14,11 +14,11 @@ final class RequestAlertPlugin: PluginType {
         self.viewController = viewController
     }
 
-    func willSendRequest(request: RequestType, target: TargetType) {
+    func willSend(request: RequestType, target: TargetType) {
 
     }
 
-    func didReceiveResponse(result: Result<Response, Error>, target: TargetType) {
+    func didReceive(result: Result<Response, Error>, target: TargetType) {
 
     }
 }
@@ -27,7 +27,7 @@ final class RequestAlertPlugin: PluginType {
 Then we add some functionality to the function called when a request will be sent:
 
 ```swift
-func willSendRequest(request: RequestType, target: TargetType) {
+func willSend(request: RequestType, target: TargetType) {
 
     //make sure we have a URL string to display
     guard let requestURLString = request.request?.url?.absoluteString else { return }
@@ -41,10 +41,10 @@ func willSendRequest(request: RequestType, target: TargetType) {
 }
 ```
 
-Finally, let's implement `didReceiveResponse` to show an alert if the result was a failure
+Finally, let's implement `didReceive` to show an alert if the result was a failure
 
 ```swift
-func didReceiveResponse(result: Result<Response, Error>, target: TargetType) {
+func didReceive(result: Result<Response, Error>, target: TargetType) {
 
     //only continue if result is a failure
     guard case Result.failure(_) = result else { return }

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -3,14 +3,14 @@ Plugins
 
 Moya plugins are used to modify requests and responses or perform side-effects.
 A plugin is called:
-- (`prepareRequest`) after Moya has resolved the `TargetType` to a `URLRequest`.
+- (`prepare`) after Moya has resolved the `TargetType` to a `URLRequest`.
   This is an opportunity to modify the request before it is sent (e.g. add
   headers).
-- (`willSendRequest`) before a request is about to be sent. This is an
+- (`willSend`) before a request is about to be sent. This is an
   opportunity to inspect the request and perform any side-effects (e.g. logging).
-- (`didReceiveResponse`) after a response has been received. This is an
+- (`didReceive`) after a response has been received. This is an
   opportunity to inspect the response and perform side-effects.
-- (`processResponse`) before `completion` is called with the `Result`. This is
+- (`process`) before `completion` is called with the `Result`. This is
   an opportunity to make any modifications to the `Result` of the `request`.
 
 ## Built in plugins

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -157,12 +157,12 @@ public final class NetworkActivityPlugin: PluginType {
     // MARK: Plugin
 
     /// Called by the provider as soon as the request is about to start
-    public func willSendRequest(request: RequestType, target: TargetType) {
+    public func willSend(request: RequestType, target: TargetType) {
         networkActivityClosure(change: .began)
     }
 
     /// Called by the provider as soon as a response arrives
-    public func didReceiveResponse(data: Data?, statusCode: Int?, response: URLResponse?, error: ErrorType?, target: TargetType) {
+    public func didReceive(data: Data?, statusCode: Int?, response: URLResponse?, error: ErrorType?, target: TargetType) {
         networkActivityClosure(change: .ended)
     }
 }


### PR DESCRIPTION
`willSendRequest` renamed to `willSend`.
`didReceiveResponse` renamed to `didReceive`.
`prepareRequest ` renamed to `prepare`.
`processResponse` renamed to `process`.