### PR TITLE
Switch to Void over () for function returns.

### DIFF
--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -108,7 +108,7 @@ public extension MoyaProvider {
     }
 
     /// Creates a function which, when called, executes the appropriate stubbing behavior for the given parameters.
-    public final func createStubFunction(_ token: CancellableToken, forTarget target: Target, withCompletion completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, plugins: [PluginType], request: URLRequest) -> (() -> ()) { // swiftlint:disable:this function_parameter_count
+    public final func createStubFunction(_ token: CancellableToken, forTarget target: Target, withCompletion completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, plugins: [PluginType], request: URLRequest) -> (() -> Void) { // swiftlint:disable:this function_parameter_count
         return {
             if token.isCancelled {
                 self.cancelCompletion(completion, target: target)
@@ -207,7 +207,7 @@ private extension MoyaProvider {
 
         var progressAlamoRequest = alamoRequest
         let progressClosure: (Progress) -> Void = { progress in
-            let sendProgress: () -> () = {
+            let sendProgress: () -> Void = {
                 progressCompletion?(ProgressResponse(progress: progress))
             }
 

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -2,7 +2,7 @@ import Foundation
 import Result
 
 /// Closure to be executed when a request has completed.
-public typealias Completion = (_ result: Result<Moya.Response, Moya.Error>) -> ()
+public typealias Completion = (_ result: Result<Moya.Response, Moya.Error>) -> Void
 
 /// Closure to be executed when progress changes.
 public typealias ProgressBlock = (_ progress: ProgressResponse) -> Void
@@ -93,7 +93,7 @@ open class MoyaProvider<Target: TargetType> {
         let cancellableToken = CancellableToken { }
         notifyPluginsOfImpendingStub(for: request, target: target)
         let plugins = self.plugins
-        let stub: () -> () = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
+        let stub: () -> Void = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
         switch stubBehavior {
         case .immediate:
             stub()

--- a/Source/Plugins/NetworkActivityPlugin.swift
+++ b/Source/Plugins/NetworkActivityPlugin.swift
@@ -9,7 +9,7 @@ public enum NetworkActivityChangeType {
 /// Notify a request's network activity changes (request begins or ends).
 public final class NetworkActivityPlugin: PluginType {
 
-    public typealias NetworkActivityClosure = (_ change: NetworkActivityChangeType) -> ()
+    public typealias NetworkActivityClosure = (_ change: NetworkActivityChangeType) -> Void
     let networkActivityClosure: NetworkActivityClosure
 
     public init(networkActivityClosure: @escaping NetworkActivityClosure) {


### PR DESCRIPTION
This is to clean up the warnings generated by SwiftLint.