### PR TITLE
In Demo, change completion for GitHub.userRepositories to use dematerialize()

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -26,24 +26,15 @@ class ViewController: UITableViewController {
 
     func downloadRepositories(_ username: String) {
          GitHubProvider.request(.userRepositories(username)) { result in
-            switch result {
-            case let .success(response):
-                do {
-                    if let json = try response.mapJSON() as? NSArray {
-                        // Presumably, you'd parse the JSON into a model object. This is just a demo, so we'll keep it as-is.
-                        self.repos = json
-                    } else {
-                        self.showAlert("GitHub Fetch", message: "Unable to fetch from GitHub")
-                    }
-                } catch {
-                    self.showAlert("GitHub Fetch", message: "Unable to fetch from GitHub")
-                }
+            do {
+                let response = try result.dematerialize()
+                let value = try response.mapNSArray()
+                self.repos = value
                 self.tableView.reloadData()
-            case let .failure(error):
-                guard let error = error as? CustomStringConvertible else {
-                    break
-                }
-                self.showAlert("GitHub Fetch", message: error.description)
+            } catch {
+                let printableError = error as? CustomStringConvertible
+                let errorMessage = printableError?.description ?? "Unable to fetch from GitHub"
+                self.showAlert("GitHub Fetch", message: errorMessage)
             }
         }
     }

--- a/Demo/DemoMultiTarget/ViewController.swift
+++ b/Demo/DemoMultiTarget/ViewController.swift
@@ -27,25 +27,16 @@ class ViewController: UITableViewController {
     // MARK: - API Stuff
     
     func downloadRepositories(_ username: String) {
-        provider.request(MultiTarget(GitHub.userRepositories(username))) { result in
-            switch result {
-            case let .success(response):
-                do {
-                    if let json = try response.mapJSON() as? NSArray {
-                        // Presumably, you'd parse the JSON into a model object. This is just a demo, so we'll keep it as-is.
-                        self.repos = json
-                    } else {
-                        self.showAlert("GitHub Fetch", message: "Unable to fetch from GitHub")
-                    }
-                } catch {
-                    self.showAlert("GitHub Fetch", message: "Unable to fetch from GitHub")
-                }
+        provider.request(.userRepositories(username)) { result in
+            do {
+                let response = try result.dematerialize()
+                let value = try response.mapNSArray()
+                self.repos = value
                 self.tableView.reloadData()
-            case let .failure(error):
-                guard let error = error as? CustomStringConvertible else {
-                    break
-                }
-                self.showAlert("GitHub Fetch", message: error.description)
+            } catch {
+                let printableError = error as? CustomStringConvertible
+                let errorMessage = printableError?.description ?? "Unable to fetch from GitHub"
+                self.showAlert("GitHub Fetch", message: errorMessage)
             }
         }
     }

--- a/Demo/Shared/GitHubAPI.swift
+++ b/Demo/Shared/GitHubAPI.swift
@@ -81,3 +81,16 @@ extension GitHub: TargetType {
 public func url(_ route: TargetType) -> String {
     return route.baseURL.appendingPathComponent(route.path).absoluteString
 }
+
+//MARK: - Response Handlers
+
+extension Moya.Response {
+    func mapNSArray() throws -> NSArray {
+        let any = try self.mapJSON()
+        guard let array = any as? NSArray else {
+            throw MoyaError.jsonMapping(self)
+        }
+        return array
+    }
+}
+


### PR DESCRIPTION
This creates a much cleaner completion block by using the Result method `dematerialize()` in the same do-try-catch block as the response mapping. Adds a `mapNSArray()` extension to Response in GitHubAPI.swift to support this and as an example. Also an example of how to create a error message from an error with default.

See #950 for more discussion.

  