### PR TITLE
Update readme regarding json fixture files

### DIFF
--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -70,8 +70,8 @@ extension MyService: TargetType {
             return "{\"id\": \(id), \"first_name\": \"\(firstName)\", \"last_name\": \"\(lastName)\"}".utf8Encoded
         case .showAccounts:
             // Provided you have a file named accounts.json in your bundle.
-            guard let path = Bundle.main.path(forResource: "accounts", ofType: "json"),
-                let data = Data(base64Encoded: path) else {
+            guard let url = Bundle.main.url(forResource: "accounts", withExtension: "json"),
+                let data = try? Data(contentsOf: url) else {
                     return Data()
             }
             return data


### PR DESCRIPTION
Hello. I could not get the json fixture file working for specs when following the example provided in readme. I updated readme to use the approach that worked for me. Looks like `Data(base64Encoded: path)` only encodes the String path into data, and does not actually read json data from the file. 

