### PR TITLE
Reapply #993 into 9.0.0-dev

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+- **Breaking Change**: Added support to get the response (if any) from `MoyaError`.
+
 # 8.0.3
 
 - Fixed `reversedPrint` arguments for output.

--- a/Sources/Moya/MoyaError.swift
+++ b/Sources/Moya/MoyaError.swift
@@ -15,7 +15,7 @@ public enum MoyaError: Swift.Error {
     case statusCode(Response)
 
     /// Indicates a response failed due to an underlying `Error`.
-    case underlying(Swift.Error)
+    case underlying(Swift.Error, Response?)
 
     /// Indicates that an `Endpoint` failed to map to a `URLRequest`.
     case requestMapping(String)
@@ -29,7 +29,7 @@ public extension MoyaError {
         case .jsonMapping(let response): return response
         case .stringMapping(let response): return response
         case .statusCode(let response): return response
-        case .underlying: return nil
+        case .underlying(_, let response): return response
         case .requestMapping: return nil
         }
     }
@@ -50,7 +50,7 @@ extension MoyaError: LocalizedError {
             return "Status code didn't fall within the given range."
         case .requestMapping:
             return "Failed to map Endpoint to a URLRequest."
-        case .underlying(let error):
+        case .underlying(let error, _):
             return error.localizedDescription
         }
     }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -117,7 +117,7 @@ public extension MoyaProvider {
     // swiftlint:enable function_body_length
 
     func cancelCompletion(_ completion: Moya.Completion, target: Target) {
-        let error = MoyaError.underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+        let error = MoyaError.underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil), nil)
         plugins.forEach { $0.didReceive(.failure(error), target: target) }
         completion(.failure(error))
     }
@@ -140,7 +140,7 @@ public extension MoyaProvider {
                 plugins.forEach { $0.didReceive(.success(response), target: target) }
                 completion(.success(response))
             case .networkError(let error):
-                let error = MoyaError.underlying(error)
+                let error = MoyaError.underlying(error, nil)
                 plugins.forEach { $0.didReceive(.failure(error), target: target) }
                 completion(.failure(error))
             }
@@ -191,7 +191,7 @@ private extension MoyaProvider {
                 }
                 cancellable.innerCancellable = self.sendAlamofireRequest(alamoRequest, target: target, queue: queue, progress: progress, completion: completion)
             case .failure(let error):
-                completion(.failure(MoyaError.underlying(error as NSError)))
+                completion(.failure(MoyaError.underlying(error as NSError, nil)))
             }
         }
 

--- a/Sources/Moya/MoyaProvider.swift
+++ b/Sources/Moya/MoyaProvider.swift
@@ -150,11 +150,15 @@ public func convertResponseToResult(_ response: HTTPURLResponse?, request: URLRe
         case let (.some(response), data, .none):
             let response = Moya.Response(statusCode: response.statusCode, data: data ?? Data(), request: request, response: response)
             return .success(response)
+        case let (.some(response), _, .some(error)):
+            let response = Moya.Response(statusCode: response.statusCode, data: data ?? Data(), request: request, response: response)
+            let error = MoyaError.underlying(error, response)
+            return .failure(error)
         case let (_, _, .some(error)):
-            let error = MoyaError.underlying(error)
+            let error = MoyaError.underlying(error, nil)
             return .failure(error)
         default:
-            let error = MoyaError.underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil))
+            let error = MoyaError.underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil), nil)
             return .failure(error)
         }
 }

--- a/Sources/ReactiveMoya/SignalProducer+Response.swift
+++ b/Sources/ReactiveMoya/SignalProducer+Response.swift
@@ -63,7 +63,7 @@ private func unwrapThrowable<T>(throwable: () throws -> T) -> SignalProducer<T, 
             return SignalProducer(error: error)
         } else {
             // The cast above should never fail, but just in case.
-            return SignalProducer(error: MoyaError.underlying(error as NSError))
+            return SignalProducer(error: MoyaError.underlying(error as NSError, nil))
         }
     }
 }

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -40,7 +40,7 @@ class ErrorTests: QuickSpec {
 
             it("should not handle Underlying error ") {
                 let nsError = NSError(domain: "Domain", code: 200, userInfo: ["data" : "some data"])
-                let error = MoyaError.underlying(nsError)
+                let error = MoyaError.underlying(nsError, nil)
 
                 expect(error.response).to( beNil() )
             }
@@ -82,7 +82,7 @@ class ErrorTests: QuickSpec {
                 switch result {
                 case let .failure(error):
                     switch error {
-                    case let .underlying(e):
+                    case let .underlying(e, _):
                         expect(e as NSError) == underlyingError
                     default:
                         XCTFail("expected to get underlying error")

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -31,6 +31,10 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 return OHHTTPStubsResponse(data: GitHub.userProfile("ashfurrow").sampleData, statusCode: 200, headers: nil)
             }
             
+            OHHTTPStubs.stubRequests(passingTest: {$0.url!.path == "/users/invalid"}) { _ in
+                return OHHTTPStubsResponse(data: GitHub.userProfile("invalid").sampleData, statusCode: 400, headers: nil)
+            }
+            
             OHHTTPStubs.stubRequests(passingTest: {$0.url!.path == "/basic-auth/user/passwd"}) { _ in
                 return OHHTTPStubsResponse(data: HTTPBin.basicAuth.sampleData, statusCode: 200, headers: nil)
             }
@@ -80,6 +84,23 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         expect(message) == userMessage
                     }
 
+                    it("returns real response when validation fails") {
+                        var response: Response?
+                        
+                        waitUntil { done in
+                            let target: GitHub = .userProfile("invalid")
+                            provider.request(target) { result in
+                                if case let .failure(error) = result {
+                                    response = error.response
+                                }
+                                done()
+                            }
+                        }
+                        
+                        expect(response).toNot(beNil())
+                        expect(response?.statusCode).to(equal(400))
+                    }
+                    
                     it("uses a custom Alamofire.Manager request generation") {
                         let manager = StubManager()
                         let provider = MoyaProvider<GitHub>(manager: manager)
@@ -110,7 +131,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         var isMainThread: Bool?
                         let target: GitHub = .zen
                         
-                        waitUntil { done in 
+                        waitUntil { done in
                             provider.request(target) { _ in
                                 isMainThread = Thread.isMainThread
                                 done()

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -430,7 +430,7 @@ class MoyaProviderSpec: QuickSpec {
                     }
                 }
 
-                if case .some(MoyaError.underlying(let underlyingError as NSError)) = receivedError {
+                if case .some(MoyaError.underlying(let underlyingError as NSError, _)) = receivedError {
                     expect(underlyingError) == error
                 } else {
                     fail("Expected to receive error, did not.")
@@ -444,7 +444,7 @@ class MoyaProviderSpec: QuickSpec {
             beforeEach {
                 let endpointResolution: MoyaProvider<GitHub>.RequestClosure = { endpoint, done in
                     let underyingError = NSError(domain: "", code: 123, userInfo: nil)
-                    done(.failure(.underlying(underyingError)))
+                    done(.failure(.underlying(underyingError, nil)))
                 }
                 provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
             }
@@ -513,7 +513,7 @@ class MoyaProviderSpec: QuickSpec {
                 }
                 
                 switch receivedError {
-                case .some(.underlying(let error)):
+                case .some(.underlying(let error, _)):
                     expect(error.localizedDescription) == "Houston, we have a problem"
                 default:
                     fail("expected an Underlying error that Houston has a problem")
@@ -668,7 +668,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(error).toNot(beNil())
                 
                 let underlyingIsCancelled: Bool
-                if let error = error, case .underlying(let err) = error {
+                if let error = error, case .underlying(let err, _) = error {
                     underlyingIsCancelled = (err as NSError).code == NSURLErrorCancelled
                 } else {
                     underlyingIsCancelled = false

--- a/Tests/NetworkLoggerPluginSpec.swift
+++ b/Tests/NetworkLoggerPluginSpec.swift
@@ -86,7 +86,7 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
         it("outputs an empty response message") {
             let emptyResponseError = AFError.responseSerializationFailed(reason: .inputDataNil)
-            let result: Result<Moya.Response, MoyaError> = .failure(.underlying(emptyResponseError))
+            let result: Result<Moya.Response, MoyaError> = .failure(.underlying(emptyResponseError, nil))
 
             plugin.didReceive(result, target: GitHub.zen)
 

--- a/Tests/ReactiveSwiftMoyaProviderTests.swift
+++ b/Tests/ReactiveSwiftMoyaProviderTests.swift
@@ -31,7 +31,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 }
                 
                 switch receivedError {
-                case .some(.underlying(let error)):
+                case .some(.underlying(let error, _)):
                     expect(error.localizedDescription) == "Houston, we have a problem"
                 default:
                     fail("expected an Underlying error that Houston has a problem")

--- a/Tests/RxSwiftMoyaProviderTests.swift
+++ b/Tests/RxSwiftMoyaProviderTests.swift
@@ -75,7 +75,7 @@ class RxSwiftMoyaProviderSpec: QuickSpec {
                 })
 
                 switch receivedError {
-                case .some(.underlying(let error)):
+                case .some(.underlying(let error, _)):
                     expect(error.localizedDescription) == "Houston, we have a problem"
                 default:
                     fail("expected an Underlying error that Houston has a problem")

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -47,6 +47,10 @@ extension GitHub: TargetType {
             return "{\"login\": \"\(name)\", \"id\": 100}".data(using: String.Encoding.utf8)!
         }
     }
+    
+    var validate: Bool {
+        return true
+    }
 }
 
 func url(_ route: TargetType) -> String {

--- a/docs/Examples/Advanced.md
+++ b/docs/Examples/Advanced.md
@@ -37,4 +37,17 @@ extension MyService: TargetType {
     }
 }
 ```
-Alamofire automatic validation can be useful, for example if you want to use the [Alamofire's `RequestRetrier` and `RequestAdapter`](https://github.com/Alamofire/Alamofire#requestretrier), for an oAuth 2 ready Moya Client.
+Alamofire automatic validation can be useful, for example if you want to use the [Alamofire's `RequestRetrier` and `RequestAdapter`](https://github.com/Alamofire/Alamofire#requestretrier), for an OAuth 2 ready Moya Client.
+
+Also, if validation fails, you can get the response from the returned `MoyaError`.
+
+```swift
+provider.request(target) { result in
+    ...
+    if case let .failure(error) = result {
+        response = error.response
+        // Do something with the response
+    }
+    ...
+}
+```


### PR DESCRIPTION
We had an acidental merge of `9.0.0-dev` into `master`, which caused #993 to be merged in `master` (see #1013). However, as #993 had to be reverted in `master` (#1015), merging `master` into `9.0.0-dev` takes the revert of #993 as well.

This PR is the result of merging `master` into `9.0.0-dev`, cherry-picking 249e436ab1c32f212a195afbe411fe5234aba81f and fixing the entry in the changelog.