### PR TITLE
[Documentation] Fix example on how to send params in URL on POST

### DIFF
--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -52,9 +52,9 @@ extension MyService: TargetType {
     var parameterEncoding: ParameterEncoding {
         switch self {
         case .zen, .showUser, .showAccounts:
-            return URLEncoding.default // Send parameters in URL
+            return URLEncoding.default // Send parameters in URL for GET, DELETE and HEAD. For other HTTP methods, parameters will be sent in request body
         case .updateUser:
-            return URLEncoding.queryString // Send parameters in URL
+            return URLEncoding.queryString // Always sends parameters in URL, regardless of which HTTP method is used
         case .createUser:
             return JSONEncoding.default // Send parameters as JSON in request body
         }

--- a/docs/Examples/Basic.md
+++ b/docs/Examples/Basic.md
@@ -49,11 +49,12 @@ extension MyService: TargetType {
             return ["first_name": firstName, "last_name": lastName]
         }
     }
-
     var parameterEncoding: ParameterEncoding {
         switch self {
-        case .zen, .showUser, .showAccounts, .updateUser:
+        case .zen, .showUser, .showAccounts:
             return URLEncoding.default // Send parameters in URL
+        case .updateUser:
+            return URLEncoding.queryString // Send parameters in URL
         case .createUser:
             return JSONEncoding.default // Send parameters as JSON in request body
         }


### PR DESCRIPTION
When doing a POST request, we should use `URLEncoding.queryString` instead of `URLEncoding.default` (as explained by @sunshinejr in [#1119](https://github.com/Moya/Moya/issues/1119#issuecomment-307929162))