### PR TITLE
Updates regex to accept X.Y.Z-beta.W versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -157,12 +157,12 @@ desc 'Release a version, specified as an argument.'
 task :release, :version do |task, args|
   version = args[:version]
   # Needs a X.Y.Z-text format.
-  abort "You must specify a version in semver format." if version.nil? || version.scan(/\d+\.\d+\.\d+/).length == 0
+  abort "You must specify a version in semver format." if version.nil? || version.scan(/\d+\.\d+\.\d+(-\w+\.\d+)?/).length == 0
 
   puts "Updating podspec."
   filename = "Moya.podspec"
   contents = File.read(filename)
-  contents.gsub!(/s\.version\s*=\s"\d+\.\d+\.\d+"/, "s.version      = \"#{version}\"")
+  contents.gsub!(/s\.version\s*=\s"\d+\.\d+\.\d+(-\w+\.\d)?"/, "s.version      = \"#{version}\"")
   File.open(filename, 'w') { |file| file.puts contents }
 
   puts "Updating Demo project."


### PR DESCRIPTION
Fixes #811 

@ashfurrow [gave us the answer](https://github.com/Moya/Moya/issues/792#issuecomment-262812613) in #792: the semver regex should accept an optional `-beta.a`.

I didn't hardcode it `beta` to give us the flexibility to go with `alpha`, `rc` or whatever makes sense in future versions. 