### PR TITLE
TargetType.swift refactor #trivial

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		3BA460521E15EB9100511D6A /* MultiTargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */; };
 		3BA460531E15EB9200511D6A /* MultiTargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */; };
 		3BA460541E15EB9200511D6A /* MultiTargetSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */; };
+		3B4D21BC1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */; };
+		3B4D21BD1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */; };
+		3B4D21BE1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */; };
 		4ACBAFF102F6CE19E4A569DE /* Pods_DemoMultiTarget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F71370BEE9C086CDD6D71B8 /* Pods_DemoMultiTarget.framework */; };
 		5EC197E61A1BB16D00F4DFD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E51A1BB16D00F4DFD4 /* AppDelegate.swift */; };
 		5EC197E81A1BB16D00F4DFD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC197E71A1BB16D00F4DFD4 /* ViewController.swift */; };
@@ -117,6 +120,7 @@
 		286AAA5F0654F6F6A0CFF235 /* Pods_MoyaTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MoyaTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		292BF354BC027FDF50F146C1 /* Pods-DemoMultiTarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoMultiTarget.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DemoMultiTarget/Pods-DemoMultiTarget.debug.xcconfig"; sourceTree = "<group>"; };
 		3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTargetSpec.swift; sourceTree = "<group>"; };
+		3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormDataSpec.swift; sourceTree = "<group>"; };
 		4BF06D5D3DD24C44F9301FB5 /* Pods-Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Demo.release.xcconfig"; path = "Pods/Target Support Files/Pods-Demo/Pods-Demo.release.xcconfig"; sourceTree = "<group>"; };
 		5E0646561BE7999C00E900DC /* Moya.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; name = Moya.podspec; path = ../Moya.podspec; sourceTree = "<group>"; };
 		5E0646571BE799C500E900DC /* License.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = License.md; path = ../License.md; sourceTree = "<group>"; };
@@ -196,6 +200,7 @@
 				067D496C1C0D3886005BBA79 /* MoyaProviderIntegrationTests.swift */,
 				067D496D1C0D3886005BBA79 /* MoyaProviderSpec.swift */,
 				3BA460501E15EA4700511D6A /* MultiTargetSpec.swift */,
+				3B4D21BB1E16075C00E2AB87 /* MultipartFormDataSpec.swift */,
 				067D496E1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift */,
 				067D496F1C0D3886005BBA79 /* Observable+MoyaSpec.swift */,
 				067D49711C0D3886005BBA79 /* ReactiveSwiftMoyaProviderTests.swift */,
@@ -766,6 +771,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				067D49951C0D3886005BBA79 /* ReactiveSwiftMoyaProviderTests.swift in Sources */,
+				3B4D21BD1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */,
 				067D49981C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
 				1D9CF9A91D4BD594004A95B7 /* MethodSpec.swift in Sources */,
 				067D498C1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift in Sources */,
@@ -787,6 +793,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				067D49961C0D3886005BBA79 /* ReactiveSwiftMoyaProviderTests.swift in Sources */,
+				3B4D21BE1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */,
 				067D49991C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
 				1D9CF9AA1D4BD594004A95B7 /* MethodSpec.swift in Sources */,
 				067D498D1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift in Sources */,
@@ -832,6 +839,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				067D49941C0D3886005BBA79 /* ReactiveSwiftMoyaProviderTests.swift in Sources */,
+				3B4D21BC1E16075C00E2AB87 /* MultipartFormDataSpec.swift in Sources */,
 				067D49971C0D3886005BBA79 /* RxSwiftMoyaProviderTests.swift in Sources */,
 				1D9CF9A81D4BD593004A95B7 /* MethodSpec.swift in Sources */,
 				067D498B1C0D3886005BBA79 /* NetworkLoggerPluginSpec.swift in Sources */,

--- a/Demo/Tests/MultipartFormDataSpec.swift
+++ b/Demo/Tests/MultipartFormDataSpec.swift
@@ -1,0 +1,27 @@
+import Quick
+import Nimble
+@testable import Moya
+
+class MultiPartFormData: QuickSpec {
+    override func spec() {
+        it("initializes correctly") {
+            let fileURL = URL(fileURLWithPath: "/tmp.txt")
+            let data = MultipartFormData(
+                provider: .file(fileURL),
+                name: "MyName",
+                fileName: "tmp.txt",
+                mimeType: "text/plain"
+            )
+
+            expect(data.name) == "MyName"
+            expect(data.fileName) == "tmp.txt"
+            expect(data.mimeType) == "text/plain"
+
+            if case .file(let url) = data.provider {
+                expect(url) == fileURL
+            } else {
+                fail("The provider was not initialized correctly.")
+            }
+        }
+    }
+}

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -61,6 +61,10 @@
 		3BC0F9841E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
 		3BC0F9851E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
 		3BC0F9861E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
+		3BCBBDCB1E15A48400F53224 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */; };
+		3BCBBDCC1E15A52C00F53224 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */; };
+		3BCBBDCD1E15A53600F53224 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */; };
+		3BCBBDCE1E15A53800F53224 /* MultipartFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */; };
 		465D2C531D457B2A0059D1B6 /* Moya.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0676A5D71BFE80D3001C7F55 /* Moya.swift */; };
 		465D2C541D457B320059D1B6 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0676A5D81BFE80D3001C7F55 /* Plugin.swift */; };
 		465D2C561D457B680059D1B6 /* Moya+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5FA8C61D4462F300ED49AF /* Moya+Internal.swift */; };
@@ -148,6 +152,7 @@
 		091F0D6B1BDE9B0C009D0A49 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		091F0D831BDE9D4D009D0A49 /* RxMoya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxMoya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BC0F9821E15AF2400F4406F /* MultiTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTarget.swift; sourceTree = "<group>"; };
+		3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		492F83BF1DED97F100C79972 /* Moya+ReactiveSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Moya+ReactiveSwift.swift"; path = "Source/ReactiveSwift/Moya+ReactiveSwift.swift"; sourceTree = SOURCE_ROOT; };
 		492F83C01DED97F100C79972 /* SignalProducer+Moya.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "SignalProducer+Moya.swift"; path = "Source/ReactiveSwift/SignalProducer+Moya.swift"; sourceTree = SOURCE_ROOT; };
 		554B0FB91BE7ED4D00F3D266 /* Moya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Moya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -313,6 +318,7 @@
 				5E5FA8C61D4462F300ED49AF /* Moya+Internal.swift */,
 				5E5FA8C71D4462F300ED49AF /* Target.swift */,
 				3BC0F9821E15AF2400F4406F /* MultiTarget.swift */,
+				3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */,
 				0676A5D91BFE80D3001C7F55 /* Plugins */,
 				0676A5DD1BFE80D3001C7F55 /* ReactiveSwift */,
 				0676A5E31BFE80D3001C7F55 /* RxSwift */,
@@ -883,6 +889,7 @@
 				0676A66D1BFE80D3001C7F55 /* Response.swift in Sources */,
 				0676A5E91BFE80D3001C7F55 /* Endpoint.swift in Sources */,
 				0676A6251BFE80D3001C7F55 /* CredentialsPlugin.swift in Sources */,
+				3BCBBDCC1E15A52C00F53224 /* MultipartFormData.swift in Sources */,
 				5E5FA8D41D4462FC00ED49AF /* Cancellable.swift in Sources */,
 				5E5FA8D61D4462FC00ED49AF /* Moya+Internal.swift in Sources */,
 				0676A63D1BFE80D3001C7F55 /* NetworkLoggerPlugin.swift in Sources */,
@@ -923,6 +930,7 @@
 				0676A66A1BFE80D3001C7F55 /* Response.swift in Sources */,
 				0676A5E61BFE80D3001C7F55 /* Endpoint.swift in Sources */,
 				0676A6221BFE80D3001C7F55 /* CredentialsPlugin.swift in Sources */,
+				3BCBBDCB1E15A48400F53224 /* MultipartFormData.swift in Sources */,
 				5E5FA8C81D4462FB00ED49AF /* Cancellable.swift in Sources */,
 				5E5FA8CA1D4462FB00ED49AF /* Moya+Internal.swift in Sources */,
 				0676A63A1BFE80D3001C7F55 /* NetworkLoggerPlugin.swift in Sources */,
@@ -963,6 +971,7 @@
 				0676A6341BFE80D3001C7F55 /* NetworkActivityPlugin.swift in Sources */,
 				0676A6701BFE80D3001C7F55 /* Response.swift in Sources */,
 				0676A5EC1BFE80D3001C7F55 /* Endpoint.swift in Sources */,
+				3BCBBDCD1E15A53600F53224 /* MultipartFormData.swift in Sources */,
 				0676A6281BFE80D3001C7F55 /* CredentialsPlugin.swift in Sources */,
 				5E5FA8E01D4462FD00ED49AF /* Cancellable.swift in Sources */,
 				5E5FA8E21D4462FD00ED49AF /* Moya+Internal.swift in Sources */,
@@ -1003,6 +1012,7 @@
 				465D2C561D457B680059D1B6 /* Moya+Internal.swift in Sources */,
 				0676A6731BFE80D3001C7F55 /* Response.swift in Sources */,
 				0676A5EF1BFE80D3001C7F55 /* Endpoint.swift in Sources */,
+				3BCBBDCE1E15A53800F53224 /* MultipartFormData.swift in Sources */,
 				0676A62B1BFE80D3001C7F55 /* CredentialsPlugin.swift in Sources */,
 				465D2C531D457B2A0059D1B6 /* Moya.swift in Sources */,
 				5E5FA8F41D44630100ED49AF /* Cancellable.swift in Sources */,

--- a/Source/Moya+Alamofire.swift
+++ b/Source/Moya+Alamofire.swift
@@ -9,6 +9,9 @@ internal typealias DataRequest = Alamofire.DataRequest
 
 internal typealias URLRequestConvertible = Alamofire.URLRequestConvertible
 
+/// Represents an HTTP method.
+public typealias Method = Alamofire.HTTPMethod
+
 /// Choice of parameter encoding.
 public typealias ParameterEncoding = Alamofire.ParameterEncoding
 public typealias JSONEncoding = Alamofire.JSONEncoding

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -6,12 +6,9 @@ import Result
 extension Method {
     public var supportsMultipart: Bool {
         switch self {
-        case .post,
-             .put,
-             .patch,
-             .connect:
+        case .post, .put, .patch, .connect:
             return true
-        default:
+        case .get, .delete, .head, .options, .trace:
             return false
         }
     }

--- a/Source/Moya+Internal.swift
+++ b/Source/Moya+Internal.swift
@@ -1,6 +1,24 @@
 import Foundation
 import Result
 
+// MARK: - Method
+
+extension Method {
+    public var supportsMultipart: Bool {
+        switch self {
+        case .post,
+             .put,
+             .patch,
+             .connect:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// MARK: - MoyaProvider
+
 /// Internal extension to keep the inner-workings outside the main Moya.swift file.
 public extension MoyaProvider {
     // Yup, we're disabling these. The function is complicated, but breaking it apart requires a large effort.
@@ -249,7 +267,7 @@ private extension MoyaProvider {
     }
 }
 
-// MARK: - RequestMultipartFormData appending
+// MARK: RequestMultipartFormData appending
 
 private extension MoyaProvider {
     func append(data: Data, bodyPart: MultipartFormData, to form: RequestMultipartFormData) {

--- a/Source/Moya.swift
+++ b/Source/Moya.swift
@@ -113,6 +113,19 @@ open class MoyaProvider<Target: TargetType> {
 
 /// Mark: Stubbing
 
+/// Controls how stub responses are returned.
+public enum StubBehavior {
+
+    /// Do not stub.
+    case never
+
+    /// Return a response immediately.
+    case immediate
+
+    /// Return a response after a delay.
+    case delayed(seconds: TimeInterval)
+}
+
 public extension MoyaProvider {
 
     // Swift won't let us put the StubBehavior enum inside the provider class, so we'll

--- a/Source/MultipartFormData.swift
+++ b/Source/MultipartFormData.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Represents "multipart/form-data" for an upload.
+public struct MultipartFormData {
+
+    /// Method to provide the form data.
+    public enum FormDataProvider {
+        case data(Foundation.Data)
+        case file(URL)
+        case stream(InputStream, UInt64)
+    }
+
+    /// Initialize a new `MultipartFormData`.
+    public init(provider: FormDataProvider, name: String, fileName: String? = nil, mimeType: String? = nil) {
+        self.provider = provider
+        self.name = name
+        self.fileName = fileName
+        self.mimeType = mimeType
+    }
+
+    /// The method being used for providing form data.
+    public let provider: FormDataProvider
+
+    /// The name.
+    public let name: String
+
+    /// The file name.
+    public let fileName: String?
+
+    /// The MIME type
+    public let mimeType: String?
+}

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -53,19 +53,6 @@ extension Method {
     }
 }
 
-/// Controls stub responses are returned.
-public enum StubBehavior {
-
-    /// Never return  a response.
-    case never
-
-    /// Return a response immediately.
-    case immediate
-
-    /// Return a response after a delay.
-    case delayed(seconds: TimeInterval)
-}
-
 /// Represents a type of upload task.
 public enum UploadType {
 

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -95,34 +95,3 @@ public enum Task {
     /// A download task.
     case download(DownloadType)
 }
-
-/// Represents "multipart/form-data" for an upload.
-public struct MultipartFormData {
-
-    /// Method to provide the form data.
-    public enum FormDataProvider {
-        case data(Foundation.Data)
-        case file(URL)
-        case stream(InputStream, UInt64)
-    }
-
-    /// Initialize a new `MultipartFormData`.
-    public init(provider: FormDataProvider, name: String, fileName: String? = nil, mimeType: String? = nil) {
-        self.provider = provider
-        self.name = name
-        self.fileName = fileName
-        self.mimeType = mimeType
-    }
-
-    /// The method being used for providing form data.
-    public let provider: FormDataProvider
-
-    /// The name.
-    public let name: String
-
-    /// The file name.
-    public let fileName: String?
-
-    /// The MIME type
-    public let mimeType: String?
-}

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -39,9 +39,6 @@ public extension TargetType {
     }
 }
 
-/// Represents an HTTP method.
-public typealias Method = Alamofire.HTTPMethod
-
 extension Method {
     public var supportsMultipart: Bool {
         switch self {

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -39,20 +39,6 @@ public extension TargetType {
     }
 }
 
-extension Method {
-    public var supportsMultipart: Bool {
-        switch self {
-        case .post,
-             .put,
-             .patch,
-             .connect:
-            return true
-        default:
-            return false
-        }
-    }
-}
-
 /// Represents a type of upload task.
 public enum UploadType {
 


### PR DESCRIPTION
There are a few things in TargetType.swift that I think there might be better locations for. Here are the changes:

* Move the `Method` typealias to the Moya+Alamofire.swift file with the other Alamofire type aliases.
* Extract MultipartFormData to it's own file.
* Move `StubBehavior` to Moya.swift since it has more to do with `MoyaProvider` than `TargetType`.
* Move the extension on `Method` to Moya+Internal.swift where it is used. This could possible also go in Moya+Alamofire.swift.

Let me know what you guys think about this.