### PR TITLE
Changes Danger 'missing changelog' rule to warn instead of fail

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -15,7 +15,7 @@ fail("fit left in tests") if `grep -r "fit Demo/Tests/ `.length > 1
 # Changelog entries are required for changes to library files.
 no_changelog_entry = !git.modified_files.include?("Changelog.md")
 if has_app_changes && no_changelog_entry && not_declared_trivial
-  fail("Any changes to library code need a summary in the Changelog.")
+  warn("Any changes to library code need a summary in the Changelog.")
 end
 
 # Added (or removed) library files need to be added (or removed) from the


### PR DESCRIPTION
Mentioned in #1070

Makes Danger `warn` about missing changelog entry instead of `fail` (which causes the build to fail and can be confusing  to new contributors)
