### PR TITLE
Changes build badge to reflect state of branch master

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://img.shields.io/circleci/project/github/Moya/Moya.svg)](https://circleci.com/gh/Moya/Moya)
+[![CircleCI](https://circleci.com/gh/Moya/Moya/tree/master.svg?style=svg)](https://circleci.com/gh/Moya/Moya/tree/master)
 [![codecov.io](https://codecov.io/github/Moya/Moya/coverage.svg?branch=master)](https://codecov.io/github/Moya/Moya?branch=master)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/Moya.svg)](https://cocoapods.org/pods/Moya)


### PR DESCRIPTION
The build badge was reflecting the status of the latest build in Circle CI, which very often is not on branch `master`.

This changes the badge to reflect the status of `master`.

