### PR TITLE
Fixed `reversedPrint` arguments for output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- Fixed `reversedPrint` arguments for output.
+
 # 8.0.2
 
 - Changed dependency pinning to rely only on major versions.

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -9,14 +9,14 @@ public final class NetworkLoggerPlugin: PluginType {
     fileprivate let separator = ", "
     fileprivate let terminator = "\n"
     fileprivate let cURLTerminator = "\\\n"
-    fileprivate let output: (_ seperator: String, _ terminator: String, _ items: Any...) -> Void
+    fileprivate let output: (_ separator: String, _ terminator: String, _ items: Any...) -> Void
     fileprivate let responseDataFormatter: ((Data) -> (Data))?
 
     /// If true, also logs response body data.
     public let isVerbose: Bool
     public let cURL: Bool
 
-    public init(verbose: Bool = false, cURL: Bool = false, output: @escaping (_ seperator: String, _ terminator: String, _ items: Any...) -> Void = NetworkLoggerPlugin.reversedPrint, responseDataFormatter: ((Data) -> (Data))? = nil) {
+    public init(verbose: Bool = false, cURL: Bool = false, output: @escaping (_ separator: String, _ terminator: String, _ items: Any...) -> Void = NetworkLoggerPlugin.reversedPrint, responseDataFormatter: ((Data) -> (Data))? = nil) {
         self.cURL = cURL
         self.isVerbose = verbose
         self.output = output
@@ -103,7 +103,9 @@ private extension NetworkLoggerPlugin {
 }
 
 fileprivate extension NetworkLoggerPlugin {
-    static func reversedPrint(seperator: String, terminator: String, items: Any...) {
-        print(items, separator: seperator, terminator: terminator)
+    static func reversedPrint(_ separator: String, terminator: String, items: Any...) {
+        for item in items {
+            print(item, separator: separator, terminator: terminator)
+        }
     }
 }


### PR DESCRIPTION
Related to #612, it fixed an issue where `reversedPrint` is printing an array of `items` which will ignore the separator and terminator that has been set. Without this, pretty print (e.g. with JSON pretty print) is broken. 

* Variadic argument needs to be enumerated and its element printed
* Renamed seperator to separator