### PR TITLE
[Proposal] Add target to EndPoint<Target>

### DIFF
--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -18,6 +18,7 @@ public enum EndpointSampleResponse {
 open class Endpoint<Target> {
     public typealias SampleResponseClosure = () -> EndpointSampleResponse
 
+    open let source: Target
     open let url: String
     open let method: Moya.Method
     open let sampleResponseClosure: SampleResponseClosure
@@ -26,13 +27,15 @@ open class Endpoint<Target> {
     open let httpHeaderFields: [String: String]?
 
     /// Main initializer for `Endpoint`.
-    public init(url: String,
+    public init(source: Target,
+                url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method = Moya.Method.get,
                 parameters: [String: Any]? = nil,
                 parameterEncoding: Moya.ParameterEncoding = URLEncoding.default,
                 httpHeaderFields: [String: String]? = nil) {
 
+        self.source = source
         self.url = url
         self.sampleResponseClosure = sampleResponseClosure
         self.method = method
@@ -61,7 +64,7 @@ open class Endpoint<Target> {
         let newParameters = add(parameters: parameters)
         let newHTTPHeaderFields = add(httpHeaderFields: httpHeaderFields)
         let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
+        return Endpoint(source: source, url: url, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
     }
 
     fileprivate func add(parameters: [String: Any]?) -> [String: Any]? {

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -6,6 +6,7 @@ public extension MoyaProvider {
     public final class func defaultEndpointMapping(for target: Target) -> Endpoint<Target> {
         let url = target.baseURL.appendingPathComponent(target.path).absoluteString
         return Endpoint(
+            source: target,
             url: url,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -11,7 +11,7 @@ class EndpointSpec: QuickSpec {
                 let target: GitHub = .zen
                 let parameters = ["Nemesis": "Harvey"]
                 let headerFields = ["Title": "Dominar"]
-                endpoint = Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, parameters: parameters, parameterEncoding: JSONEncoding.default, httpHeaderFields: headerFields)
+                endpoint = Endpoint<GitHub>(source: target, url: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, parameters: parameters, parameterEncoding: JSONEncoding.default, httpHeaderFields: headerFields)
             }
             
             it("returns a new endpoint for adding(newParameters:)") {
@@ -98,7 +98,8 @@ class EndpointSpec: QuickSpec {
             }
 
             it("returns a nil urlRequest for an invalid URL") {
-                let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) })
+                // FIXME: no target
+                let badEndpoint = Endpoint<Empty>(source: target, url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) })
 
                 expect(badEndpoint.urlRequest).to( beNil() )
             }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -383,7 +383,7 @@ class MoyaProviderSpec: QuickSpec {
             it("returns sample data") {
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
+                    return Endpoint(source: target, url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -401,7 +401,7 @@ class MoyaProviderSpec: QuickSpec {
                 let response = HTTPURLResponse(url: URL(string: "http://example.com")!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method, parameters: target.parameters)
+                    return Endpoint(source: target, url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method, parameters: target.parameters)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -419,7 +419,7 @@ class MoyaProviderSpec: QuickSpec {
                 let error = NSError(domain: "Internal iOS Error", code: -1234, userInfo: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method, parameters: target.parameters)
+                    return Endpoint(source: target, url: url, sampleResponseClosure: { .networkError(error) }, method: target.method, parameters: target.parameters)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -55,7 +55,7 @@ func url(_ route: TargetType) -> String {
 
 let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.moyaerror", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(source: target, url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method, parameters: target.parameters)
 }
 
 enum HTTPBin: TargetType {


### PR DESCRIPTION
Added `source: Target` to EndPoint <Target>.

The reason for adding is to make it possible to create a Result according to the Target in RequestClosure of MoyaProvider.

For example, when requesting a specific Target, if the header does not contain the necessary parameters, it can be done as `completion (.failure ~)`.


### TODO

- [ ] Fix Tests
