### PR TITLE
Rename functions to comply with Swift 3 guidelines

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Next
 
 - **Breaking Change** Renamed `ReactiveCocoaMoyaProvider` to `ReactiveSwiftMoyaProvider`.
+- **Breaking Change** Renamed `filterStatusCodes(:)` to `filterStatusCodes(in:)`.
+- **Breaking Change** Renamed `request(token:)` to simply `request(:_)` (ReactiveSwift).
+- **Breaking Change** Renamed `notifyPluginsOfImpendingStub(request:)` to `notifyPluginsOfImpendingStub(for:)`.
 - Renamed the `ReactiveCocoa` subspec to `ReactiveSwift`.
 - `PluginType` can now modify requests and responses through `prepareRequest` and `processResponse`
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Next
 
 - **Breaking Change** Renamed `ReactiveCocoaMoyaProvider` to `ReactiveSwiftMoyaProvider`.
-- **Breaking Change** Renamed `filterStatusCodes(:)` to `filter(statusCodes:)`.
+- **Breaking Change** Renamed `filterStatusCodes(:)` to `filter(statusCodes:)` (and `filterStatusCode(:)` to `filter(statusCode:)`).
 - **Breaking Change** Renamed `request(token:)` to simply `request(:_)` (ReactiveSwift).
 - **Breaking Change** Renamed `notifyPluginsOfImpendingStub(request:)` to `notifyPluginsOfImpendingStub(for:)`.
 - Renamed the `ReactiveCocoa` subspec to `ReactiveSwift`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Next
 
 - **Breaking Change** Renamed `ReactiveCocoaMoyaProvider` to `ReactiveSwiftMoyaProvider`.
-- **Breaking Change** Renamed `filterStatusCodes(:)` to `filterStatusCodes(in:)`.
+- **Breaking Change** Renamed `filterStatusCodes(:)` to `filter(statusCodes:)`.
 - **Breaking Change** Renamed `request(token:)` to simply `request(:_)` (ReactiveSwift).
 - **Breaking Change** Renamed `notifyPluginsOfImpendingStub(request:)` to `notifyPluginsOfImpendingStub(for:)`.
 - Renamed the `ReactiveCocoa` subspec to `ReactiveSwift`.

--- a/Demo/Tests/MoyaProviderIntegrationTests.swift
+++ b/Demo/Tests/MoyaProviderIntegrationTests.swift
@@ -238,7 +238,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                     var message: String?
 
                     waitUntil { done in
-                        provider.request(token: .zen).startWithResult { result in
+                        provider.request(.zen).startWithResult { result in
                             if case .success(let response) = result {
                                 message = String(data: response.data, encoding: String.Encoding.utf8)
                                 done()
@@ -254,7 +254,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
 
                     waitUntil { done in
                         let target: GitHub = .userProfile("ashfurrow")
-                        provider.request(token: target).startWithResult { result in
+                        provider.request(target).startWithResult { result in
                             if case .success(let response) = result {
                                 message = String(data: response.data, encoding: String.Encoding.utf8)
                                 done()

--- a/Demo/Tests/Observable+MoyaSpec.swift
+++ b/Demo/Tests/Observable+MoyaSpec.swift
@@ -37,7 +37,7 @@ class ObservableMoyaSpec: QuickSpec {
                 let observable = observableSendingData(data, statusCode: 10)
                 
                 var errored = false
-                _ = observable.filterStatusCodes(0...9).subscribe { (event) -> Void in
+                _ = observable.filterStatusCodes(in: 0...9).subscribe { (event) -> Void in
                     switch event {
                     case .next(let object):
                         fail("called on non-correct status code: \(object)")

--- a/Demo/Tests/Observable+MoyaSpec.swift
+++ b/Demo/Tests/Observable+MoyaSpec.swift
@@ -37,7 +37,7 @@ class ObservableMoyaSpec: QuickSpec {
                 let observable = observableSendingData(data, statusCode: 10)
                 
                 var errored = false
-                _ = observable.filterStatusCodes(0...9).subscribe { event in
+                _ = observable.filter(statusCodes: 0...9).subscribe { event in
                     switch event {
                     case .next(let object):
                         fail("called on non-correct status code: \(object)")
@@ -131,7 +131,7 @@ class ObservableMoyaSpec: QuickSpec {
                 let observable = observableSendingData(data, statusCode: 42)
                 
                 var called = false
-                _ = observable.filterStatusCode(42).subscribe(onNext: { object in
+                _ = observable.filter(statusCode: 42).subscribe(onNext: { object in
                     called = true
                 })
                 
@@ -143,7 +143,7 @@ class ObservableMoyaSpec: QuickSpec {
                 let observable = observableSendingData(data, statusCode: 43)
                 
                 var errored = false
-                _ = observable.filterStatusCode(42).subscribe { event in
+                _ = observable.filter(statusCode: 42).subscribe { event in
                     switch event {
                     case .next(let object):
                         fail("called on non-success status code: \(object)")

--- a/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
@@ -23,7 +23,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var receivedError: Moya.Error?
                 
                 waitUntil { done in
-                    provider.request(token: .zen).startWithFailed { (error) -> Void in
+                    provider.request(.zen).startWithFailed { (error) -> Void in
                         receivedError = error
                         done()
                     }
@@ -41,7 +41,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var errored = false
                 
                 let target: GitHub = .zen
-                provider.request(token: target).startWithFailed { (error) -> Void in
+                provider.request(target).startWithFailed { (error) -> Void in
                     errored = true
                 }
                 
@@ -84,7 +84,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
             it("cancels network request when subscription is cancelled") {
                 let target: GitHub = .zen
 
-                let disposable = provider.request(token: target).startWithCompleted {
+                let disposable = provider.request(target).startWithCompleted {
                     // Should never be executed
                     fail()
                 }
@@ -99,7 +99,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
             it("returns a Response object") {
                 var called = false
                 
-                provider.request(token: .zen).startWithResult { _ in
+                provider.request(.zen).startWithResult { _ in
                     called = true
                 }
                 
@@ -110,7 +110,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var message: String?
                 
                 let target: GitHub = .zen
-                provider.request(token: target).startWithResult { result in
+                provider.request(target).startWithResult { result in
                     if case .success(let response) = result {
                         message = String(data: response.data, encoding: .utf8)
                     }
@@ -124,7 +124,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var receivedResponse: NSDictionary?
                 
                 let target: GitHub = .userProfile("ashfurrow")
-                provider.request(token: target).startWithResult { (result) -> Void in
+                provider.request(target).startWithResult { (result) -> Void in
                     if case .success(let response) = result {
                         receivedResponse = try! JSONSerialization.jsonObject(with: response.data, options: []) as? NSDictionary
                     }
@@ -171,7 +171,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 it("cancels network request when subscription is cancelled") {
                     let target: GitHub = .zen
                     
-                    let disposable = provider.request(token: target).startWithCompleted {
+                    let disposable = provider.request(target).startWithCompleted {
                         // Should never be executed
                         fail()
                     }
@@ -187,7 +187,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
             beforeEach {
                 testScheduler = TestScheduler()
                 provider = ReactiveSwiftMoyaProvider<GitHub>(stubClosure: MoyaProvider.immediatelyStub, stubScheduler: testScheduler)
-                provider.request(token: .zen).startWithResult { result in
+                provider.request(.zen).startWithResult { result in
                     if case .success(let next) = result {
                         response = next
                     }
@@ -217,8 +217,8 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
 
             it("returns identical signalproducers for inflight requests") {
                 let target: GitHub = .zen
-                let signalProducer1: SignalProducer<Moya.Response, Moya.Error> = provider.request(token: target)
-                let signalProducer2: SignalProducer<Moya.Response, Moya.Error> = provider.request(token: target)
+                let signalProducer1: SignalProducer<Moya.Response, Moya.Error> = provider.request(target)
+                let signalProducer2: SignalProducer<Moya.Response, Moya.Error> = provider.request(target)
 
                 expect(provider.inflightRequests.keys.count).to( equal(0) )
 

--- a/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
+++ b/Demo/Tests/ReactiveCocoaMoyaProviderTests.swift
@@ -23,7 +23,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var receivedError: Moya.Error?
                 
                 waitUntil { done in
-                    provider.request(token: .zen).startWithFailed { error in
+                    provider.request(.zen).startWithFailed { error in
                         receivedError = error
                         done()
                     }
@@ -41,7 +41,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var errored = false
                 
                 let target: GitHub = .zen
-                provider.request(token: target).startWithFailed { error in
+                provider.request(target).startWithFailed { error in
                     errored = true
                 }
                 
@@ -124,7 +124,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 var receivedResponse: NSDictionary?
                 
                 let target: GitHub = .userProfile("ashfurrow")
-                provider.request(token: target).startWithResult { result in
+                provider.request(target).startWithResult { result in
                     if case .success(let response) = result {
                         receivedResponse = try! JSONSerialization.jsonObject(with: response.data, options: []) as? NSDictionary
                     }

--- a/Demo/Tests/SignalProducer+MoyaSpec.swift
+++ b/Demo/Tests/SignalProducer+MoyaSpec.swift
@@ -38,7 +38,7 @@ class SignalProducerMoyaSpec: QuickSpec {
                 let signal = signalSendingData(data, statusCode: 10)
                 
                 var errored = false
-                signal.filterStatusCodes(range: 0...9).startWithResult { event in
+                signal.filter(statusCodes: 0...9).startWithResult { event in
                     switch event {
                     case .success(let object):
                         fail("called on non-correct status code: \(object)")
@@ -125,7 +125,7 @@ class SignalProducerMoyaSpec: QuickSpec {
                 let signal = signalSendingData(data, statusCode: 42)
                 
                 var called = false
-                signal.filterStatusCode(code: 42).startWithResult { _ in
+                signal.filter(statusCode: 42).startWithResult { _ in
                     called = true
                 }
                 
@@ -137,7 +137,7 @@ class SignalProducerMoyaSpec: QuickSpec {
                 let signal = signalSendingData(data, statusCode: 43)
                 
                 var errored = false
-                signal.filterStatusCode(code: 42).startWithResult { result in
+                signal.filter(statusCode: 42).startWithResult { result in
                     switch result {
                     case .success(let object):
                         fail("called on non-success status code: \(object)")

--- a/Demo/Tests/SignalProducer+MoyaSpec.swift
+++ b/Demo/Tests/SignalProducer+MoyaSpec.swift
@@ -38,7 +38,7 @@ class SignalProducerMoyaSpec: QuickSpec {
                 let signal = signalSendingData(data, statusCode: 10)
                 
                 var errored = false
-                signal.filterStatusCodes(range: 0...9).startWithResult { event -> Void in
+                signal.filterStatusCodes(in: 0...9).startWithResult { event -> Void in
                     switch event {
                     case .success(let object):
                         fail("called on non-correct status code: \(object)")

--- a/Source/Endpoint.swift
+++ b/Source/Endpoint.swift
@@ -58,13 +58,13 @@ open class Endpoint<Target> {
 
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
     open func adding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
-        let newParameters = addParameters(parameters)
-        let newHTTPHeaderFields = addHTTPHeaderFields(httpHeaderFields)
+        let newParameters = add(parameters: parameters)
+        let newHTTPHeaderFields = add(httpHeaderFields: httpHeaderFields)
         let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
         return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
     }
 
-    fileprivate func addParameters(_ parameters: [String: Any]?) -> [String: Any]? {
+    fileprivate func add(parameters: [String: Any]?) -> [String: Any]? {
         guard let unwrappedParameters = parameters, unwrappedParameters.isEmpty == false else {
             return self.parameters
         }
@@ -76,7 +76,7 @@ open class Endpoint<Target> {
         return newParameters
     }
 
-    fileprivate func addHTTPHeaderFields(_ headers: [String: String]?) -> [String: String]? {
+    fileprivate func add(httpHeaderFields headers: [String: String]?) -> [String: String]? {
         guard let unwrappedHeaders = headers, unwrappedHeaders.isEmpty == false else {
             return self.httpHeaderFields
         }

--- a/Source/Moya+Defaults.swift
+++ b/Source/Moya+Defaults.swift
@@ -2,12 +2,12 @@ import Alamofire
 
 /// These functions are default mappings to `MoyaProvider`'s properties: endpoints, requests, manager, etc.
 public extension MoyaProvider {
-    public final class func defaultEndpointMapping(_ target: Target) -> Endpoint<Target> {
+    public final class func defaultEndpointMapping(for target: Target) -> Endpoint<Target> {
         let url = target.baseURL.appendingPathComponent(target.path).absoluteString
         return Endpoint(url: url, sampleResponseClosure: { .networkResponse(200, target.sampleData) }, method: target.method, parameters: target.parameters)
     }
 
-    public final class func defaultRequestMapping(_ endpoint: Endpoint<Target>, closure: RequestResultClosure) {
+    public final class func defaultRequestMapping(for endpoint: Endpoint<Target>, closure: RequestResultClosure) {
         if let urlRequest = endpoint.urlRequest {
             closure(.success(urlRequest))
         } else {

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -133,7 +133,7 @@ public extension MoyaProvider {
     }
 
     /// Notify all plugins that a stub is about to be performed. You must call this if overriding `stubRequest`.
-    final func notifyPluginsOfImpendingStub(_ request: URLRequest, target: Target) {
+    final func notifyPluginsOfImpendingStub(for request: URLRequest, target: Target) {
         let alamoRequest = manager.request(request as URLRequestConvertible)
         plugins.forEach { $0.willSendRequest(alamoRequest, target: target) }
     }

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -91,7 +91,7 @@ open class MoyaProvider<Target: TargetType> {
     @discardableResult
     open func stubRequest(_ target: Target, request: URLRequest, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
         let cancellableToken = CancellableToken { }
-        notifyPluginsOfImpendingStub(request, target: target)
+        notifyPluginsOfImpendingStub(for: request, target: target)
         let plugins = self.plugins
         let stub: () -> () = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
         switch stubBehavior {

--- a/Source/ReactiveSwift/Moya+ReactiveSwift.swift
+++ b/Source/ReactiveSwift/Moya+ReactiveSwift.swift
@@ -44,7 +44,7 @@ open class ReactiveSwiftMoyaProvider<Target>: MoyaProvider<Target> where Target:
         guard let stubScheduler = self.stubScheduler else {
             return super.stubRequest(target, request: request, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
         }
-        notifyPluginsOfImpendingStub(request, target: target)
+        notifyPluginsOfImpendingStub(for: request, target: target)
         var dis: Disposable? = .none
         let token = CancellableToken {
             dis?.dispose()

--- a/Source/ReactiveSwift/Moya+ReactiveSwift.swift
+++ b/Source/ReactiveSwift/Moya+ReactiveSwift.swift
@@ -19,7 +19,7 @@ open class ReactiveSwiftMoyaProvider<Target>: MoyaProvider<Target> where Target:
     }
 
     /// Designated request-making method.
-    open func request(token: Target) -> SignalProducer<Response, Moya.Error> {
+    open func request(_ token: Target) -> SignalProducer<Response, Moya.Error> {
 
         // Creates a producer that starts a request each time it's started.
         return SignalProducer { [weak self] observer, requestDisposable in
@@ -65,7 +65,7 @@ open class ReactiveSwiftMoyaProvider<Target>: MoyaProvider<Target> where Target:
 }
 
 public extension ReactiveSwiftMoyaProvider {
-    public func requestWithProgress(token: Target) -> SignalProducer<ProgressResponse, Moya.Error> {
+    public func requestWithProgress(_ token: Target) -> SignalProducer<ProgressResponse, Moya.Error> {
         let progressBlock = { (observer: Signal<ProgressResponse, Moya.Error>.Observer) -> (ProgressResponse) -> Void in
             return { progress in
                 observer.send(value: progress)

--- a/Source/ReactiveSwift/SignalProducer+Moya.swift
+++ b/Source/ReactiveSwift/SignalProducer+Moya.swift
@@ -8,15 +8,15 @@ import Moya
 extension SignalProducerProtocol where Value == Response, Error == Moya.Error {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filterStatusCodes(in range: ClosedRange<Int>) -> SignalProducer<Value, Error> {
+    public func filter(statusCodes: ClosedRange<Int>) -> SignalProducer<Value, Error> {
         return producer.flatMap(.latest) { response -> SignalProducer<Value, Error> in
-            return unwrapThrowable { try response.filterStatusCodes(in: range) }
+            return unwrapThrowable { try response.filter(statusCodes: statusCodes) }
         }
     }
 
-    public func filterStatusCode(code: Int) -> SignalProducer<Value, Moya.Error> {
+    public func filter(statusCode: Int) -> SignalProducer<Value, Moya.Error> {
         return producer.flatMap(.latest) { response -> SignalProducer<Value, Error> in
-            return unwrapThrowable { try response.filterStatusCode(code) }
+            return unwrapThrowable { try response.filter(statusCode: statusCode) }
         }
     }
 

--- a/Source/ReactiveSwift/SignalProducer+Moya.swift
+++ b/Source/ReactiveSwift/SignalProducer+Moya.swift
@@ -8,9 +8,9 @@ import Moya
 extension SignalProducerProtocol where Value == Response, Error == Moya.Error {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filterStatusCodes(range: ClosedRange<Int>) -> SignalProducer<Value, Error> {
+    public func filterStatusCodes(in range: ClosedRange<Int>) -> SignalProducer<Value, Error> {
         return producer.flatMap(.latest) { response -> SignalProducer<Value, Error> in
-            return unwrapThrowable { try response.filterStatusCodes(range) }
+            return unwrapThrowable { try response.filterStatusCodes(in: range) }
         }
     }
 

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -31,23 +31,23 @@ public final class Response: CustomDebugStringConvertible, Equatable {
 public extension Response {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filterStatusCodes(in range: ClosedRange<Int>) throws -> Response {
-        guard range.contains(statusCode) else {
+    public func filter(statusCodes: ClosedRange<Int>) throws -> Response {
+        guard statusCodes.contains(statusCode) else {
             throw Error.statusCode(self)
         }
         return self
     }
 
-    public func filterStatusCode(_ code: Int) throws -> Response {
-        return try filterStatusCodes(in: code...code)
+    public func filter(statusCode: Int) throws -> Response {
+        return try filter(statusCodes: statusCode...statusCode)
     }
 
     public func filterSuccessfulStatusCodes() throws -> Response {
-        return try filterStatusCodes(in: 200...299)
+        return try filter(statusCodes: 200...299)
     }
 
     public func filterSuccessfulStatusAndRedirectCodes() throws -> Response {
-        return try filterStatusCodes(in: 200...399)
+        return try filter(statusCodes: 200...399)
     }
 
     /// Maps data received from the signal into a UIImage.

--- a/Source/Response.swift
+++ b/Source/Response.swift
@@ -31,7 +31,7 @@ public final class Response: CustomDebugStringConvertible, Equatable {
 public extension Response {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filterStatusCodes(_ range: ClosedRange<Int>) throws -> Response {
+    public func filterStatusCodes(in range: ClosedRange<Int>) throws -> Response {
         guard range.contains(statusCode) else {
             throw Error.statusCode(self)
         }
@@ -39,15 +39,15 @@ public extension Response {
     }
 
     public func filterStatusCode(_ code: Int) throws -> Response {
-        return try filterStatusCodes(code...code)
+        return try filterStatusCodes(in: code...code)
     }
 
     public func filterSuccessfulStatusCodes() throws -> Response {
-        return try filterStatusCodes(200...299)
+        return try filterStatusCodes(in: 200...299)
     }
 
     public func filterSuccessfulStatusAndRedirectCodes() throws -> Response {
-        return try filterStatusCodes(200...399)
+        return try filterStatusCodes(in: 200...399)
     }
 
     /// Maps data received from the signal into a UIImage.

--- a/Source/RxSwift/Observable+Moya.swift
+++ b/Source/RxSwift/Observable+Moya.swift
@@ -8,15 +8,15 @@ import Moya
 extension ObservableType where E == Response {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filterStatusCodes(in range: ClosedRange<Int>) -> Observable<E> {
+    public func filter(statusCodes: ClosedRange<Int>) -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filterStatusCodes(in: range))
+            return Observable.just(try response.filter(statusCodes: statusCodes))
         }
     }
 
-    public func filterStatusCode(_ code: Int) -> Observable<E> {
+    public func filter(statusCode: Int) -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filterStatusCode(code))
+            return Observable.just(try response.filter(statusCode: statusCode))
         }
     }
 

--- a/Source/RxSwift/Observable+Moya.swift
+++ b/Source/RxSwift/Observable+Moya.swift
@@ -8,9 +8,9 @@ import Moya
 extension ObservableType where E == Response {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filterStatusCodes(_ range: ClosedRange<Int>) -> Observable<E> {
+    public func filterStatusCodes(in range: ClosedRange<Int>) -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filterStatusCodes(range))
+            return Observable.just(try response.filterStatusCodes(in: range))
         }
     }
 

--- a/docs/ReactiveSwift.md
+++ b/docs/ReactiveSwift.md
@@ -50,10 +50,10 @@ To make things even awesomer, Moya provides some extensions to
 `SignalProducer` (and `RACSignal`) that make dealing with `Moya.Responses`
 really easy.
 
-- `filterStatusCodes()` takes a range of status codes. If the
+- `filter(statusCodes:)` takes a range of status codes. If the
   response's status code is not within that range, an error is
   produced.
-- `filterStatusCode()` looks for a specific status code, and errors
+- `filter(statusCode:)` looks for a specific status code, and errors
   if it finds anything else.
 - `filterSuccessfulStatusCodes()` filters status codes that
   are in the 200-range.

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -48,10 +48,10 @@ you like in `subscribeNext` or `map` calls.
 To make things even awesomer, Moya provides some extensions to
 `Observable` that make dealing with `MoyaResponses`really easy.
 
-- `filterStatusCodes()` takes a range of status codes. If the
+- `filter(statusCodes:)` takes a range of status codes. If the
   response's status code is not within that range, an error is
   produced.
-- `filterStatusCode()` looks for a specific status code, and errors
+- `filter(statusCode:)` looks for a specific status code, and errors
   if it finds anything else.
 - `filterSuccessfulStatusCodes()` filters status codes that
   are in the 200-range.


### PR DESCRIPTION
This renames some functions to better comply with the Swift 3 guidelines, as well as unifying the RxSwift and ReactiveSwift functions