### PR TITLE
Added a progress parameter to the reactive providers 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
 - Fixed an issue where `RxMoyaProvider` never sends `next` or errors if it's disposed before a subscription is made.
+- Added a progress parameter to the reactive providers to track progress changes of upload & download tasks.
 
 # 8.0.0
 

--- a/Sources/ReactiveMoya/ReactiveSwiftMoyaProvider.swift
+++ b/Sources/ReactiveMoya/ReactiveSwiftMoyaProvider.swift
@@ -19,11 +19,11 @@ open class ReactiveSwiftMoyaProvider<Target>: MoyaProvider<Target> where Target:
     }
 
     /// Designated request-making method.
-    open func request(_ token: Target) -> SignalProducer<Response, MoyaError> {
+    open func request(_ token: Target, progress: ProgressBlock? = nil) -> SignalProducer<Response, MoyaError> {
 
         // Creates a producer that starts a request each time it's started.
         return SignalProducer { [weak self] observer, requestDisposable in
-            let cancellableToken = self?.request(token) { result in
+            let cancellableToken = self?.request(token, queue: nil, progress: progress, completion: { (result) in
                 switch result {
                 case let .success(response):
                     observer.send(value: response)
@@ -31,7 +31,7 @@ open class ReactiveSwiftMoyaProvider<Target>: MoyaProvider<Target> where Target:
                 case let .failure(error):
                     observer.send(error: error)
                 }
-            }
+            })
 
             requestDisposable.add {
                 // Cancel the request

--- a/Sources/RxMoya/RxMoyaProvider.swift
+++ b/Sources/RxMoya/RxMoyaProvider.swift
@@ -21,8 +21,7 @@ open class RxMoyaProvider<Target>: MoyaProvider<Target> where Target: TargetType
 
         // Creates an observable that starts a request each time it's subscribed to.
         return Observable.create { observer in
-            let cancellableToken = self?.request(token, queue: nil, progress: progress, completion:
-                { (result) in
+            let cancellableToken = self.request(token, queue: nil, progress: progress, completion: { (result) in
                 switch result {
                 case let .success(response):
                     observer.onNext(response)

--- a/Sources/RxMoya/RxMoyaProvider.swift
+++ b/Sources/RxMoya/RxMoyaProvider.swift
@@ -17,11 +17,12 @@ open class RxMoyaProvider<Target>: MoyaProvider<Target> where Target: TargetType
     }
 
     /// Designated request-making method.
-    open func request(_ token: Target) -> Observable<Response> {
+    open func request(_ token: Target, progress: ProgressBlock? = nil) -> Observable<Response> {
 
         // Creates an observable that starts a request each time it's subscribed to.
         return Observable.create { observer in
-            let cancellableToken = self.request(token) { result in
+            let cancellableToken = self?.request(token, queue: nil, progress: progress, completion:
+                { (result) in
                 switch result {
                 case let .success(response):
                     observer.onNext(response)
@@ -29,7 +30,7 @@ open class RxMoyaProvider<Target>: MoyaProvider<Target> where Target: TargetType
                 case let .failure(error):
                     observer.onError(error)
                 }
-            }
+            })
 
             return Disposables.create {
                 cancellableToken.cancel()

--- a/Tests/ReactiveSwiftMoyaProviderTests.swift
+++ b/Tests/ReactiveSwiftMoyaProviderTests.swift
@@ -69,8 +69,8 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
 
                         super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                 }
-
-                override func request(_ target: Target, completion: @escaping Moya.Completion) -> Cancellable {
+                
+                override func request(_ target: Target, queue: DispatchQueue?, progress: Moya.ProgressBlock? = nil, completion: @escaping Moya.Completion) -> Cancellable {
                     return TestCancellable()
                 }
             }
@@ -157,7 +157,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                             super.init(endpointClosure: endpointClosure, requestClosure: requestClosure, stubClosure: stubClosure, manager: manager, plugins: plugins)
                     }
                     
-                    override func request(_ target: Target, completion: @escaping Moya.Completion) -> Cancellable {
+                    override func request(_ target: Target, queue: DispatchQueue?, progress: Moya.ProgressBlock? = nil, completion: @escaping Moya.Completion) -> Cancellable {
                         return TestCancellable()
                     }
                 }


### PR DESCRIPTION
This pull requests adds a progress parameter to the reactive providers to track progress changes of upload & download tasks. Currently it's impossible to track these changes and to use the same Moya provider for download & upload tasks.