### PR TITLE
[WIP] MoyaProvider variant without generic parameter

### DIFF
--- a/docs/Examples/MultiTarget.md
+++ b/docs/Examples/MultiTarget.md
@@ -35,3 +35,98 @@ want to see this API in action, check out our
 targets: one of them is `Demo`, which uses the basic form of Moya, and the
 second one is `DemoMultiTarget`, which uses the modified version with usage of
 `MultiTarget`.
+
+
+## Multiple targets when using `associatedtype`
+
+Using Moya enables you to statically verify the arguments when invoking a
+network request. You might want to extend Moya's `TargetType` to verify your
+custom types. One use case is to have the `request` method return deserialized
+models which vary based on request, instead of `MoyaResponse`. This can be
+achieved by adding an `associatedtype` to `TargetType`
+
+```swift
+protocol DecodableTargetType: Moya.TargetType {
+    associatedType ResultType: SomeJSONDecodableProtocolConformance
+}
+
+enum UserApi : DecodableTargetType {
+    case get(id: Int)
+    case update(id: Int, name: String)
+    ...
+
+    var baseURL: URL { ... }
+    var path: String { switch self ... }
+    var method: Moya.Method { ... }
+
+    typealias ResultType = UserModel
+}
+```
+
+Because of `associatedtype`, `MultiTarget` cannot be used with `DecodableTargetType`.
+Instead, we can use the `MultiMoyaProvider` variant. It does not require a
+generic argument. Thus, requests can be invoked with any instance that
+conforms to `TargetType`. Using `MultiMoyaProvider` allows you to write
+request wrappers which can make use of your `associatedtype`s.
+
+For example, we can build a `requestDecoded` method that returns `ResultType`
+instead of `MoyaResponse` as
+
+```swift
+extension MultiMoyaProvider {
+  func requestDecoded<T: DecodableTargetType>(_ target: T, completion: @escaping (_ result: Result<[T.ResultType], Moya.Error>) -> ()) -> Cancellable {
+
+      return request(target) { result in
+          switch result {
+          case .success(let response):
+              if let parsed = T.ResultType.parse(try! response.mapJSON()) {
+                  completion(.success(parsed))
+              }
+              else {
+                  completion(.failure(.jsonMapping(response)))
+              }
+
+          case .failure(let error):
+              completion(.failure(error))
+          }
+      }
+  }
+}
+```
+
+The beauty of this is that the type of input in the callback is implicitly
+determined from the target passed.
+
+You can pass any `DecodableTargetType` to start a request
+```swift
+let provider = MultiMoyaProvider()
+provider.requestDecoded(UserApi.get(id: 1)) { result in
+    switch result {
+    case .success(let user):
+      // type of `user` is implicitly `UserModel`. Using any other type results
+      // in compile error
+      print(user.name)
+    }
+}
+```
+
+When using `associatedtype`, you will have to define different targets to work
+with different types. For example, lets say we have another target `SessionApi`
+
+```swift
+struct SessionApi: DecodableTargetType {
+  typealias ResultType = SessionModel
+}
+```
+
+which has a different `ResultType`. We can use the same `MultiMoyaProvider`
+instance
+
+```swift
+provider.requestDecoded(SessionApi.get) { result in
+  switch result {
+  case .success(let session):
+    // type of `user` is implicitly `SessionModel` here
+  }
+}
+```


### PR DESCRIPTION
This is based on #830. I have updated only the docs to provide a usecase for why this is required.
I strongly think that this will enable end-users to extend Moya's functionality in different ways which are not possible right now. 

Would love to have feedback on whether this makes sense.
I am not sure where exactly this documentation belongs. Fundamentally, this feature provides a MoyaProvider that can be used with different targets. Hence, I added it to `MultiTarget`.

I would like to start working on the implementation as soon as this requirement is validated.