### PR TITLE
Adds property headers to TargetType

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
 - **Breaking Change** Changed `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
 - Updated the `RxSwift` version requirement to `3.3`.
+- **Breaking Change** Added `headers` to `TargetType`.
 
 # 8.0.3
 

--- a/Demo/Shared/GiphyAPI.swift
+++ b/Demo/Shared/GiphyAPI.swift
@@ -42,6 +42,10 @@ extension Giphy: TargetType {
             return "{\"data\":{\"id\":\"your_new_gif_id\"},\"meta\":{\"status\":200,\"msg\":\"OK\"}}".data(using: String.Encoding.utf8)!
         }
     }
+
+    public var headers: [String: String]? {
+        return nil
+    }
 }
 
 func animatedBirdData() -> Data {

--- a/Demo/Shared/GitHubAPI.swift
+++ b/Demo/Shared/GitHubAPI.swift
@@ -76,6 +76,9 @@ extension GitHub: TargetType {
             return "[{\"name\": \"Repo Name\"}]".data(using: String.Encoding.utf8)!
         }
     }
+    public var headers: [String: String]? {
+        return nil
+    }
 }
 
 public func url(_ route: TargetType) -> String {

--- a/Demo/Shared/GitHubUserContentAPI.swift
+++ b/Demo/Shared/GitHubUserContentAPI.swift
@@ -42,6 +42,9 @@ extension GitHubUserContent: TargetType {
             return animatedBirdData() as Data
         }
     }
+    public var headers: [String: String]? {
+        return nil
+    }
 
 }
 

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -9,7 +9,8 @@ public extension MoyaProvider {
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,
             parameters: target.parameters,
-            parameterEncoding: target.parameterEncoding
+            parameterEncoding: target.parameterEncoding,
+            httpHeaderFields: target.headers
         )
     }
 

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -41,6 +41,10 @@ public enum MultiTarget: TargetType {
         return target.validate
     }
 
+    public var headers: [String: String]? {
+        return target.headers
+    }
+
     /// The embedded `TargetType`.
     public var target: TargetType {
         switch self {

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -27,6 +27,9 @@ public protocol TargetType {
 
     /// Whether or not to perform Alamofire validation. Defaults to `false`.
     var validate: Bool { get }
+
+    // The headers to used in the request.
+    var headers: [String: String]? { get }
 }
 
 public extension TargetType {

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -12,6 +12,7 @@ final class AccessTokenPluginSpec: QuickSpec {
         let parameterEncoding: ParameterEncoding = URLEncoding.default
         let task = Task.request
         let sampleData = Data()
+        let headers: [String: String]? = nil
 
         let shouldAuthorize: Bool
     }

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -118,4 +118,5 @@ extension Empty: TargetType {
     var parameterEncoding: ParameterEncoding { return URLEncoding.default }
     var task: Task { return .request }
     var sampleData: Data { return Data() }
+    var headers: [String: String]? { return nil }
 }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -530,6 +530,7 @@ class MoyaProviderSpec: QuickSpec {
                 let parameterEncoding: ParameterEncoding = URLEncoding.default
                 let task = Task.request
                 let sampleData = "sample data".data(using: .utf8)!
+                let headers: [String: String]? = ["headerKey": "headerValue"]
             }
 
             it("uses correct URL") {
@@ -610,6 +611,27 @@ class MoyaProviderSpec: QuickSpec {
 
                 expect(dataString) == "sample data"
             }
+
+            it("uses correct headers") {
+                var headers: [String : String]?
+                let endpointResolution: MoyaProvider<MultiTarget>.RequestClosure = { endpoint, done in
+                    headers = endpoint.httpHeaderFields
+                    if let urlRequest = endpoint.urlRequest {
+                        done(.success(urlRequest))
+                    } else {
+                        done(.failure(MoyaError.requestMapping(endpoint.url)))
+                    }
+                }
+                let provider = MoyaProvider<MultiTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
+
+                waitUntil { done in
+                    provider.request(MultiTarget(StructAPI())) { _ in
+                        done()
+                    }
+                }
+
+                expect(headers) == ["headerKey": "headerValue"]
+            }
         }
 
         describe("a target with empty path") {
@@ -621,6 +643,7 @@ class MoyaProviderSpec: QuickSpec {
                 let parameterEncoding: ParameterEncoding = URLEncoding.default
                 let task = Task.request
                 let sampleData = "sample data".data(using: .utf8)!
+                let headers: [String: String]? = nil
             }
 
             // When a TargetType's path is empty, URL.appendingPathComponent may introduce trailing /, which may not be wanted in some cases

--- a/Tests/MultiTargetSpec.swift
+++ b/Tests/MultiTargetSpec.swift
@@ -14,6 +14,7 @@ class MultiTargetSpec: QuickSpec {
                 let task = Task.request
                 let sampleData = "sample data".data(using: .utf8)!
                 let validate = true
+                let headers: [String: String]? = ["headerKey": "headerValue"]
             }
 
             var target: MultiTarget!
@@ -54,6 +55,10 @@ class MultiTargetSpec: QuickSpec {
 
             it("uses correct validate") {
                 expect(target.validate) == true
+            }
+
+            it("uses correct headers") {
+                expect(target.headers) == ["headerKey": "headerValue"]
             }
         }
     }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -47,9 +47,13 @@ extension GitHub: TargetType {
             return "{\"login\": \"\(name)\", \"id\": 100}".data(using: String.Encoding.utf8)!
         }
     }
-    
+
     var validate: Bool {
         return true
+    }
+
+    var headers: [String: String]? {
+        return nil
     }
 }
 
@@ -98,6 +102,10 @@ enum HTTPBin: TargetType {
             return "{\"authenticated\": true, \"user\": \"user\"}".data(using: String.Encoding.utf8)!
         }
     }
+
+    var headers: [String: String]? {
+        return nil
+    }
 }
 
 public enum GitHubUserContent {
@@ -139,7 +147,11 @@ extension GitHubUserContent: TargetType {
             return Data(count: 4000)
         }
     }
-   
+
+    public var headers: [String: String]? {
+        return nil
+    }
+
 }
 
 private let DefaultDownloadDestination: DownloadDestination = { temporaryURL, response in

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -72,6 +72,8 @@ let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
 let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)
 ```
 
+*Note that header fields can also be added as part of the [Target](Targets.md) definition.*
+
 This also means that you can provide additional parameters to some or all of
 your endpoints. For example, say that there is an authentication token we need
 for  all values of the hypothetical `MyTarget` target, with the exception of the

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -84,6 +84,9 @@ extension MyService: TargetType {
             return .request
         }
     }
+    var headers: [String: String]? {
+        return ["Content-type": "application/json"]
+    }
 }
 // MARK: - Helpers
 private extension String {

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -121,7 +121,7 @@ public var sampleData: Data {
 }
 ```
 
-Finally, our `TargetType` has a `task` property that represents how you are sending / receiving data. This can be either `.request`, `.upload` or `.download`, and allows you to add data, files and streams to the request body.
+`TargetType` also has a `task` property that represents how you are sending / receiving data. This can be either `.request`, `.upload` or `.download`, and allows you to add data, files and streams to the request body.
 
 ```swift
 public var task: Task {
@@ -129,6 +129,14 @@ public var task: Task {
     case .zen, .userProfile, .userRepositories, .branches:
         return .request
     }
+}
+```
+
+Finally, `headers` property stores header fields that should be sent on the request.
+
+```swift
+public var headers: [String: String]? {
+    return ["Content-Type": "application/json"]
 }
 ```
 

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -132,7 +132,7 @@ public var task: Task {
 }
 ```
 
-Finally, `headers` property stores header fields that should be sent on the request.
+Finally, the `headers` property stores header fields that should be sent on the request.
 
 ```swift
 public var headers: [String: String]? {


### PR DESCRIPTION
Implements #1046 (and #1058).

How to add header fields to a request is a question that shows up in issues every once in a while (e.g. #510, #1003, #208). The answers always mention a custom `endpointClosure` to add the fields to the header request. In fact, [this is suggested in the docs as well](https://github.com/Moya/Moya/blob/master/docs/Endpoints.md#from-target-to-endpoint).

However, having the header fields specified in the `TargetType` makes the whole process easier (and more obvious). Which raises a couple of questions: 

1. Is there any reason for us not to specify header information inside `TargetType`?
2. Is the usage of headers not as common as I think it is and it's better to leave the `endpointClosure` as the official way? Assuming most people don't need to specify headers at all, adding it to `TargetType` just forces an implementation of headers that would return `nil`. 

If we decide to go forward with the change, we still need to:

- [x] Update Changelog
- [x] Update documentation