### PR TITLE
[WIP] Support Encodable types in TargetType

### DIFF
--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -21,29 +21,21 @@ open class Endpoint<Target> {
     open let url: String
     open let method: Moya.Method
     open let sampleResponseClosure: SampleResponseClosure
-    open let parameters: [String: Any]?
-    open let parameterEncoding: Moya.ParameterEncoding
+    open let requestData: RequestData?
     open let httpHeaderFields: [String: String]?
 
     /// Main initializer for `Endpoint`.
     public init(url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method = Moya.Method.get,
-                parameters: [String: Any]? = nil,
-                parameterEncoding: Moya.ParameterEncoding = URLEncoding.default,
+                requestData: RequestData? = nil,
                 httpHeaderFields: [String: String]? = nil) {
 
         self.url = url
         self.sampleResponseClosure = sampleResponseClosure
         self.method = method
-        self.parameters = parameters
-        self.parameterEncoding = parameterEncoding
+        self.requestData = requestData
         self.httpHeaderFields = httpHeaderFields
-    }
-
-    /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added parameters.
-    open func adding(newParameters: [String: Any]) -> Endpoint<Target> {
-        return adding(parameters: newParameters)
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added HTTP header fields.
@@ -51,29 +43,10 @@ open class Endpoint<Target> {
         return adding(httpHeaderFields: newHTTPHeaderFields)
     }
 
-    /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with another parameter encoding.
-    open func adding(newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<Target> {
-        return adding(parameterEncoding: newParameterEncoding)
-    }
-
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
-    open func adding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
-        let newParameters = add(parameters: parameters)
+    open func adding(httpHeaderFields: [String: String]? = nil) -> Endpoint<Target> {
         let newHTTPHeaderFields = add(httpHeaderFields: httpHeaderFields)
-        let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
-    }
-
-    fileprivate func add(parameters: [String: Any]?) -> [String: Any]? {
-        guard let unwrappedParameters = parameters, unwrappedParameters.isEmpty == false else {
-            return self.parameters
-        }
-
-        var newParameters = self.parameters ?? [:]
-        unwrappedParameters.forEach { key, value in
-            newParameters[key] = value
-        }
-        return newParameters
+        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, requestData: requestData, httpHeaderFields: newHTTPHeaderFields)
     }
 
     fileprivate func add(httpHeaderFields headers: [String: String]?) -> [String: String]? {
@@ -99,7 +72,30 @@ extension Endpoint {
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = httpHeaderFields
 
-        return try? parameterEncoding.encode(request, with: parameters)
+        guard let requestData = requestData else {
+            return request
+        }
+
+        switch requestData {
+        case let .json(encodable):
+            request.httpBody = try? JSONEncoder().encode(encodable)
+            return request
+
+        case let .propertyList(encodable):
+            request.httpBody = try? PropertyListEncoder().encode(encodable)
+            return request
+
+        case let .jsonEncoder(encodable, encoder):
+            request.httpBody = try? encoder.encode(encodable)
+            return request
+
+        case let .propertyListEncoder(encodable, encoder):
+            request.httpBody = try? encoder.encode(encodable)
+            return request
+
+        case let .parameterEncoding(parameters, parameterEncoding):
+            return try? parameterEncoding.encode(request, with: parameters)
+        }
     }
 }
 

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -8,8 +8,7 @@ public extension MoyaProvider {
             url: url(for: target).absoluteString,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,
-            parameters: target.parameters,
-            parameterEncoding: target.parameterEncoding
+            requestData: target.requestData
         )
     }
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -170,16 +170,6 @@ private extension MoyaProvider {
                     self.append(stream: stream, length: length, bodyPart: bodyPart, to: form)
                 }
             }
-
-            if let parameters = target.parameters {
-                parameters
-                    .flatMap { key, value in multipartQueryComponents(key, value) }
-                    .forEach { key, value in
-                        if let data = value.data(using: .utf8, allowLossyConversion: false) {
-                            form.append(data, withName: key)
-                        }
-                }
-            }
         }
 
         manager.upload(multipartFormData: multipartFormData, with: request) { result in

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -21,12 +21,8 @@ public enum MultiTarget: TargetType {
         return target.method
     }
 
-    public var parameters: [String: Any]? {
-        return target.parameters
-    }
-
-    public var parameterEncoding: ParameterEncoding {
-        return target.parameterEncoding
+    public var requestData: RequestData? {
+        return target.requestData
     }
 
     public var sampleData: Data {

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -13,11 +13,8 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
-    /// The parameters to be encoded in the request.
-    var parameters: [String: Any]? { get }
-
-    /// The method used for parameter encoding.
-    var parameterEncoding: ParameterEncoding { get }
+    /// The data to be passed alongside the request.
+    var requestData: RequestData? { get }
 
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
@@ -33,6 +30,24 @@ public extension TargetType {
     var validate: Bool {
         return false
     }
+}
+
+/// Represents the request data type.
+public enum RequestData {
+    /// Use `JSONEncoder` using its default configuration with an `Encodable` type.
+    case json(Encodable)
+
+    /// Use `JSONEncoder` using a custom configuration with an `Encodable` type.
+    case jsonEncoder(Encodable, JSONEncoder)
+
+    /// Use `PropertyListEncoder` using its default configuration with an `Encodable` type.
+    case propertyList(Encodable)
+
+    /// Use `PropertyListEncoder` using a custom configuration with an `Encodable` type.
+    case propertyListEncoder(Encodable, PropertyListEncoder)
+
+    /// Use Alamofire's parameters with a specified encoding.
+    case parameterEncoding([String: Any], ParameterEncoding)
 }
 
 /// Represents a type of upload task.


### PR DESCRIPTION
This is an exploration of my idea explained in #1135 which fixes the same issue.

Unfortunately, I'm getting an error which renders this PR useless as it is right now:
> Cannot invoke 'encode' with an argument list of type '((Encodable))'

This error appears in places such as 
```swift
request.httpBody = try? JSONEncoder().encode(encodable)
```
since the `encodable` parameter is of a generic type (`Encodable`).

Does anybody have a good solution for preventing this issue? Then I can continue exploring this.

Note that I have removed all convenience methods for `parameters` and `parameterEncoding` as a first step. We could (and probably should) reintroduce them later. Also I have not yet included a solution for the side-requirement of fixing #314 (which we could tackle using the same approach as well as explained [here](https://github.com/Moya/Moya/issues/1135#issuecomment-310677003)). I think we should discuss that in a subsequent PR.

**TODOs:**
- [x] Explain the basic idea using code
- [ ] Make the code usable
- [ ] Update the Docs
- [ ] Update the Tests
- [ ] Write a migration guide
- [ ] Write a changelog entry