### PR TITLE
Add explicit dependency on Result.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
 github "Alamofire/Alamofire" ~> 4.1
 github "ReactiveCocoa/ReactiveSwift" ~> 1.0
 github "ReactiveX/RxSwift" ~> 3.0
+github "antitypical/Result" ~> 3.1


### PR DESCRIPTION
We shouldn't rely on this being there from ReactiveSwift.