### PR TITLE
Updated capitalization in Endpoint docs.

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -66,8 +66,8 @@ analytics.
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let defaultEndpoint = MoyaProvider.defaultEndpointMapping(target)
-    return defaultEndpoint.adding(newHttpHeaderFields: ["APP_NAME": "MY_AWESOME_APP"])
+    let defaultEndpoint = MoyaProvider.defaultEndpointMapping(for: target)
+    return defaultEndpoint.adding(newHTTPHeaderFields: ["APP_NAME": "MY_AWESOME_APP"])
 }
 let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)
 ```
@@ -80,14 +80,14 @@ target that actually does the authentication. We could construct an
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let defaultEndpoint = MoyaProvider.defaultEndpointMapping(target)
+    let defaultEndpoint = MoyaProvider.defaultEndpointMapping(for: target)
 
     // Sign all non-authenticating requests
     switch target {
     case .authenticate:
         return defaultEndpoint
     default:
-        return defaultEndpoint.adding(newHttpHeaderFields: ["AUTHENTICATION_TOKEN": GlobalAppStorage.authToken])
+        return defaultEndpoint.adding(newHTTPHeaderFields: ["AUTHENTICATION_TOKEN": GlobalAppStorage.authToken])
     }
 }
 let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)


### PR DESCRIPTION
According to the [changelog](https://github.com/Moya/Moya/blob/master/Changelog.md), there were slight changes made to the capitalization of `newHttpHeaderFields`. I've updated the docs to reflect the change.

Solves #961