### PR TITLE
Fixed link to `Code of Conduct.md`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -290,7 +290,7 @@ requests and help steer the ship :ship: You can read more details about that [in
 
 Moya's community has a tremendous positive energy, and the maintainers are committed to keeping things awesome. Like [in the CocoaPods community](https://github.com/CocoaPods/CocoaPods/wiki/Communication-&-Design-Rules), always assume positive intent; even if a comment sounds mean-spirited, give the person the benefit of the doubt.
 
-Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by [its terms](https://github.com/Moya/contributors/blob/master/Code of Conduct.md).
+Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by [its terms](https://github.com/Moya/contributors/blob/master/Code%20of%20Conduct.md).
 
 ### Adding new source files
 


### PR DESCRIPTION
Fixes link to [`Code of Conduct.md`](https://github.com/Moya/contributors/blob/master/Code%20of%20Conduct.md) by replacing the spaces in url with [url encoded characters](https://www.w3schools.com/tags/ref_urlencode.asp).