### PR TITLE
Update Carthage install instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -114,9 +114,8 @@ Then run `pod install`.
 
 Carthage users can point to this repository and use whichever
 generated framework they'd like, `Moya`, `RxMoya`, or `ReactiveMoya`.
-The full Moya framework is bundled in each of those frameworks;
-importing more than one framework in a single file will result in
-ambiguous lookups at compile time.
+When linking frameworks remember to always link `Moya` along with `RxMoya` and 
+`ReactiveMoya`, if you use any of these.
 
 ```
 github "Moya/Moya"


### PR DESCRIPTION
With #563 it changes how Moya is used with Carthage. It seems that the importing conflicts are resolved, but the current wording can also be confusing, since it seems to suggest you only link either `RxMoya` or `ReactiveMoya` if you use either of these.

Granted I can have misunderstood how Moya should be used with Carthage.