### PR TITLE
TargetType specifies ParameterEncoding

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- `TargetType` can specify its `ParameterEncoding`. The Default is `URLEncoding`.
+
 # 8.0.0-beta.6
 
 - **Breaking Change** Renamed `ReactiveCocoaMoyaProvider` to `ReactiveSwiftMoyaProvider`.

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -139,6 +139,11 @@ class MoyaProviderSpec: QuickSpec {
             expect(called) == true
         }
 
+        it("uses the target's parameter encoding") {
+            let endpoint = MoyaProvider.defaultEndpointMapping(for: GitHub.zen)
+            expect(endpoint.parameterEncoding is JSONEncoding) == true
+        }
+
         describe("a provider with delayed stubs") {
             var provider: MoyaProvider<GitHub>!
             var plugin: TestingPlugin!

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -30,7 +30,11 @@ extension GitHub: TargetType {
     var parameters: [String: Any]? {
         return nil
     }
-    
+
+    public var parameterEncoding: ParameterEncoding {
+        return JSONEncoding.default
+    }
+
     var task: Task {
         return .request
     }

--- a/Source/Moya+Defaults.swift
+++ b/Source/Moya+Defaults.swift
@@ -4,7 +4,13 @@ import Alamofire
 public extension MoyaProvider {
     public final class func defaultEndpointMapping(for target: Target) -> Endpoint<Target> {
         let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-        return Endpoint(url: url, sampleResponseClosure: { .networkResponse(200, target.sampleData) }, method: target.method, parameters: target.parameters)
+        return Endpoint(
+            url: url,
+            sampleResponseClosure: { .networkResponse(200, target.sampleData) },
+            method: target.method,
+            parameters: target.parameters,
+            parameterEncoding: target.parameterEncoding
+        )
     }
 
     public final class func defaultRequestMapping(for endpoint: Endpoint<Target>, closure: RequestResultClosure) {

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -7,12 +7,17 @@ public protocol TargetType {
     var path: String { get }
     var method: Moya.Method { get }
     var parameters: [String: Any]? { get }
+    var parameterEncoding: ParameterEncoding { get } // Defaults to `URLEncoding`
     var sampleData: Data { get }
     var task: Task { get }
     var validate: Bool { get } // Alamofire validation (defaults to `false`)
 }
 
 public extension TargetType {
+    var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
+
     var validate: Bool {
         return false
     }

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -26,6 +26,7 @@ providers). Here's the beginning of our extension:
 ```swift
 extension GitHub: TargetType {
     public var baseURL: URL { return URL(string: "https://api.github.com")! }
+}
 ```
 
 This protocol specifies the locations of
@@ -82,16 +83,16 @@ public var parameters: [String: Any]? {
 Unlike our `path` property earlier, we don't actually care about the associated values of our `userRepositories` case, so we use the Swift `_` ignored-value symbol.
 Let's take a look at the `branches` case: we'll use our `Bool` associated value (`protected`) as a request parameter by assigning it to the `"protected"` key. We're parsing our `Bool` value to `String`. (Alamofire does not encode `Bool` parameters automatically, so we need to do it by our own).
 
-By default, Moya will encode parameters using URL encoding. If you wish for certain requests to be encoded differently (e.g. as JSON in the HTTP Body), you can provide a value for the `parameterEncoding` property. Alamofire provides `JSONEncoding` and `PropertyListEncoding`, but you can also create your own encoder that conforms to `ParameterEcoding` (e.g. `XMLEncoder`).
+By default, Moya will encode parameters using URL encoding. If you wish for certain requests to be encoded differently (e.g. as JSON in the HTTP Body), you can provide a value for the `parameterEncoding` property. Alamofire provides `JSONEncoding` and `PropertyListEncoding`, but you can also create your own encoder that conforms to `ParameterEncoding` (e.g. `XMLEncoder`).
 
 ```swift
 public var parameterEncoding: ParameterEcoding {
-  switch self {
-  case .zen:
-    return JSONEncoding.default
-  default:
-    return URLEncoding.default
-  }
+    switch self {
+    case .zen:
+        return JSONEncoding.default
+    default:
+        return URLEncoding.default
+    }
 }
 ```
 

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -82,6 +82,19 @@ public var parameters: [String: Any]? {
 Unlike our `path` property earlier, we don't actually care about the associated values of our `userRepositories` case, so we use the Swift `_` ignored-value symbol.
 Let's take a look at the `branches` case: we'll use our `Bool` associated value (`protected`) as a request parameter by assigning it to the `"protected"` key. We're parsing our `Bool` value to `String`. (Alamofire does not encode `Bool` parameters automatically, so we need to do it by our own).
 
+By default, Moya will encode parameters using URL encoding. If you wish for certain requests to be encoded differently (e.g. as JSON in the HTTP Body), you can provide a value for the `parameterEncoding` property. Alamofire provides `JSONEncoding` and `PropertyListEncoding`, but you can also create your own encoder that conforms to `ParameterEcoding` (e.g. `XMLEncoder`).
+
+```swift
+public var parameterEncoding: ParameterEcoding {
+  switch self {
+  case .zen:
+    return JSONEncoding.default
+  default:
+    return URLEncoding.default
+  }
+}
+```
+
 Notice the `sampleData` property on the enum. This is a requirement of
 the `TargetType` protocol. Any target you want to hit must provide some non-nil
 `Data` that represents a sample response. This can be used later for tests or


### PR DESCRIPTION
Closes #858 

This is a simple implementation of allowing the `TargetType` to specify its `ParameterEncoding`. The default implementation specifies `URLEncoding`.