### PR TITLE
Add manual installation guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,13 +103,42 @@ github "Moya/Moya"
 
 ### Manually
 
-Although we recommend you to use either CocoaPods or Carthage, it is possible to add Moya to your project manually.
+- Open up Terminal, `cd` into your top-level project directory, and run the following command *if* your project is not initialized as a git repository:
 
-1. Add [`Alamofire`](https://github.com/Alamofire/Alamofire) to your project; they provide a great guide to do so [in their Readme](https://github.com/Alamofire/Alamofire#manually).
-2. Add [`Result`](https://github.com/antitypical/Result) to your project, following the same steps as you did with Alamofire.
-3. Do the same for Moya.
+```bash
+$ git init
+```
 
-After that, you should be good to go!
+- Add Alamofire, Result & Moya as a git [submodule](http://git-scm.com/docs/git-submodule) by running the following commands:
+
+```bash
+$ git submodule add https://github.com/Alamofire/Alamofire.git
+$ git submodule add https://github.com/antitypical/Result.git
+$ git submodule add https://github.com/Moya/Moya.git
+```
+
+- Open the new `Alamofire` folder, and drag the `Alamofire.xcodeproj` into the Project Navigator of your application's Xcode project. Do the same with the `Result.xcodeproj` in the `Result` folder and `Moya.xcodeproj` in the `Moya` folder.
+
+> They should appear nested underneath your application's blue project icon. Whether it is above or below all the other Xcode groups does not matter.
+
+- Verify that the deployment targets of the `xcodeproj`s match that of your application target in the Project Navigator.
+- Next, select your application project in the Project Navigator (blue project icon) to navigate to the target configuration window and select the application target under the "Targets" heading in the sidebar.
+- In the tab bar at the top of that window, open the "General" panel.
+- Click on the `+` button under the "Embedded Binaries" section.
+- You will see two different `Alamofire.xcodeproj` folders each with two different versions of the `Alamofire.framework` nested inside a `Products` folder.
+
+> It does not matter which `Products` folder you choose from, but it does matter whether you choose the top or bottom `Alamofire.framework`.
+
+- Select the top `Alamofire.framework` for iOS and the bottom one for OS X.
+
+> You can verify which one you selected by inspecting the build log for your project. The build target for `Alamofire` will be listed as either `Alamofire iOS`, `Alamofire macOS`, `Alamofire tvOS` or `Alamofire watchOS`.
+
+- Click on the `+` button under "Embedded Binaries" again and add the build target you need for `Result`.
+- Click on the `+` button again and add the correct build target for `Moya`.
+
+- And that's it!
+
+> The three frameworks are automagically added as a target dependency, linked framework and embedded framework in a copy files build phase which is all you need to build on the simulator and a device.
 
 Usage
 ---

--- a/Readme.md
+++ b/Readme.md
@@ -101,6 +101,16 @@ ambiguous lookups at compile time.
 github "Moya/Moya"
 ```
 
+### Manually
+
+Although we recommend you to use either CocoaPods or Carthage, it is possible to add Moya to your project manually.
+
+1. Add [`Alamofire`](https://github.com/Alamofire/Alamofire) to your project; they provide a great guide to do so [in their Readme](https://github.com/Alamofire/Alamofire#manually).
+2. Add [`Result`](https://github.com/antitypical/Result) to your project, following the same steps as you did with Alamofire.
+3. Do the same for Moya.
+
+After that, you should be good to go!
+
 Usage
 ---
 


### PR DESCRIPTION
Hmm, how should we do this? Alamofire has a great explanation on how to add their project as a `git submodule`, which are roughly the same steps needed for `Result` and `Moya`.

I don't think I've captured that the best I could; I'd love some feedback on how to make it better!

Fixes #780 