### PR TITLE
fix typos using misspell

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -97,7 +97,7 @@ structure and more.
 - Adds Download and Upload Task type support to Moya.
 - Corrects SwiftLint warnings.
 - Separates `Moya.swift` into multiple files.
-- Updated `mapJSON` API to include an optional named parameter `failsOnEmptyData:` that when overriden returns an empty `NSNull()` result instead of throwing an error when the response data is empty.
+- Updated `mapJSON` API to include an optional named parameter `failsOnEmptyData:` that when overridden returns an empty `NSNull()` result instead of throwing an error when the response data is empty.
 - Added `supportsMultipart` to the `Method` type, which helps determine whether to use `multipart/form-data` encoding.
 - Added `PATCH` and `CONNECT` to the `Method` cases which support multipart encoding.
 - Added `request` for `Response`.
@@ -126,7 +126,7 @@ structure and more.
 - Moves from OSSpinLock to `dispatch_semaphor` to avoid deadlocks.
 - Integrates Danger into the repo.
 - Fixes a xcodeproj referencing bug introduced by the new cURL-based logging plugin.
-- Calls completion even when cancellable token is cancelled
+- Calls completion even when cancellable token is canceled
 
 # 6.5.0
 
@@ -342,18 +342,18 @@ structure and more.
 
 - **Breaking change** Combines `MoyaPath` and `MoyaTarget` protocols.
 - **Breaking change** Renames `Moya/Reactive` subspec to `Moya/ReactiveCocoa`.
-- **Breaking change** Removes `stubResponses` from initializer; replaced with new stubbing behavior `.NoStubbing`. Added class methods to `MoyaProvider` to provide defaults, while allowing users to still change stubbing behaviour on a per-request basis.
+- **Breaking change** Removes `stubResponses` from initializer; replaced with new stubbing behavior `.NoStubbing`. Added class methods to `MoyaProvider` to provide defaults, while allowing users to still change stubbing behavior on a per-request basis.
 - **Breaking change** Redefines types of `DefaultEndpointMapping` and `DefaultEnpointResolution` class functions on `MoyaProvider`. You no longer invoke these functions to return a closure, rather, you reference the functions themselves _as_ closures.
 - **Breaking change** Renames `endpointsClosure` parameter and property of `MoyaProvider` to `endpointClosure`.
 - **Breaking change** Renames `ReactiveMoyaProvider` to `ReactiveCocoaMoyaProvider` for consistency.
-- Fixes problem that the `ReactiveMoyaProvider` initializer would not respect the stubbing behaviour it was passed.
+- Fixes problem that the `ReactiveMoyaProvider` initializer would not respect the stubbing behavior it was passed.
 - Adds official Carthage support – [@neonichu](http://github.com/neonichu)
 - Relaxes version dependency on RxSwift - [@alcarvalho](http://github.com/alcarvalho)
 - Fixes possible concurrency bugs with reactive providers - [@alcarvalho](http://github.com/alcarvalho)
 
 # 1.1.1
 
-- Fixes problem where `RxMoyaProvider` would not respect customized stubbing behaviour (delays).
+- Fixes problem where `RxMoyaProvider` would not respect customized stubbing behavior (delays).
 
 # 1.1.0
 
@@ -406,7 +406,7 @@ structure and more.
 
 # 0.2
 
-- Fixes [#44](https://github.com/AshFurrow/Moya/issues/44) where status codes weren't being pass through to completion blocks. This also modified the behaviour of the ReactiveCocoa extensions significantly but sending MoyaResponse objects instead of just NSData ones. —[@ashfurrow](http://github.com/AshFurrow)
+- Fixes [#44](https://github.com/AshFurrow/Moya/issues/44) where status codes weren't being passed through to completion blocks. This also modified the behavior of the ReactiveCocoa extensions significantly but sending MoyaResponse objects instead of just NSData ones. —[@ashfurrow](http://github.com/AshFurrow)
 
 # 0.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -178,7 +178,7 @@ task :release, :version do |task, args|
   changelog.gsub!(/# Next/, "# Next\n\n# #{version}")
   File.open(changelog_filename, 'w') { |file| file.puts changelog }
 
-  puts "Comitting, tagging, and pushing."
+  puts "Committing, tagging, and pushing."
   message = "Releasing version #{version}."
   sh "git commit -am '#{message}'"
   sh "git tag #{version} -m '#{message}'"

--- a/Sources/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkActivityPlugin.swift
@@ -23,7 +23,7 @@ public final class NetworkActivityPlugin: PluginType {
         networkActivityClosure(.began)
     }
 
-    /// Called by the provider as soon as a response arrives, even if the request is cancelled.
+    /// Called by the provider as soon as a response arrives, even if the request is canceled.
     public func didReceive(_ result: Result<Moya.Response, MoyaError>, target: TargetType) {
         networkActivityClosure(.ended)
     }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -169,7 +169,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(endDate?.timeIntervalSince(startDate)) >= delay
             }
 
-            it("returns an error when request is cancelled") {
+            it("returns an error when request is canceled") {
                 var receivedError: Swift.Error?
 
                 waitUntil { done in
@@ -186,7 +186,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(receivedError).toNot( beNil() )
             }
 
-            it("notifies plugins when request is cancelled") {
+            it("notifies plugins when request is canceled") {
                 var receivedError: Swift.Error?
 
                 waitUntil { done in
@@ -215,7 +215,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(plugin.didPrepare).to( beTrue() )
             }
 
-            it("returns success when request is not cancelled") {
+            it("returns success when request is not canceled") {
                 var receivedError: Swift.Error?
 
                 waitUntil { done in
@@ -288,7 +288,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(receivedError).to( beNil() )
             }
 
-            it("calls completion if cancelled immediately") {
+            it("calls completion if canceled immediately") {
                 var receivedError: Swift.Error?
                 var calledCompletion = false
 
@@ -310,7 +310,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(calledCompletion).to( beTrue() )
             }
 
-            it("calls completion if cancelled before request is created") {
+            it("calls completion if canceled before request is created") {
                 var receivedError: Swift.Error?
                 var calledCompletion = false
 
@@ -334,7 +334,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(calledCompletion).to( beTrue() )
             }
 
-            it("receives an error if request is cancelled before response comes back") {
+            it("receives an error if request is canceled before response comes back") {
                 var receivedError: Swift.Error?
 
                 waitUntil { done in
@@ -673,7 +673,7 @@ class MoyaProviderSpec: QuickSpec {
                 provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(0.5))
             }
             
-            it("invokes completion and returns .Failure if cancelled immediately") {
+            it("invokes completion and returns. Failure if canceled immediately") {
                 var error: MoyaError?
                 waitUntil { done in
                     let cancellable = provider.request(.zen, completion: { (result) in

--- a/Tests/ReactiveSwiftMoyaProviderTests.swift
+++ b/Tests/ReactiveSwiftMoyaProviderTests.swift
@@ -82,7 +82,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                 provider = TestProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(1))
             }
 
-            it("cancels network request when subscription is cancelled") {
+            it("cancels network request when subscription is canceled") {
                 let target: GitHub = .zen
 
                 let disposable = provider.request(target).startWithCompleted {
@@ -169,7 +169,7 @@ class ReactiveSwiftMoyaProviderSpec: QuickSpec {
                     provider = TestProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(1))
                 }
                 
-                it("cancels network request when subscription is cancelled") {
+                it("cancels network request when subscription is canceled") {
                     let target: GitHub = .zen
                     
                     let disposable = provider.request(target).startWithCompleted {

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -27,7 +27,7 @@ Remember, *where* you put your target and the provider, are completely up
 to you. You can check out [Artsy's implementation](https://github.com/artsy/eidolon/blob/master/Kiosk/App/Networking/ArtsyAPI.swift)
 for an example.
 
-But don't forget to keep a reference for it in property. If it gets deallocated you'll see `-999 "cancelled"` error on response.
+But don't forget to keep a reference for it in property. If it gets deallocated you'll see `-999 "canceled"` error on response.
 
 Advanced Usage
 ------------

--- a/docs/ReactiveSwift.md
+++ b/docs/ReactiveSwift.md
@@ -31,7 +31,7 @@ provider.request(.zen).start { event in
 
 For `ReactiveSwiftMoyaProvider`, the network request is not started
 until the signal is subscribed to. If the subscription to the signal
-is disposed of before the request completes, the request is cancelled.
+is disposed of before the request completes, the request is canceled.
 
 If the request completes normally, two things happen:
 

--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -30,7 +30,7 @@ provider.request(.zen).subscribe { event in
 
 For `RxMoyaProvider`, the network request is not started
 until the signal is subscribed to. If the subscription to the signal
-is disposed of before the request completes, the request is cancelled.
+is disposed of before the request completes, the request is canceled.
 
 If the request completes normally, two things happen:
 


### PR DESCRIPTION
This PR is part of a campaign to fix a lot of typos on github using https://github.com/client9/misspell!
You can see the progress on https://github.com/fixTypos/fix_typos/