### PR TITLE
Only append path to URL when path is not empty

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # Next
-- Bumped minimum version of ReactiveSwift to 1.1
+- Bumped minimum version of ReactiveSwift to 1.1.
 - Changed use of deprecated `DateSchedulerProtocol` to `DateScheduler`.
-- Move project to using a single target for all platforms
+- Move project to using a single target for all platforms.
+- Changed default endpoint creation to only append `path` to `baseURL` when `path` is not empty.
 
 # 8.0.3
 

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -31,7 +31,7 @@ public extension MoyaProvider {
     }
 
     private final class func url(for target: Target) -> URL {
-        if (target.path.isEmpty) {
+        if target.path.isEmpty {
             return target.baseURL
         }
 

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -4,9 +4,8 @@ import Alamofire
 /// These functions are default mappings to `MoyaProvider`'s properties: endpoints, requests, manager, etc.
 public extension MoyaProvider {
     public final class func defaultEndpointMapping(for target: Target) -> Endpoint<Target> {
-        let url = target.baseURL.appendingPathComponent(target.path).absoluteString
         return Endpoint(
-            url: url,
+            url: url(for: target).absoluteString,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,
             parameters: target.parameters,
@@ -29,5 +28,13 @@ public extension MoyaProvider {
         let manager = Manager(configuration: configuration)
         manager.startRequestsImmediately = false
         return manager
+    }
+
+    private final class func url(for target: Target) -> URL {
+        if (target.path.isEmpty) {
+            return target.baseURL
+        }
+
+        return target.baseURL.appendingPathComponent(target.path)
     }
 }

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -30,6 +30,9 @@ public extension MoyaProvider {
         return manager
     }
 
+    // When a TargetType's path is empty, URL.appendingPathComponent may introduce trailing /, which may not be wanted in some cases
+    // See: https://github.com/Moya/Moya/pull/1053
+    // And: https://github.com/Moya/Moya/issues/1049
     private final class func url(for target: Target) -> URL {
         if target.path.isEmpty {
             return target.baseURL

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -611,6 +611,23 @@ class MoyaProviderSpec: QuickSpec {
                 expect(dataString) == "sample data"
             }
         }
+
+        describe("a target with empty path") {
+            struct PathlessAPI: TargetType {
+                let baseURL = URL(string: "http://example.com/123/somepath?X-ABC-Asd=123")!
+                let path = ""
+                let method = Moya.Method.get
+                let parameters: [String: Any]? = ["key": "value"]
+                let parameterEncoding: ParameterEncoding = URLEncoding.default
+                let task = Task.request
+                let sampleData = "sample data".data(using: .utf8)!
+            }
+
+            it("uses the base url unchanged") {
+                let endpoint = MoyaProvider.defaultEndpointMapping(for: PathlessAPI())
+                expect(endpoint.url) == "http://example.com/123/somepath?X-ABC-Asd=123"
+            }
+        }
         
         describe("an inflight-tracking provider") {
             var provider: MoyaProvider<GitHub>!

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -623,6 +623,9 @@ class MoyaProviderSpec: QuickSpec {
                 let sampleData = "sample data".data(using: .utf8)!
             }
 
+            // When a TargetType's path is empty, URL.appendingPathComponent may introduce trailing /, which may not be wanted in some cases
+            // See: https://github.com/Moya/Moya/pull/1053
+            // And: https://github.com/Moya/Moya/issues/1049
             it("uses the base url unchanged") {
                 let endpoint = MoyaProvider.defaultEndpointMapping(for: PathlessAPI())
                 expect(endpoint.url) == "http://example.com/123/somepath?X-ABC-Asd=123"


### PR DESCRIPTION
Fixes #1049 

When a `TargetType`'s `path` is empty, `URL.appendingPathComponent` may introduce trailing `/`, which may not be wanted.

From the [docs](https://developer.apple.com/reference/foundation/url/1780239-appendingpathcomponent): 
> This function performs a file system operation to determine if the path component is a directory. If so, it will append a trailing /. If you know in advance that the path component is a directory or not, then use func appendingPathComponent(_:isDirectory:).

Using `appendingPathComponent(_:isDirectory:)` doesn't seem to solve the problem (note `somepath/?`)

```swift
import Foundation

let urlString = "https://google.com/123/somepath?X-ABC-Asd=123"
let url = URL(string: urlString)!

url.absoluteString //"https://google.com/123/somepath?X-ABC-Asd=123"
url.appendingPathComponent("").absoluteString //"https://google.com/123/somepath/?X-ABC-Asd=123"
url.appendingPathComponent("", isDirectory: false).absoluteString //"https://google.com/123/somepath/?X-ABC-Asd=123"
```

I think that having an empty `path` is not usual, but as seen in #1049 it may be necessary. These changes shouldn't cause side effects for non-empty `path`s.