### PR TITLE
Changes POST example in Basic.md to send parameters as JSON

### DIFF
--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -53,9 +53,9 @@ extension MyService: TargetType {
 
     var parameterEncoding: ParameterEncoding {
         switch self {
-        case .zen, .showUser, .showAccounts, .updateUser(_, _, _):
+        case .zen, .showUser, .showAccounts, .updateUser:
             return URLEncoding.default // Send parameters in URL
-        case .createUser(_, _):
+        case .createUser:
             return JSONEncoding.default // Send parameters as JSON in request body
         }
     }

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -30,7 +30,7 @@ extension MyService: TargetType {
         case .createUser(_, _):
             return "/users"
         case .showAccounts:
-        	  return "/accounts"
+            return "/accounts"
         }
     }
     var method: Moya.Method {
@@ -49,8 +49,14 @@ extension MyService: TargetType {
             return ["first_name": firstName, "last_name": lastName]
         }
     }
+
     var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
+        switch self {
+        case .zen, .showUser, .showAccounts:
+            return URLEncoding.default
+        case .createUser(_, _):
+            return JSONEncoding.default // Send parameters as JSON in request body
+        }
     }
     var sampleData: Data {
         switch self {
@@ -63,20 +69,19 @@ extension MyService: TargetType {
         case .showAccounts:
             // Provided you have a file named accounts.json in your bundle.
             guard let path = Bundle.main.path(forResource: "accounts", ofType: "json"),
-                  let data = Data(base64Encoded: path) else {
-                      return Data()
+                let data = Data(base64Encoded: path) else {
+                    return Data()
             }
             return data
         }
     }
     var task: Task {
         switch self {
-            case .zen, .showUser, .createUser, .showAccounts:
-                return .request
+        case .zen, .showUser, .createUser, .showAccounts:
+            return .request
         }
     }
 }
-
 // MARK: - Helpers
 private extension String {
     var urlEscaped: String {
@@ -101,8 +106,13 @@ provider.request(.createUser(firstName: "James", lastName: "Potter")) { result i
     // do something with the result (read on for more details)
 }
 
-// The full request will result to the following (by default):
-// POST https://api.myservice.com/users?first_name=James&last_name=Potter
+// The full request will result to the following:
+// POST https://api.myservice.com/users
+// Request body: 
+// { 
+//  "first_name": "James", 
+//  "last_name": "Potter" 
+// }
 ```
 
 The `TargetType` specifies both a base URL for the API and the sample data for


### PR DESCRIPTION
The POST example in `Basic.md` currently sends the parameters encoded in the URL. I don't think this is the most common way of sending parameters in a POST request 🤔  

I believe the usual case is to send parameters in the request body as JSON. Having this in the most basic example may be more helpful to people using Moya for the first time.