### PR TITLE
Remove default for TargetType.parameterEncoding

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Next
 
 - **Breaking Change** Renamed `verbose` in the NetworkLoggerPlugin to `isVerbose`.
-- `TargetType` can specify its `ParameterEncoding`. The Default is `URLEncoding`.
+- **Breaking Change** `TargetType` now specifies its `ParameterEncoding`.
 - Added documentation for `TargetType` and associated data structures.
 - Re-add `MultiTarget` to project.
 

--- a/Demo/Shared/GiphyAPI.swift
+++ b/Demo/Shared/GiphyAPI.swift
@@ -27,6 +27,9 @@ extension Giphy: TargetType {
             return ["api_key": "dc6zaTOxFJmzC", "username": "Moya"]
         }
     }
+    public var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
     public var task: Task {
         switch self {
         case let .upload(data):

--- a/Demo/Shared/GitHubAPI.swift
+++ b/Demo/Shared/GitHubAPI.swift
@@ -52,6 +52,9 @@ extension GitHub: TargetType {
             return nil
         }
     }
+    public var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
     public var task: Task {
         return .request
     }

--- a/Demo/Shared/GitHubUserContentAPI.swift
+++ b/Demo/Shared/GitHubUserContentAPI.swift
@@ -27,6 +27,9 @@ extension GitHubUserContent: TargetType {
             return nil
         }
     }
+    public var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
     public var task: Task {
         switch self {
         case .downloadMoyaWebContent:

--- a/Demo/Tests/EndpointSpec.swift
+++ b/Demo/Tests/EndpointSpec.swift
@@ -115,6 +115,7 @@ extension Empty: TargetType {
     var path: String { return "" }
     var method: Moya.Method { return .get }
     var parameters: [String: Any]? { return nil }
+    var parameterEncoding: ParameterEncoding { return URLEncoding.default }
     var task: Task { return .request }
     var sampleData: Data { return Data() }
 }

--- a/Demo/Tests/MoyaProviderSpec.swift
+++ b/Demo/Tests/MoyaProviderSpec.swift
@@ -527,6 +527,7 @@ class MoyaProviderSpec: QuickSpec {
                 let path = "/endpoint"
                 let method = Moya.Method.get
                 let parameters: [String: Any]? = ["key": "value"]
+                let parameterEncoding: ParameterEncoding = URLEncoding.default
                 let task = Task.request
                 let sampleData = "sample data".data(using: .utf8)!
             }

--- a/Demo/Tests/TestHelpers.swift
+++ b/Demo/Tests/TestHelpers.swift
@@ -79,6 +79,10 @@ enum HTTPBin: TargetType {
             return [:]
         }
     }
+
+    var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
     
     var task: Task {
         return .request
@@ -115,6 +119,9 @@ extension GitHubUserContent: TargetType {
         case .downloadMoyaWebContent:
             return nil
         }
+    }
+    public var parameterEncoding: ParameterEncoding {
+        return URLEncoding.default
     }
     public var task: Task {
         switch self {

--- a/Source/Target.swift
+++ b/Source/Target.swift
@@ -16,7 +16,7 @@ public protocol TargetType {
     /// The parameters to be incoded in the request.
     var parameters: [String: Any]? { get }
 
-    /// The method used for parameter encoding. Defaults to `URLEncoding`.
+    /// The method used for parameter encoding.
     var parameterEncoding: ParameterEncoding { get }
 
     /// Provides stub data for use in testing.
@@ -30,10 +30,6 @@ public protocol TargetType {
 }
 
 public extension TargetType {
-    var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
-
     var validate: Bool {
         return false
     }

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -83,7 +83,12 @@ public var parameters: [String: Any]? {
 Unlike our `path` property earlier, we don't actually care about the associated values of our `userRepositories` case, so we use the Swift `_` ignored-value symbol.
 Let's take a look at the `branches` case: we'll use our `Bool` associated value (`protected`) as a request parameter by assigning it to the `"protected"` key. We're parsing our `Bool` value to `String`. (Alamofire does not encode `Bool` parameters automatically, so we need to do it by our own).
 
-By default, Moya will encode parameters using URL encoding. If you wish for certain requests to be encoded differently (e.g. as JSON in the HTTP Body), you can provide a value for the `parameterEncoding` property. Alamofire provides `JSONEncoding` and `PropertyListEncoding`, but you can also create your own encoder that conforms to `ParameterEncoding` (e.g. `XMLEncoder`).
+While we are talking about parameters, we need to indicate how we want our
+parameters to be encoded into our request. We do this by returning a
+`ParameterEncoding` from a `parameterEncoding` computed property. Out of the
+box, Moya has `URLEncoding`, `JSONEncoding`, and `PropertyListEncoding`. You can
+also create your own encoder that conforms to `ParameterEncoding` (e.g.
+`XMLEncoder`).
 
 ```swift
 public var parameterEncoding: ParameterEcoding {


### PR DESCRIPTION
As discussed in #861, this PR removes the default implementation for `TargetType`'s `parameterEncoding` to be consistent with current approach for `TargetType`. The default will be reintroduced as part of #861.