### PR TITLE
Fix inaccurate Codecov reporting. #trivial

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,8 +16,8 @@ dependencies:
 
 test:
   pre:
-  override: 
+  override:
   - rake test && rake test:carthage
-  post: 
+  post:
     - bundle exec danger
-    - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash) -J Moya

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 coverage:
   ignore:
-    - Demo/Demo/.*
-
+    - Demo
+    - Carthage


### PR DESCRIPTION
While trying to figure out some of the codecov problems from #871, I realized that we were incorrectly getting a lot of coverage credit for the testing code itself. I added everything in the Demo and Carthage directories to be ignored.

Unfortunately this means a hit to the coverage metric. 😢