### PR TITLE
appendingPathComponent  didn't work well

### DIFF
--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -37,7 +37,10 @@ public extension MoyaProvider {
         if target.path.isEmpty {
             return target.baseURL
         }
-
-        return target.baseURL.appendingPathComponent(target.path)
+        
+        let originalString = target.baseURL.absoluteString+target.path
+        let urlString = originalString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!
+        
+        return URL.init(string: urlString)!
     }
 }


### PR DESCRIPTION
target.baseURL.appendingPathComponent will convert '?' to '%3f'. 'urlQueryAllowed' will be perfect
eg."http://cdn2.jianshu.io/assets/default_avatar/13-394c31a9cb492fcb39c27422ca7d2815.jpg?imageMogr2/auto-orient/strip|imageView2/1/w/240/h/240" -> OK 
"http://cdn2.jianshu.io/assets/default_avatar/13-394c31a9cb492fcb39c27422ca7d2815.jpg?imageMogr2/auto-orient/strip|imageView2/1/w/240/h/240"  ->404