### PR TITLE
fix memory leak in stub mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
 - Fixed `reversedPrint` arguments for output.
+- Fixed memory leak when request with stub
 
 # 8.0.2
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -151,6 +151,7 @@ public extension MoyaProvider {
     final func notifyPluginsOfImpendingStub(for request: URLRequest, target: Target) {
         let alamoRequest = manager.request(request as URLRequestConvertible)
         plugins.forEach { $0.willSend(alamoRequest, target: target) }
+        alamoRequest.cancel()
     }
 }
 


### PR DESCRIPTION
Seems like the `request` for plugin in stub mode never complete so just cancel it. It fix the memory leak issue. Related to https://github.com/Moya/Moya/issues/1000 