### PR TITLE
LocalizedError for Moya.Error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 - **Breaking Change** Renamed `verbose` in the NetworkLoggerPlugin to `isVerbose`.
 - **Breaking Change** `TargetType` now specifies its `ParameterEncoding`.
+- **Breaking Change** Removed unused `Moya.Error.data`.
+- `Moya.Error` now conforms to `LocalizedError` protocol.
 - Added documentation for `TargetType` and associated data structures.
 - Re-add `MultiTarget` to project.
 

--- a/Demo/Tests/Error+MoyaSpec.swift
+++ b/Demo/Tests/Error+MoyaSpec.swift
@@ -37,13 +37,6 @@ public func beOfSameErrorType(_ expectedValue: Moya.Error) -> MatcherFunc<Moya.E
                 default:
                     return false
                 }
-            case .data:
-                switch expectedValue {
-                case .data:
-                    return true
-                default:
-                    return false
-                }
             case .underlying:
                 switch expectedValue {
                 case .underlying:

--- a/Demo/Tests/ErrorTests.swift
+++ b/Demo/Tests/ErrorTests.swift
@@ -38,12 +38,6 @@ class ErrorTests: QuickSpec {
                 expect(error.response) == response
             }
 
-            it("should handle Data error") {
-                let error = Moya.Error.data(response)
-
-                expect(error.response) == response
-            }
-
             it("should not handle Underlying error ") {
                 let nsError = NSError(domain: "Domain", code: 200, userInfo: ["data" : "some data"])
                 let error = Moya.Error.underlying(nsError)

--- a/Demo/Tests/NetworkLoggerPluginSpec.swift
+++ b/Demo/Tests/NetworkLoggerPluginSpec.swift
@@ -2,6 +2,7 @@ import Quick
 import Nimble
 import Moya
 import Result
+import enum Alamofire.AFError
 
 final class NetworkLoggerPluginSpec: QuickSpec {
     override func spec() {
@@ -84,11 +85,12 @@ final class NetworkLoggerPluginSpec: QuickSpec {
         }
 
         it("outputs an empty response message") {
-            let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: nil)
-            let result: Result<Moya.Response, Moya.Error> = .failure(Moya.Error.data(response))
-
+            let emptyResponseError = AFError.responseSerializationFailed(reason: .inputDataNil)
+            
+            let result: Result<Moya.Response, Moya.Error> = .failure(.underlying(emptyResponseError))
+            
             plugin.didReceive(result, target: GitHub.zen)
-
+            
             expect(log).to( contain("Response: Received empty network response for zen.") )
         }
 

--- a/Demo/Tests/NetworkLoggerPluginSpec.swift
+++ b/Demo/Tests/NetworkLoggerPluginSpec.swift
@@ -87,7 +87,7 @@ final class NetworkLoggerPluginSpec: QuickSpec {
         it("outputs an empty response message") {
             let emptyResponseError = AFError.responseSerializationFailed(reason: .inputDataNil)
             let result: Result<Moya.Response, Moya.Error> = .failure(.underlying(emptyResponseError))
-            
+
             plugin.didReceive(result, target: GitHub.zen)
 
             expect(log).to( contain("Response: Received empty network response for zen.") )

--- a/Demo/Tests/NetworkLoggerPluginSpec.swift
+++ b/Demo/Tests/NetworkLoggerPluginSpec.swift
@@ -86,11 +86,10 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
         it("outputs an empty response message") {
             let emptyResponseError = AFError.responseSerializationFailed(reason: .inputDataNil)
-            
             let result: Result<Moya.Response, Moya.Error> = .failure(.underlying(emptyResponseError))
             
             plugin.didReceive(result, target: GitHub.zen)
-            
+
             expect(log).to( contain("Response: Received empty network response for zen.") )
         }
 

--- a/Demo/Tests/NetworkLoggerPluginSpec.swift
+++ b/Demo/Tests/NetworkLoggerPluginSpec.swift
@@ -83,7 +83,7 @@ final class NetworkLoggerPluginSpec: QuickSpec {
             expect(log).to( contain("formatted body") )
         }
 
-        it("outputs an empty reponse message") {
+        it("outputs an empty response message") {
             let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: nil)
             let result: Result<Moya.Response, Moya.Error> = .failure(Moya.Error.data(response))
 

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -22,3 +22,25 @@ public extension Moya.Error {
         }
     }
 }
+
+// MARK: - Error Descriptions
+
+extension Moya.Error: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .imageMapping:
+            return "Failed to map data to an Image"
+        case .jsonMapping:
+            return "Failed to map data to a JSON"
+        case .stringMapping:
+            return "Failed to map data to a String"
+        case .statusCode:
+            return "Status code didn't fall within the given range"
+        case .requestMapping:
+            return "Failed to map Endpoint to a URLRequest"
+        case .underlying(let error):
+            return error.localizedDescription
+        }
+    }
+}
+

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -5,7 +5,6 @@ public enum Error: Swift.Error {
     case jsonMapping(Response)
     case stringMapping(Response)
     case statusCode(Response)
-    case data(Response)
     case underlying(Swift.Error)
     case requestMapping(String)
 }
@@ -18,7 +17,6 @@ public extension Moya.Error {
         case .jsonMapping(let response): return response
         case .stringMapping(let response): return response
         case .statusCode(let response): return response
-        case .data(let response): return response
         case .underlying: return nil
         case .requestMapping: return nil
         }

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -43,4 +43,3 @@ extension Moya.Error: LocalizedError {
         }
     }
 }
-

--- a/Source/Error.swift
+++ b/Source/Error.swift
@@ -29,15 +29,15 @@ extension Moya.Error: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .imageMapping:
-            return "Failed to map data to an Image"
+            return "Failed to map data to an Image."
         case .jsonMapping:
-            return "Failed to map data to a JSON"
+            return "Failed to map data to a JSON."
         case .stringMapping:
-            return "Failed to map data to a String"
+            return "Failed to map data to a String."
         case .statusCode:
-            return "Status code didn't fall within the given range"
+            return "Status code didn't fall within the given range."
         case .requestMapping:
-            return "Failed to map Endpoint to a URLRequest"
+            return "Failed to map Endpoint to a URLRequest."
         case .underlying(let error):
             return error.localizedDescription
         }


### PR DESCRIPTION
With this pull request Moya.Error conforms to LocalizedError thus providing more meaningful error descriptions. Also removed unused Moya.Error enumeration case.

Before
print(imageMappingError.localizedDescription): The operation couldn’t be completed. (Moya.Error error 0.)
print(underlyingError.localizedDescription): The operation couldn’t be completed. (Moya.Error error 5.)

After
print(imageMappingError.localizedDescription): Failed to map data to an Image
print(underlyingError.localizedDescription): Response status code was unacceptable: 404.