### PR TITLE
get response and error when use Alamofire validation

### DIFF
--- a/Sources/Moya/Moya+Alamofire.swift
+++ b/Sources/Moya/Moya+Alamofire.swift
@@ -86,3 +86,22 @@ extension DownloadRequest: Requestable {
         }
     }
 }
+
+extension Swift.Error {
+    internal func convertToMoyaError(response: Moya.Response?) -> MoyaError {
+        if let afError = self as? AFError {
+            switch afError {
+            case .responseValidationFailed:
+                if let response = response {
+                    return MoyaError.statusCode(response)
+                } else {
+                    return MoyaError.underlying(self)
+                }
+            case .invalidURL, .parameterEncodingFailed, .multipartEncodingFailed, .responseSerializationFailed:
+                return MoyaError.underlying(self)
+            }
+        } else {
+            return MoyaError.underlying(self)
+        }
+    }
+}

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -249,7 +249,7 @@ private extension MoyaProvider {
         }
 
         let completionHandler: RequestableCompletion = { response, request, data, error in
-            let result = convertResponseToResult(response, request: request, data: data, error: error)
+            let result = convertResponseToResult(response, target: target, request: request, data: data, error: error)
             // Inform all plugins about the response
             plugins.forEach { $0.didReceive(result, target: target) }
             progressCompletion?(ProgressResponse(response: result.value))

--- a/Sources/Moya/MoyaProvider.swift
+++ b/Sources/Moya/MoyaProvider.swift
@@ -144,12 +144,20 @@ public extension MoyaProvider {
     }
 }
 
-public func convertResponseToResult(_ response: HTTPURLResponse?, request: URLRequest?, data: Data?, error: Swift.Error?) ->
+public func convertResponseToResult(_ response: HTTPURLResponse?, target: TargetType, request: URLRequest?, data: Data?, error: Swift.Error?) ->
     Result<Moya.Response, MoyaError> {
         switch (response, data, error) {
         case let (.some(response), data, .none):
             let response = Moya.Response(statusCode: response.statusCode, data: data ?? Data(), request: request, response: response)
             return .success(response)
+        case let (.some(response), data, .some(error)):
+            let response = Moya.Response(statusCode: response.statusCode, data: data ?? Data(), request: request, response: response)
+            if target.validate {
+                return .failure(error.convertToMoyaError(response: response))
+            } else {
+                let error = MoyaError.underlying(error)
+                return .failure(error)
+            }
         case let (_, _, .some(error)):
             let error = MoyaError.underlying(error)
             return .failure(error)

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import Alamofire
 @testable
 import Moya
 
@@ -73,23 +74,71 @@ class ErrorTests: QuickSpec {
         }
 
         describe("Alamofire responses should return the errors where appropriate") {
-            it("should return the underlying error in spite of having a response and data") {
-                let underlyingError = NSError(domain: "", code: 0, userInfo: nil)
-                let request = NSURLRequest() as URLRequest
-                let response = HTTPURLResponse()
-                let data = Data()
-                let result = convertResponseToResult(response, request: request, data: data, error: underlyingError)
-                switch result {
-                case let .failure(error):
-                    switch error {
-                    case let .underlying(e):
-                        expect(e as NSError) == underlyingError
-                    default:
-                        XCTFail("expected to get underlying error")
-                    }
+            context("when error is underlying error") {
+                it("should return the underlying error in spite of having a response and data") {
+                    let underlyingError = NSError(domain: "", code: 0, userInfo: nil)
+                    let request = NSURLRequest() as URLRequest
+                    let response = HTTPURLResponse()
+                    let data = Data()
+                    let result = convertResponseToResult(response, target: GitHub.zen, request: request, data: data, error: underlyingError)
+                    switch result {
+                    case let .failure(error):
+                        switch error {
+                        case let .underlying(e):
+                            expect(e as NSError) == underlyingError
+                        default:
+                            XCTFail("expected to get underlying error")
+                        }
 
-                case .success:
-                    XCTFail("expected to be failing result")
+                    case .success:
+                        XCTFail("expected to be failing result")
+                    }
+                }
+            }
+
+            context("when error is Alamofire Error") {
+                context("without Alamofire validation") {
+                    it("should return the underlying error in spite of having a response and data") {
+                        let httpError = AFError.responseValidationFailed(reason: AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: 404))
+                        let request = NSURLRequest() as URLRequest
+                        let response = HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 404, httpVersion: nil, headerFields: nil)
+                        let data = Data()
+                        let result = convertResponseToResult(response, target: GitHub.zen, request: request, data: data, error: httpError)
+                        switch result {
+                        case let .failure(error):
+                            switch error {
+                            case let .underlying(e):
+                                expect(e).to(beAnInstanceOf(AFError.self))
+                            default:
+                                XCTFail("expected to get underlying error")
+                            }
+
+                        case .success:
+                            XCTFail("expected to be failing result")
+                        }
+                    }
+                }
+
+                context("with Alamofire validation") {
+                    it("should return the status code error in spite of having a response and data") {
+                        let httpError = AFError.responseValidationFailed(reason: AFError.ResponseValidationFailureReason.unacceptableStatusCode(code: 404))
+                        let request = NSURLRequest() as URLRequest
+                        let response = HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 404, httpVersion: nil, headerFields: nil)
+                        let data = Data()
+                        let result = convertResponseToResult(response, target: GitHub.searchRepositories(""), request: request, data: data, error: httpError)
+                        switch result {
+                        case let .failure(error):
+                            switch error {
+                            case let .statusCode(res):
+                                expect(res.statusCode).to(equal(404))
+                            default:
+                                XCTFail("expected to get underlying error")
+                            }
+
+                        case .success:
+                            XCTFail("expected to be failing result")
+                        }
+                    }
                 }
             }
         }

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -37,7 +37,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
 
             OHHTTPStubs.stubRequests(passingTest: {$0.url!.path == "/search/repositories"}) { request in
                 if request.url?.query == "q=" {
-                    return OHHTTPStubsResponse(data: GitHub.searchRepositories("abc").sampleData, statusCode: 400, headers: nil)
+                    return OHHTTPStubsResponse(data: GitHub.searchRepositories("").sampleData, statusCode: 400, headers: nil)
                 } else {
                     return OHHTTPStubsResponse(data: GitHub.searchRepositories("abc").sampleData, statusCode: 200, headers: nil)
                 }
@@ -89,19 +89,19 @@ class MoyaProviderIntegrationTests: QuickSpec {
 
                     describe("with validation") {
                         it("returns success for search result request") {
-                            var statusCode: Int?
+                            var message: String?
 
                             waitUntil { done in
-                                let target: GitHub = .searchRepositories("")
+                                let target: GitHub = .searchRepositories("abc")
                                 provider.request(target) { result in
-                                if case let .success(response) = result {
-                                        statusCode = response.statusCode
+                                    if case let .success(response) = result {
+                                        message = String(data: response.data, encoding: .utf8)
                                     }
                                     done()
                                 }
                             }
 
-                            expect(statusCode).to(equal(200))
+                            expect(message).notTo(beNil())
                         }
 
                         it("returns failure for search result request") {

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -141,7 +141,7 @@ class MoyaProviderSpec: QuickSpec {
 
         it("uses the target's parameter encoding") {
             let endpoint = MoyaProvider.defaultEndpointMapping(for: GitHub.zen)
-            expect(endpoint.parameterEncoding is JSONEncoding) == true
+            expect(endpoint.parameterEncoding is URLEncoding) == true
         }
 
         describe("a provider with delayed stubs") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -42,7 +42,7 @@ extension GitHub: TargetType {
     }
 
     public var parameterEncoding: ParameterEncoding {
-        return JSONEncoding.default
+        return URLEncoding.default
     }
 
     var task: Task {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -10,6 +10,7 @@ extension String {
 enum GitHub {
     case zen
     case userProfile(String)
+    case searchRepositories(String)
 }
 
 extension GitHub: TargetType {
@@ -20,6 +21,8 @@ extension GitHub: TargetType {
             return "/zen"
         case .userProfile(let name):
             return "/users/\(name.urlEscaped)"
+        case .searchRepositories:
+            return "/search/repositories"
         }
     }
     
@@ -28,7 +31,14 @@ extension GitHub: TargetType {
     }
     
     var parameters: [String: Any]? {
-        return nil
+        switch self {
+        case .zen:
+            return nil
+        case .userProfile:
+            return nil
+        case .searchRepositories(let keyword):
+            return ["q": keyword]
+        }
     }
 
     public var parameterEncoding: ParameterEncoding {
@@ -45,6 +55,23 @@ extension GitHub: TargetType {
             return "Half measures are as bad as nothing at all.".data(using: String.Encoding.utf8)!
         case .userProfile(let name):
             return "{\"login\": \"\(name)\", \"id\": 100}".data(using: String.Encoding.utf8)!
+        case .searchRepositories(let keyword):
+            if keyword.isEmpty {
+                return "{\"message\": \"error\"}".data(using: String.Encoding.utf8)!
+            } else {
+                return "{\"name\": \"\(keyword)\"}".data(using: String.Encoding.utf8)!
+            }
+        }
+    }
+
+    var validate: Bool {
+        switch self {
+        case .zen:
+            return false
+        case .userProfile:
+            return false
+        case .searchRepositories:
+            return true
         }
     }
 }


### PR DESCRIPTION
I tried to solve this problem.
https://github.com/Moya/Moya/issues/975

This change does not affect to current behavior, so I pull request to master branch.

## solved problem
when use Alamofire validation, we cannot get response in failure result.

## how to solved
check the Target is using "validate" in convertResponseToResult()