### PR TITLE
[SPM] Git suffix + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Demo/Pods
 # Swift Package Manager
 .build
 Packages
+Package.pins

--- a/Package.swift
+++ b/Package.swift
@@ -16,10 +16,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .Package(url: "https://github.com/Alamofire/Alamofire", majorVersion: 4),
-        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", majorVersion: 1),
-        .Package(url: "https://github.com/ReactiveX/RxSwift", majorVersion: 3),
-        .Package(url: "https://github.com/antitypical/Result", majorVersion: 3)
+        .Package(url: "https://github.com/Alamofire/Alamofire.git", majorVersion: 4),
+        .Package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", majorVersion: 1),
+        .Package(url: "https://github.com/ReactiveX/RxSwift.git", majorVersion: 3),
+        .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3)
     ],
     exclude: [
         "Tests"

--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ you should use for your Swift version.
 To integrate using Apple's Swift package manager, add the following as a dependency to your `Package.swift`:
 
 ```swift
-.Package(url: "https://github.com/Moya/Moya", majorVersion: 8)
+.Package(url: "https://github.com/Moya/Moya.git", majorVersion: 8)
 ```
 
 and then specify `.Target(name: "Moya")` as a dependency of the Target in which you wish to use Moya.
@@ -80,7 +80,7 @@ import PackageDescription
 let package = Package(
   name: "MyApp",
   dependencies: [
-    .Package(url: "https://github.com/Moya/Moya", majorVersion: 8)
+    .Package(url: "https://github.com/Moya/Moya.git", majorVersion: 8)
   ]
 )
 ```


### PR DESCRIPTION
In this PR:

1. Add .git suffixes. Rationale: [Stencil#84](https://github.com/kylef/Stencil/pull/84) and [Stencil#101](https://github.com/kylef/Stencil/issues/101). Basically really similar situation in our case. `ReactiveSwift` has `Result` as a dependency with `.git` suffix in `Package.swift`, and we also have `Result` dependency - but without `.git` in `Package.swift`. It might also resolve our problem in [SPM-compat](https://github.com/apple/swift-source-compat-suite/pull/35).
2. Add `Package.pins` to `.gitignore`, as per [SPM docs](https://github.com/apple/swift-package-manager/blob/master/Documentation/Usage.md#automatic-pinning).