### PR TITLE
Enhance Moya.Response by using HTTPURLResponse

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,9 @@
 # Next
 
 - **Breaking Change** Added support to get the response (if any) from `MoyaError`.
-- **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123)
+- **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
+- **Breaking Change** Changed `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
 - Updated the `RxSwift` version requirement to `3.3`.
-- Changed `Moya.Response` response class to `HTTPURLResponse`
 
 # 8.0.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 - **Breaking Change** Added support to get the response (if any) from `MoyaError`.
 - **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123)
 - Updated the `RxSwift` version requirement to `3.3`.
+- Changed `Moya.Response` response class to `HTTPURLResponse`
 
 # 8.0.3
 

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -85,7 +85,7 @@ private extension NetworkLoggerPlugin {
         return output
     }
 
-    func logNetworkResponse(_ response: URLResponse?, data: Data?, target: TargetType) -> [String] {
+    func logNetworkResponse(_ response: HTTPURLResponse?, data: Data?, target: TargetType) -> [String] {
         guard let response = response else {
            return [format(loggerId, date: date, identifier: "Response", message: "Received empty network response for \(target).")]
         }

--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -8,7 +8,7 @@ public final class Response: CustomDebugStringConvertible, Equatable {
     public let response: HTTPURLResponse?
 
     /// Initialize a new `Response`.
-    public init(statusCode: Int, data: Data, request: URLRequest? = nil, response: URLResponse? = nil) {
+    public init(statusCode: Int, data: Data, request: URLRequest? = nil, response: HTTPURLResponse? = nil) {
         self.statusCode = statusCode
         self.data = data
         self.request = request

--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -5,7 +5,7 @@ public final class Response: CustomDebugStringConvertible, Equatable {
     public let statusCode: Int
     public let data: Data
     public let request: URLRequest?
-    public let response: URLResponse?
+    public let response: HTTPURLResponse?
 
     /// Initialize a new `Response`.
     public init(statusCode: Int, data: Data, request: URLRequest? = nil, response: URLResponse? = nil) {

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -405,7 +405,7 @@ class MoyaProviderSpec: QuickSpec {
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
-                var receivedResponse: URLResponse?
+                var receivedResponse: HTTPURLResponse?
                 provider.request(.zen) { result in
                     if case .success(let response) = result {
                         receivedResponse = response.response

--- a/Tests/NetworkLoggerPluginSpec.swift
+++ b/Tests/NetworkLoggerPluginSpec.swift
@@ -63,7 +63,7 @@ final class NetworkLoggerPluginSpec: QuickSpec {
         }
 
         it("outputs the response data") {
-            let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: URLResponse(url: URL(string: url(GitHub.zen))!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
+            let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: HTTPURLResponse(url: URL(string: url(GitHub.zen))!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
             let result: Result<Moya.Response, MoyaError> = .success(response)
 
             plugin.didReceive(result, target: GitHub.zen)
@@ -74,7 +74,7 @@ final class NetworkLoggerPluginSpec: QuickSpec {
         }
 
         it("outputs the formatted response data") {
-            let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: URLResponse(url: URL(string: url(GitHub.zen))!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
+            let response = Response(statusCode: 200, data: "cool body".data(using: .utf8)!, response: HTTPURLResponse(url: URL(string: url(GitHub.zen))!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil))
             let result: Result<Moya.Response, MoyaError> = .success(response)
 
             pluginWithResponseDataFormatter.didReceive(result, target: GitHub.zen)


### PR DESCRIPTION
## Subject

Enhance Moya.Response by using HTTPURLResponse

## Why 

* Moya use Alamofire
* Alamofire's responses are `HTTPURLResponse` 
* `HTTPURLResponse` give us the ability to access `allHttpHeaderFields`

## How

Modify the `Moya.Response` by avoiding downcast Alamofire's response

## Related issue

[#1040 - Moya.Response should use URLHTTPResponse class](https://github.com/Moya/Moya/issues/1040)