### PR TITLE
Fixes fourth-tier header in Advanced.md

### DIFF
--- a/docs/Examples/Advanced.md
+++ b/docs/Examples/Advanced.md
@@ -1,7 +1,7 @@
 Advanced
 =======
 
-####Alamofire automatic validation
+#### Alamofire automatic validation
 Sometimes, you will want to use [Alamofire automatic validation](https://github.com/Alamofire/Alamofire#automatic-validation) for some requests.
 When a request is configured with Alamofire validation, Moya will internally call Alamofire's  `validate()` method on the concerned `DataRequest`.
 


### PR DESCRIPTION
The parser seems to need that space between the header mark and the actual text 🤔 