### PR TITLE
Add AccessTokenPlugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
 - Adopted an SPM-compatible project structure.
 - Moved tests to Moya.xcodeproj.
 - Supported the swift package manager
+- Added `AccessTokenPlugin` for easier authorization.
+- Added `AccessTokenAuthorizable` protocol for optionally controlling the authorization behavior of `TargetType`s when using `AccessTokenPlugin`.
 
 # 8.0.0-beta.6
 

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		3B3F9C651E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
 		3B3F9C661E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
 		3B3F9C671E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
+		3B3F9C691E1B2A7A0083107D /* AccessTokenPluginSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C681E1B2A7A0083107D /* AccessTokenPluginSpec.swift */; };
+		3B3F9C6A1E1B2A7A0083107D /* AccessTokenPluginSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C681E1B2A7A0083107D /* AccessTokenPluginSpec.swift */; };
+		3B3F9C6B1E1B2A7A0083107D /* AccessTokenPluginSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C681E1B2A7A0083107D /* AccessTokenPluginSpec.swift */; };
 		3BC0F9831E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
 		3BC0F9841E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
 		3BC0F9851E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
@@ -341,6 +344,7 @@
 		091F0D441BDE9A01009D0A49 /* ReactiveMoya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveMoya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		091F0D831BDE9D4D009D0A49 /* RxMoya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxMoya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessTokenPlugin.swift; sourceTree = "<group>"; };
+		3B3F9C681E1B2A7A0083107D /* AccessTokenPluginSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessTokenPluginSpec.swift; sourceTree = "<group>"; };
 		3BC0F9821E15AF2400F4406F /* MultiTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTarget.swift; sourceTree = "<group>"; };
 		3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		3BE0900A1E1AD730000F5DD4 /* TargetType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetType.swift; sourceTree = "<group>"; };
@@ -722,6 +726,7 @@
 				463CF2A31E1A062600824884 /* MultiTargetSpec.swift */,
 				463CF2A41E1A062600824884 /* MultipartFormDataSpec.swift */,
 				463CF2A51E1A062600824884 /* NetworkLoggerPluginSpec.swift */,
+				3B3F9C681E1B2A7A0083107D /* AccessTokenPluginSpec.swift */,
 				463CF2A61E1A062600824884 /* Observable+MoyaSpec.swift */,
 				463CF2A71E1A062600824884 /* ReactiveSwiftMoyaProviderTests.swift */,
 				463CF2A81E1A062600824884 /* RxSwiftMoyaProviderTests.swift */,
@@ -1397,6 +1402,7 @@
 				463CF2B91E1A062600824884 /* MoyaProviderIntegrationTests.swift in Sources */,
 				463CF2C21E1A062600824884 /* MultipartFormDataSpec.swift in Sources */,
 				463CF2AD1E1A062600824884 /* EndpointSpec.swift in Sources */,
+				3B3F9C6A1E1B2A7A0083107D /* AccessTokenPluginSpec.swift in Sources */,
 				463CF2BF1E1A062600824884 /* MultiTargetSpec.swift in Sources */,
 				463CF2D71E1A062600824884 /* TestPlugin.swift in Sources */,
 				463CF2CE1E1A062600824884 /* RxSwiftMoyaProviderTests.swift in Sources */,
@@ -1419,6 +1425,7 @@
 				463CF2BA1E1A062600824884 /* MoyaProviderIntegrationTests.swift in Sources */,
 				463CF2C31E1A062600824884 /* MultipartFormDataSpec.swift in Sources */,
 				463CF2AE1E1A062600824884 /* EndpointSpec.swift in Sources */,
+				3B3F9C691E1B2A7A0083107D /* AccessTokenPluginSpec.swift in Sources */,
 				463CF2C01E1A062600824884 /* MultiTargetSpec.swift in Sources */,
 				463CF2D81E1A062600824884 /* TestPlugin.swift in Sources */,
 				463CF2CF1E1A062600824884 /* RxSwiftMoyaProviderTests.swift in Sources */,
@@ -1441,6 +1448,7 @@
 				463CF2BB1E1A062600824884 /* MoyaProviderIntegrationTests.swift in Sources */,
 				463CF2C41E1A062600824884 /* MultipartFormDataSpec.swift in Sources */,
 				463CF2AF1E1A062600824884 /* EndpointSpec.swift in Sources */,
+				3B3F9C6B1E1B2A7A0083107D /* AccessTokenPluginSpec.swift in Sources */,
 				463CF2C11E1A062600824884 /* MultiTargetSpec.swift in Sources */,
 				463CF2D91E1A062600824884 /* TestPlugin.swift in Sources */,
 				463CF2D01E1A062600824884 /* RxSwiftMoyaProviderTests.swift in Sources */,

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -47,6 +47,10 @@
 		0676A6931BFE80D3001C7F55 /* Observable+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0676A5E51BFE80D3001C7F55 /* Observable+Response.swift */; };
 		0676A6961BFE80D3001C7F55 /* Observable+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0676A5E51BFE80D3001C7F55 /* Observable+Response.swift */; };
 		0676A6991BFE80D3001C7F55 /* Observable+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0676A5E51BFE80D3001C7F55 /* Observable+Response.swift */; };
+		3B3F9C641E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
+		3B3F9C651E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
+		3B3F9C661E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
+		3B3F9C671E1B273C0083107D /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */; };
 		3BC0F9831E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
 		3BC0F9841E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
 		3BC0F9851E15AF2400F4406F /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC0F9821E15AF2400F4406F /* MultiTarget.swift */; };
@@ -336,6 +340,7 @@
 		091F0D341BDE998F009D0A49 /* Moya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Moya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		091F0D441BDE9A01009D0A49 /* ReactiveMoya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactiveMoya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		091F0D831BDE9D4D009D0A49 /* RxMoya.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxMoya.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessTokenPlugin.swift; sourceTree = "<group>"; };
 		3BC0F9821E15AF2400F4406F /* MultiTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiTarget.swift; sourceTree = "<group>"; };
 		3BCBBDCA1E15A48400F53224 /* MultipartFormData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartFormData.swift; sourceTree = "<group>"; };
 		3BE0900A1E1AD730000F5DD4 /* TargetType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TargetType.swift; sourceTree = "<group>"; };
@@ -570,6 +575,7 @@
 		0676A5D91BFE80D3001C7F55 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
+				3B3F9C631E1B273C0083107D /* AccessTokenPlugin.swift */,
 				0676A5DA1BFE80D3001C7F55 /* CredentialsPlugin.swift */,
 				0676A5DB1BFE80D3001C7F55 /* NetworkActivityPlugin.swift */,
 				0676A5DC1BFE80D3001C7F55 /* NetworkLoggerPlugin.swift */,
@@ -1306,6 +1312,7 @@
 			files = (
 				55B5D5D01C1F6FC200A11B82 /* Moya+Alamofire.swift in Sources */,
 				0676A5F51BFE80D3001C7F55 /* MoyaError.swift in Sources */,
+				3B3F9C651E1B273C0083107D /* AccessTokenPlugin.swift in Sources */,
 				3BC0F9841E15AF2400F4406F /* MultiTarget.swift in Sources */,
 				0676A6011BFE80D3001C7F55 /* Image.swift in Sources */,
 				3BE0900C1E1AD730000F5DD4 /* TargetType.swift in Sources */,
@@ -1347,6 +1354,7 @@
 			files = (
 				55B5D5CD1C1F6FBE00A11B82 /* Moya+Alamofire.swift in Sources */,
 				0676A5F21BFE80D3001C7F55 /* MoyaError.swift in Sources */,
+				3B3F9C641E1B273C0083107D /* AccessTokenPlugin.swift in Sources */,
 				3BC0F9831E15AF2400F4406F /* MultiTarget.swift in Sources */,
 				0676A5FE1BFE80D3001C7F55 /* Image.swift in Sources */,
 				3BE0900B1E1AD730000F5DD4 /* TargetType.swift in Sources */,
@@ -1454,6 +1462,7 @@
 			files = (
 				55B5D5D31C1F6FC300A11B82 /* Moya+Alamofire.swift in Sources */,
 				0676A5F81BFE80D3001C7F55 /* MoyaError.swift in Sources */,
+				3B3F9C661E1B273C0083107D /* AccessTokenPlugin.swift in Sources */,
 				3BC0F9851E15AF2400F4406F /* MultiTarget.swift in Sources */,
 				465D2C541D457B320059D1B6 /* Plugin.swift in Sources */,
 				3BE0900D1E1AD730000F5DD4 /* TargetType.swift in Sources */,
@@ -1495,6 +1504,7 @@
 			files = (
 				55B5D5D61C1F6FC500A11B82 /* Moya+Alamofire.swift in Sources */,
 				0676A5FB1BFE80D3001C7F55 /* MoyaError.swift in Sources */,
+				3B3F9C671E1B273C0083107D /* AccessTokenPlugin.swift in Sources */,
 				3BC0F9861E15AF2400F4406F /* MultiTarget.swift in Sources */,
 				0676A6071BFE80D3001C7F55 /* Image.swift in Sources */,
 				3BE0900E1E1AD730000F5DD4 /* TargetType.swift in Sources */,

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -3,23 +3,53 @@ import Result
 
 // MARK: - AccessTokenAuthorizable
 
+/// A protocol for controlling the behavior of `AccessTokenPlugin`.
 public protocol AccessTokenAuthorizable {
+
+    /// Declares whether or not `AccessTokenPlugin` should add an authorization header
+    /// to requests.
     var shouldAuthorize: Bool { get }
 }
 
 // MARK: - AccessTokenPlugin
 
+/** 
+ A plugin for adding bearer-type authorization headers to requests. Example:
+ 
+ ```
+ Authorization: Bearer <token>
+ ```
+ 
+ - Note: By default, requests to all `TargetType`s will receive this header. You can control this
+   behvaior by conforming to `AccessTokenAuthorizable`.
+*/
 public struct AccessTokenPlugin: PluginType {
+
+    /// The access token to be applied in the header.
     public let token: String
 
     private var authVal: String {
         return "Bearer " + token
     }
 
+    /**
+     Initialize a new `AccessTokenPlugin`.
+     
+     - parameters:
+       - token: The token to be applied in the pattern `Authorization: Bearer <token>`
+    */
     public init(token: String) {
         self.token = token
     }
 
+    /**
+     Prepare a request by adding an authorization header if necessary.
+     
+     - parameters:
+       - request: The request to modify.
+       - target: The target of the request.
+     - returns: The modified `URLRequest`.
+    */
     public func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
         if let authorizable = target as? AccessTokenAuthorizable, !authorizable.shouldAuthorize {
             return request

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -13,13 +13,13 @@ public protocol AccessTokenAuthorizable {
 
 // MARK: - AccessTokenPlugin
 
-/** 
+/**
  A plugin for adding bearer-type authorization headers to requests. Example:
- 
+
  ```
  Authorization: Bearer <token>
  ```
- 
+
  - Note: By default, requests to all `TargetType`s will receive this header. You can control this
    behvaior by conforming to `AccessTokenAuthorizable`.
 */
@@ -34,7 +34,7 @@ public struct AccessTokenPlugin: PluginType {
 
     /**
      Initialize a new `AccessTokenPlugin`.
-     
+
      - parameters:
        - token: The token to be applied in the pattern `Authorization: Bearer <token>`
     */
@@ -44,14 +44,14 @@ public struct AccessTokenPlugin: PluginType {
 
     /**
      Prepare a request by adding an authorization header if necessary.
-     
+
      - parameters:
        - request: The request to modify.
        - target: The target of the request.
      - returns: The modified `URLRequest`.
     */
     public func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
-        if let authorizable = target as? AccessTokenAuthorizable, !authorizable.shouldAuthorize {
+        if let authorizable = target as? AccessTokenAuthorizable, authorizable.shouldAuthorize == false {
             return request
         }
 

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Result
+
+// MARK: - AccessTokenAuthorizable
+
+public protocol AccessTokenAuthorizable {
+    var shouldAuthorize: Bool { get }
+}
+
+// MARK: - AccessTokenPlugin
+
+public struct AccessTokenPlugin: PluginType {
+    public let token: String
+
+    private var authVal: String {
+        return "Bearer " + token
+    }
+
+    public init(token: String) {
+        self.token = token
+    }
+
+    public func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
+        if let authorizable = target as? AccessTokenAuthorizable, !authorizable.shouldAuthorize {
+            return request
+        }
+
+        var request = request
+        request.addValue(authVal, forHTTPHeaderField: "Authorization")
+
+        return request
+    }
+}

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -1,0 +1,44 @@
+import Quick
+import Nimble
+import Moya
+import Result
+
+final class AccessTokenPluginSpec: QuickSpec {
+    struct TestTarget: TargetType, AccessTokenAuthorizable {
+        let baseURL = URL(string: "http://www.api.com/")!
+        let path = ""
+        let method = Method.get
+        let parameters: [String: Any]? = nil
+        let parameterEncoding: ParameterEncoding = URLEncoding.default
+        let task = Task.request
+        let sampleData = Data()
+
+        let shouldAuthorize: Bool
+    }
+
+    override func spec() {
+        let token = "eyeAm.AJsoN.weBTOKen"
+        let plugin = AccessTokenPlugin(token: token)
+
+        it("adds an authorization header to TargetTypes by default") {
+            let target = GitHub.zen
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Bearer eyeAm.AJsoN.weBTOKen"]
+        }
+
+        it("adds an authorization header to AccessTokenAuthorizables when it's supposed to") {
+            let target = TestTarget(shouldAuthorize: true)
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Bearer eyeAm.AJsoN.weBTOKen"]
+        }
+
+        it("doesn't add an authorization header to AccessTokenAuthorizables when it's not supposed to") {
+            let target = TestTarget(shouldAuthorize: false)
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            expect(preparedRequest.allHTTPHeaderFields).to(beNil())
+        }
+    }
+}

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -33,6 +33,52 @@ let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { target -> URL
 ])
 ```
 
+Bearer HTTP Auth
+----------------
+
+Another common method of authentication is by using an access token. Commonly
+this is a [JWT](https://jwt.io/introduction/), but it can take other forms as
+well. These requests are authorized by adding an HTTP header of the following
+form:
+
+```
+Authorization: Bearer <token>
+```
+
+To make adding these authorization headers easier, Moya comes with an
+`AccessTokenPlugin`. It can be added to your provider like this:
+
+```swift
+let token = "eyeAm.AJsoN.weBTOKen"
+let authPlugin = AccessTokenPlugin(token: token)
+let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
+```
+
+By default, `AccessTokenPlugin` will add the authorization header to requests to
+any `TargetType`. If you want to control this behavior, you can have your
+`TargetType` conform to `AccessTokenAuthorizable` and use `shouldAuthorize` to
+specify the behavior:
+
+```swift
+enum YourAPI: TargetType, AccessTokenAuthorizable {
+  case needsAuthorization
+  case doesntNeedAuthorization
+
+  /*
+  TargetType implementation
+  */
+
+  var shouldAuthorize: Bool {
+    switch self {
+    case .needsAuthorization:
+      return true
+    case .doesntNeedAuthorization:
+      return false
+    }
+  }
+}
+```
+
 OAuth
 -----
 

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -61,8 +61,8 @@ specify the behavior:
 
 ```swift
 enum YourAPI: TargetType, AccessTokenAuthorizable {
-  case needsAuthorization
-  case doesntNeedAuthorization
+  case targetThatNeedsAuthorization
+  case targetThatDoesntNeedAuthorization
 
   /*
   TargetType implementation
@@ -70,9 +70,9 @@ enum YourAPI: TargetType, AccessTokenAuthorizable {
 
   var shouldAuthorize: Bool {
     switch self {
-    case .needsAuthorization:
+    case .targetThatNeedsAuthorization:
       return true
-    case .doesntNeedAuthorization:
+    case .targetThatDoesntNeedAuthorization:
       return false
     }
   }

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -54,9 +54,9 @@ let authPlugin = AccessTokenPlugin(token: token)
 let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
 ```
 
-By default, `AccessTokenPlugin` will add the authorization header to requests to
-any `TargetType`. If you want to control this behavior, you can have your
-`TargetType` conform to `AccessTokenAuthorizable` and use `shouldAuthorize` to
+By default, `AccessTokenPlugin` will add the authorization header to all
+requests. If you want to control this behavior for a `TargetType`, you can
+conform to `AccessTokenAuthorizable` and use `shouldAuthorize` to
 specify the behavior:
 
 ```swift


### PR DESCRIPTION
Following through with the promise of #813, this PR adds a new `PluginType` called `AccessTokenPlugin`. This plugin can be added to a `MoyaProvider` to add authorization headers of the form:

```
Authorization: Bearer <token>
```

By default, this plugin will add the auth header to all `TargetType`s. However, if you want to control this behavior, you can have your `TargetType` conform to `AccessTokenAuthorizable` and provide `var shouldAuthorize: Bool { get }`.