### PR TITLE
Default TargetType Property Implementations And SingleURLTarget

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -71,6 +71,9 @@
 		3B4D21BC1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */; };
 		3B4D21BD1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */; };
 		3B4D21BE1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */; };
+		3B151C521E0F006A00BAF065 /* TargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B151C511E0F006A00BAF065 /* TargetSpec.swift */; };
+		3B151C531E0F006A00BAF065 /* TargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B151C511E0F006A00BAF065 /* TargetSpec.swift */; };
+		3B151C541E0F006A00BAF065 /* TargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B151C511E0F006A00BAF065 /* TargetSpec.swift */; };
 		4ACBAFF102F6CE19E4A569DE /* Pods_DemoMultiTarget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F71370BEE9C086CDD6D71B8 /* Pods_DemoMultiTarget.framework */; };
 		5EC197E61A1BB16D00F4DFD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E51A1BB16D00F4DFD4 /* AppDelegate.swift */; };
 		5EC197E81A1BB16D00F4DFD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E71A1BB16D00F4DFD4 /* ViewController.swift */; };
@@ -121,6 +124,7 @@
 		292BF354BC027FDF50F146C1 /* Pods-DemoMultiTarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoMultiTarget.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoMultiTarget/Pods-DemoMultiTarget.debug.xcconfig"; sourceTree = "<group>"; };
 		3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTargetSpec.swift; sourceTree = "<group>"; };
 		3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataSpec.swift; sourceTree = "<group>"; };
+		3B151C511E0F006A00BAF065 /* TargetSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetSpec.swift; sourceTree = "<group>"; };
 		4BF06D5D3DD24C44F9301FB5 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		5E0646561BE7999C00E900DC /* Moya.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Moya.podspec; path = ../Moya.podspec; sourceTree = "<group>"; };
 		5E0646571BE799C500E900DC /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = License.md; path = ../License.md; sourceTree = "<group>"; };
@@ -201,6 +205,7 @@
 				067D496D1C0D3886005BBA79 /* MoyaProviderSpec.swift */,
 				3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */,
 				3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */,
+				3B151C511E0F006A00BAF065 /* TargetSpec.swift */,
 				067D496E1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift */,
 				067D496F1C0D3886005BBA79 /* Observable+MoyaSpec.swift */,
 				067D49711C0D3886005BBA79 /* ReactiveSwiftMoyaProviderTests.swift */,
@@ -774,6 +779,7 @@
 				3B4D21BD1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */,
 				067D49981C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
 				1D9CF9A91D4BD594004A95B7 /* MethodSpec.swift in Sources */,
+				3B151C531E0F006A00BAF065 /* TargetSpec.swift in Sources */,
 				067D498C1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift in Sources */,
 				067D49861C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift in Sources */,
 				067D49801C0D3886005BBA79 /* ErrorTests.swift in Sources */,
@@ -796,6 +802,7 @@
 				3B4D21BE1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */,
 				067D49991C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
 				1D9CF9AA1D4BD594004A95B7 /* MethodSpec.swift in Sources */,
+				3B151C541E0F006A00BAF065 /* TargetSpec.swift in Sources */,
 				067D498D1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift in Sources */,
 				067D49871C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift in Sources */,
 				067D49811C0D3886005BBA79 /* ErrorTests.swift in Sources */,
@@ -842,6 +849,7 @@
 				3B4D21BC1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */,
 				067D49971C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
 				1D9CF9A81D4BD593004A95B7 /* MethodSpec.swift in Sources */,
+				3B151C521E0F006A00BAF065 /* TargetSpec.swift in Sources */,
 				067D498B1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift in Sources */,
 				067D49851C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift in Sources */,
 				067D497F1C0D3886005BBA79 /* ErrorTests.swift in Sources */,

--- a/Demo/Shared/GiphyAPI.swift
+++ b/Demo/Shared/GiphyAPI.swift
@@ -27,9 +27,6 @@ extension Giphy: TargetType {
             return ["api_key": "dc6zaTOxFJmzC", "username": "Moya"]
         }
     }
-    public var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
     public var task: Task {
         switch self {
         case let .upload(data):

--- a/Demo/Shared/GitHubAPI.swift
+++ b/Demo/Shared/GitHubAPI.swift
@@ -41,9 +41,6 @@ extension GitHub: TargetType {
             return "/users/\(name.urlEscaped)/repos"
         }
     }
-    public var method: Moya.Method {
-        return .get
-    }
     public var parameters: [String: Any]? {
         switch self {
         case .userRepositories(_):
@@ -51,12 +48,6 @@ extension GitHub: TargetType {
         default:
             return nil
         }
-    }
-    public var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
-    public var task: Task {
-        return .request
     }
     public var validate: Bool {
         switch self {

--- a/Demo/Shared/GitHubUserContentAPI.swift
+++ b/Demo/Shared/GitHubUserContentAPI.swift
@@ -15,21 +15,6 @@ extension GitHubUserContent: TargetType {
             return "/Moya/Moya/master/web/\(contentPath)"
         }
     }
-    public var method: Moya.Method {
-        switch self {
-        case .downloadMoyaWebContent:
-            return .get
-        }
-    }
-    public var parameters: [String: Any]? {
-        switch self {
-        case .downloadMoyaWebContent:
-            return nil
-        }
-    }
-    public var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
     public var task: Task {
         switch self {
         case .downloadMoyaWebContent:

--- a/Demo/Tests/TargetSpec.swift
+++ b/Demo/Tests/TargetSpec.swift
@@ -1,0 +1,22 @@
+import Quick
+import Nimble
+@testable import Moya
+
+class TargetSpec: QuickSpec {
+    override func spec() {
+        describe("a SingleURLTarget") {
+            it("initializes correctly with defaults") {
+                let url = URL(string: "http://api.com")!
+                let target = SingleURLTarget(url: url)
+                expect(target.baseURL).to(equal(url))
+                expect(target.path).to(equal(""))
+                expect(target.method).to(equal(Method.get))
+                expect(target.parameters).to(beNil())
+                expect(target.parameterEncoding is URLEncoding).to(equal(true))
+                expect(target.sampleData).to(equal(Data()))
+                expect(String(describing: target.task)).to(equal("request")) // This is a hack to avoid implementing Equatable for Task
+                expect(target.validate).to(equal(false))
+            }
+        }
+    }
+}

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -22,23 +22,11 @@ extension GitHub: TargetType {
             return "/users/\(name.urlEscaped)"
         }
     }
-    
-    var method: Moya.Method {
-        return .get
-    }
-    
-    var parameters: [String: Any]? {
-        return nil
-    }
 
     public var parameterEncoding: ParameterEncoding {
         return JSONEncoding.default
     }
 
-    var task: Task {
-        return .request
-    }
-    
     var sampleData: Data {
         switch self {
         case .zen:
@@ -69,25 +57,6 @@ enum HTTPBin: TargetType {
         }
     }
 
-    var method: Moya.Method {
-        return .get
-    }
-    
-    var parameters: [String: Any]? {
-        switch self {
-        default:
-            return [:]
-        }
-    }
-
-    var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
-    
-    var task: Task {
-        return .request
-    }
-    
     var sampleData: Data {
         switch self {
         case .basicAuth:
@@ -108,21 +77,7 @@ extension GitHubUserContent: TargetType {
             return "/Moya/Moya/master/web/\(contentPath)"
         }
     }
-    public var method: Moya.Method {
-        switch self {
-        case .downloadMoyaWebContent:
-            return .get
-        }
-    }
-    public var parameters: [String: Any]? {
-        switch self {
-        case .downloadMoyaWebContent:
-            return nil
-        }
-    }
-    public var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
+
     public var task: Task {
         switch self {
         case .downloadMoyaWebContent:
@@ -135,7 +90,7 @@ extension GitHubUserContent: TargetType {
             return Data(count: 4000)
         }
     }
-   
+
 }
 
 private let DefaultDownloadDestination: DownloadDestination = { temporaryURL, response in
@@ -144,6 +99,6 @@ private let DefaultDownloadDestination: DownloadDestination = { temporaryURL, re
     if !directoryURLs.isEmpty {
         return (directoryURLs.first!.appendingPathComponent(response.suggestedFilename!), [])
     }
-    
+
     return (temporaryURL, [])
 }

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -30,9 +30,13 @@ public protocol TargetType {
 }
 
 public extension TargetType {
-    var validate: Bool {
-        return false
-    }
+    var path: String { return "" }
+    var method: Moya.Method { return .get }
+    var parameters: [String: Any]? { return nil }
+    var parameterEncoding: ParameterEncoding { return URLEncoding.default }
+    var sampleData: Data { return Data() }
+    var task: Task { return .request }
+    var validate: Bool { return false }
 }
 
 /// Represents a type of upload task.

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -7,22 +7,22 @@ public protocol TargetType {
     /// The target's base `URL`.
     var baseURL: URL { get }
 
-    /// The path to be appended to `baseURL` to form the full `URL`.
+    /// The path to be appended to `baseURL` to form the full `URL`. Defaults to none.
     var path: String { get }
 
-    /// The HTTP method used in the request.
+    /// The HTTP method used in the request. Defaults to `.get`.
     var method: Moya.Method { get }
 
-    /// The parameters to be incoded in the request.
+    /// The parameters to be incoded in the request. Defaults to `nil`.
     var parameters: [String: Any]? { get }
 
-    /// The method used for parameter encoding.
+    /// The method used for parameter encoding. Defaults to `URLEncoding`.
     var parameterEncoding: ParameterEncoding { get }
 
-    /// Provides stub data for use in testing.
+    /// Provides stub data for use in testing. Defaults to `Data()`.
     var sampleData: Data { get }
 
-    /// The type of HTTP task to be performed.
+    /// The type of HTTP task to be performed. Defaults to `.request`.
     var task: Task { get }
 
     /// Whether or not to perform Alamofire validation. Defaults to `false`.
@@ -39,7 +39,7 @@ public extension TargetType {
     var validate: Bool { return false }
 }
 
-/// A TargetType that represents a GET request to a single URL with no parameters.
+/// A `TargetType` that represents a GET request to a single `URL` with no parameters.
 public struct SingleURLTarget: TargetType {
     public let baseURL: URL
 

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -39,6 +39,16 @@ public extension TargetType {
     var validate: Bool { return false }
 }
 
+/// A TargetType that represents a GET request to a single URL with no parameters.
+public struct SingleURLTarget: TargetType {
+    public let baseURL: URL
+
+    /// Initialize a SingleURLTarget
+    public init(url: URL) {
+        baseURL = url
+    }
+}
+
 /// Represents a type of upload task.
 public enum UploadType {
 


### PR DESCRIPTION
Not 100% sure this is a great idea, but hopefully this PR can facilitate a discussion. I'll add a CHANGELOG entry and update the docs if we agree on this direction.

## Default `TargetType` Property Implementations And `SingleURLTarget`

### Problem

Currently, if a Moya user wants to make a simple GET request to a new URL (not represented by an existing `TargetType`) they have a couple of options: 

They can create a new `TargetType` which will allow them to keep a consistent networking layer as well as have access to `RxMoyaProvider`, `ReactiveMoyaProvider`, easy response mapping, and 3rd party extensions. However, there is a good amount of boilerplate needed for a simple request and a new type needs to be created even for one-off requests.

Alternatively, they could utilize `Alamofire` or `URLSession` directly, but this would introduce inconsistency into their networking layer and they wouldn't have access to easy reactive extensions and response mapping.

### Solution

Provide default implementations of all `TargetType` properties to represent the most commonly used combination of request settings: a GET request with no parameters.

Additionally, provide a trivial `TargetType` implementation (`SingleURLTarget`) so that users can easily create a `TargetType` that represents a GET request to a single URL with no parameters.

### Usage

```swift
let url = URL(string: "http://api.com")!

// Example 1
MoyaProvider().request(SingleURLTarget(url: url)) {
    result in
    // process result
}

// Example 2
let target = SingleURLTarget(url: url)
MoyaProvider().request(target) {
    result in
    // process result
}

// Example 3
let provider = MoyaProvider<SingleURLTarget>()
provider.request(target) {
    result in
    // process result
}
```

### Tradeoffs

* A reduction in conformance errors that are generated in compilation. These errors are often a source of documentation of available behavior.
* Explicit implementation of all behavior is self documenting and may be easier for developers to reason about.

These tradeoffs can be mitigated by improving the documentation for `TargetType`.

### Alternatives Considered

Provide `SingleURLTarget` without providing default implementations for other `TargetType`s. This would be a good compromise between servicing the specific use case of a simple target without reducing the self-documenting nature of implementing `TargetType`. However, there are other common use cases where other properties like `parameters`, `method`, `task`, or `sampleData` can result in unnecessary boilerplate.