### PR TITLE
Fetch CocoaPods from S3 instead of caching the repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,14 +5,14 @@ machine:
     LANG: en_US.UTF-8
 
 dependencies:
+  pre:
+    - curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
   override:
     - brew update ; brew update # Due to a problem with Homebrew, see: https://github.com/Homebrew/brew/issues/991
     - brew install swiftlint
     - bundle install
     - cd Demo ; bundle exec pod repo update
     - cd Demo ; bundle exec pod install --verbose # Verbose to keep CI alive during long Specs repo setups.
-  cache_directories:
-    - "~/.cocoapods/repos/master"
 
 test:
   pre:


### PR DESCRIPTION
Circle CI finally rolled it out to everyone :tada:

Fixes #755