### PR TITLE
Flatten enums & parameters into extended Task type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@
 # 9.0.0-alpha.1
 
 - **Breaking Change** Added support to get the response (if any) from `MoyaError`.
+- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
+- **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases.
+- **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
+- **Breaking Change** Changed `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
 - **Breaking Change** Added `headers` to `TargetType`.
 - **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
 - **Breaking Change** Updated `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
@@ -17,10 +21,6 @@
 - Add optional callback queue parameter to reactive providers.
 
 - Bumped minimum version of ReactiveSwift to 2.0.
-- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases. Migration guide available in Readme.
-- **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases. Migration guide available in Readme.
-- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
-- **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases.
 - Add optional callback queue parameter to reactive providers.
 - Enabled the "Allow app extension API only" flag.
 - Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,8 +6,6 @@
 # 9.0.0-alpha.1
 
 - **Breaking Change** Added support to get the response (if any) from `MoyaError`.
-- **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
-- **Breaking Change** Changed `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
 - **Breaking Change** Added `headers` to `TargetType`.
 - **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
 - **Breaking Change** Updated `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
@@ -16,11 +14,6 @@
 - **Breaking Change** Removed parameter name in `requestWithProgress` for `ReactiveSwiftMoyaProvider`.
 - **Breaking Change** Removed deprecated in Moya 8.0.0: `Moya.Error`, `endpointByAddingParameters(parameters:)`, `endpointByAddingHttpHeaderFields(httpHeaderFields:)`, `endpointByAddingParameterEncoding(newParameterEncoding:)`, `endpointByAdding(parameters:httpHeaderFields:parameterEncoding)`, `StructTarget`, `filterStatusCodes(range:)`, `filterStatusCode(code:)`, `willSendRequest(request:target:)`, `didReceiveResponse(result:target:)`, `ReactiveCocoaMoyaProvider`, `ReactiveSwiftMoyaProvider.request(token:)`. 
 - Added optional callback queue parameter to reactive providers.
-- Updated the `RxSwift` version requirement to `3.3`.
-- Fixed a bug where you would have two response events in `requestWithProgress` method on ReactiveSwift module.
-- Bumped minimum version of ReactiveSwift to 2.0.
-- Enabled the "Allow app extension API only" flag.
-- Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.
 - Added public `URL(target:)` initializator that creates url from `TargetType`.
 - Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.
 - Updated minimum version of `RxSwift` to `3.3`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,11 @@
 # Next
 - Added Swift 4.0 support.
+- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
+- **Breaking Change** Flattened `UploadType` and `DownloadType` into `Task` cases.
 
 # 9.0.0-alpha.1
 
 - **Breaking Change** Added support to get the response (if any) from `MoyaError`.
-- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
-- **Breaking Change** Flattened `UploadType` and `DownloadType` into `Task` cases.
 - **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
 - **Breaking Change** Changed `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
 - **Breaking Change** Added `headers` to `TargetType`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,6 @@
 - Added optional callback queue parameter to reactive providers.
 - Updated the `RxSwift` version requirement to `3.3`.
 - Fixed a bug where you would have two response events in `requestWithProgress` method on ReactiveSwift module.
-- Add optional callback queue parameter to reactive providers.
 - Bumped minimum version of ReactiveSwift to 2.0.
 - Enabled the "Allow app extension API only" flag.
 - Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,15 @@
 - **Breaking Change** Removed parameter name in `requestWithProgress` for `ReactiveSwiftMoyaProvider`.
 - **Breaking Change** Removed deprecated in Moya 8.0.0: `Moya.Error`, `endpointByAddingParameters(parameters:)`, `endpointByAddingHttpHeaderFields(httpHeaderFields:)`, `endpointByAddingParameterEncoding(newParameterEncoding:)`, `endpointByAdding(parameters:httpHeaderFields:parameterEncoding)`, `StructTarget`, `filterStatusCodes(range:)`, `filterStatusCode(code:)`, `willSendRequest(request:target:)`, `didReceiveResponse(result:target:)`, `ReactiveCocoaMoyaProvider`, `ReactiveSwiftMoyaProvider.request(token:)`. 
 - Added optional callback queue parameter to reactive providers.
+- Updated the `RxSwift` version requirement to `3.3`.
+- Fixed a bug where you would have two response events in `requestWithProgress` method on ReactiveSwift module.
+- Add optional callback queue parameter to reactive providers.
+
+- Bumped minimum version of ReactiveSwift to 2.0.
+- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases. Migration guide available in Readme.
+- **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases. Migration guide available in Readme.
+- Enabled the "Allow app extension API only" flag.
+- Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.
 - Added public `URL(target:)` initializator that creates url from `TargetType`.
 - Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.
 - Updated minimum version of `RxSwift` to `3.3`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 
 - **Breaking Change** Added support to get the response (if any) from `MoyaError`.
 - **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
-- **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases.
+- **Breaking Change** Flattened `UploadType` and `DownloadType` into `Task` cases.
 - **Breaking Change** Updated `RxMoyaProvider.request` to return a [`Single<Request>`](https://github.com/ReactiveX/RxSwift/pull/1123).
 - **Breaking Change** Changed `Moya.Response`'s `response`to use an `HTTPURLResponse` instead of a `URLResponse`.
 - **Breaking Change** Added `headers` to `TargetType`.
@@ -19,9 +19,7 @@
 - Updated the `RxSwift` version requirement to `3.3`.
 - Fixed a bug where you would have two response events in `requestWithProgress` method on ReactiveSwift module.
 - Add optional callback queue parameter to reactive providers.
-
 - Bumped minimum version of ReactiveSwift to 2.0.
-- Add optional callback queue parameter to reactive providers.
 - Enabled the "Allow app extension API only" flag.
 - Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.
 - Added public `URL(target:)` initializator that creates url from `TargetType`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,9 @@
 - Bumped minimum version of ReactiveSwift to 2.0.
 - **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases. Migration guide available in Readme.
 - **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases. Migration guide available in Readme.
+- **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
+- **Breaking Change** Flattened `UploadType` and `DownloadType` into Task cases.
+- Add optional callback queue parameter to reactive providers.
 - Enabled the "Allow app extension API only" flag.
 - Added an optional `requestDataFormatter`in `NetworkLoggerPlugin` to allow the client to interact with the request data before logging it.
 - Added public `URL(target:)` initializator that creates url from `TargetType`.

--- a/Demo/Shared/GiphyAPI.swift
+++ b/Demo/Shared/GiphyAPI.swift
@@ -25,7 +25,7 @@ extension Giphy: TargetType {
         switch self {
         case let .upload(data):
             let multipartFormData = [MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]
-            return .uploadMultipartParameters(parameters: ["api_key": "dc6zaTOxFJmzC", "username": "Moya"], encoding: URLEncoding.default, multipartFormData)
+            return .uploadCompositeMultipart(multipartFormData, urlParameters: ["api_key": "dc6zaTOxFJmzC", "username": "Moya"])
         }
     }
     public var sampleData: Data {

--- a/Demo/Shared/GiphyAPI.swift
+++ b/Demo/Shared/GiphyAPI.swift
@@ -21,19 +21,11 @@ extension Giphy: TargetType {
             return .post
         }
     }
-    public var parameters: [String: Any]? {
-        switch self {
-        case .upload:
-            return ["api_key": "dc6zaTOxFJmzC", "username": "Moya"]
-        }
-    }
-    public var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
     public var task: Task {
         switch self {
         case let .upload(data):
-            return .upload(.multipart([MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]))
+            let multipartFormData = [MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]
+            return .uploadMultipartParameters(parameters: ["api_key": "dc6zaTOxFJmzC", "username": "Moya"], encoding: URLEncoding.default, multipartFormData)
         }
     }
     public var sampleData: Data {

--- a/Demo/Shared/GitHubAPI.swift
+++ b/Demo/Shared/GitHubAPI.swift
@@ -56,7 +56,7 @@ extension GitHub: TargetType {
         return URLEncoding.default
     }
     public var task: Task {
-        return .request
+        return .requestPlain
     }
     public var validate: Bool {
         switch self {

--- a/Demo/Shared/GitHubUserContentAPI.swift
+++ b/Demo/Shared/GitHubUserContentAPI.swift
@@ -21,19 +21,10 @@ extension GitHubUserContent: TargetType {
             return .get
         }
     }
-    public var parameters: [String: Any]? {
-        switch self {
-        case .downloadMoyaWebContent:
-            return nil
-        }
-    }
-    public var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
     public var task: Task {
         switch self {
         case .downloadMoyaWebContent:
-            return .download(.request(DefaultDownloadDestination))
+            return .downloadDestination(DefaultDownloadDestination)
         }
     }
     public var sampleData: Data {

--- a/Readme.md
+++ b/Readme.md
@@ -244,6 +244,22 @@ for filtering out certain status codes. This means that you can place your code 
 handling API errors like 400's in the same places as code for handling invalid
 responses.
 
+## Migration Guides
+
+This project follows [Semantic Versioning](http://semver.org).
+
+Please follow the appropriate guide below when **upgrading to a new major version** of Moya (e.g. 8.0 -> 9.0).
+
+### Upgrade from 8.x to 9.x
+
+- Move the `parameters` and `parameterEncoding` to the `task` computed property by using the case `.requestParameters(parameters:,encoding:)`
+- Replace the task type `.request` with either `.requestPlain` (if you have no parameters) or `.requestParameters(parameters:,encoding:)`
+- There's no `parameters` and `parameterEncoding` on Endpoints any more (e.g. `addingParameters()`), provide them through the `task` on your target instead
+- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(urlParameters:,bodyParameters:,bodyEncoding:)`
+- Simplify occurences of task type `.download(.request(destination))` to `.downloadDestination(destination)`
+- Simplify occurences of task type `.upload(.file(url))` to `.uploadFile(url)`
+- Simplify occurences of task type `.upload(.multipart(data))` to `.uploadMultipart(data)`
+
 ## Community Projects
 
 [Moya has a great community around it and some people have created some very helpful extensions.](https://github.com/Moya/Moya/blob/master/docs/CommunityProjects.md)

--- a/Readme.md
+++ b/Readme.md
@@ -244,22 +244,6 @@ for filtering out certain status codes. This means that you can place your code 
 handling API errors like 400's in the same places as code for handling invalid
 responses.
 
-## Migration Guides
-
-This project follows [Semantic Versioning](http://semver.org).
-
-Please follow the appropriate guide below when **upgrading to a new major version** of Moya (e.g. 8.0 -> 9.0).
-
-### Upgrade from 8.x to 9.x
-
-- Move the `parameters` and `parameterEncoding` to the `task` computed property by using the case `.requestParameters(parameters:,encoding:)`
-- Replace the task type `.request` with either `.requestPlain` (if you have no parameters) or `.requestParameters(parameters:,encoding:)`
-- There's no `parameters` and `parameterEncoding` on Endpoints any more (e.g. `addingParameters()`), provide them through the `task` on your target instead
-- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(urlParameters:,bodyParameters:,bodyEncoding:)`
-- Simplify occurences of task type `.download(.request(destination))` to `.downloadDestination(destination)`
-- Simplify occurences of task type `.upload(.file(url))` to `.uploadFile(url)`
-- Simplify occurences of task type `.upload(.multipart(data))` to `.uploadMultipart(data)`
-
 ## Community Projects
 
 [Moya has a great community around it and some people have created some very helpful extensions.](https://github.com/Moya/Moya/blob/master/docs/CommunityProjects.md)

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -72,6 +72,44 @@ extension Endpoint {
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = httpHeaderFields
 
+        switch task {
+        case .requestPlain, .uploadFile, .uploadMultipart, .downloadDestination:
+            break
+
+        case .requestData(let data):
+            request.httpBody = data
+
+        case let .requestParameters(parameters: parameters, encoding: parameterEncoding):
+            do {
+                request = try parameterEncoding.encode(request, with: parameters)
+            } catch {
+                return nil
+            }
+
+        case let .requestCompositeData(urlParameters: urlParameters, bodyData: bodyData):
+            do {
+                request = try URLEncoding.default.encode(request, with: urlParameters)
+            } catch {
+                return nil
+            }
+            request.httpBody = bodyData
+
+        case let .requestCompositeParameters(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding):
+            do {
+                request = try URLEncoding.default.encode(request, with: urlParameters)
+                request = try bodyParameterEncoding.encode(request, with: bodyParameters)
+            } catch {
+                return nil
+            }
+
+        case let .downloadParameters(_, parameters: parameters, encoding: parameterEncoding):
+            do {
+                request = try parameterEncoding.encode(request, with: parameters)
+            } catch {
+                return nil
+            }
+        }
+
         return request
     }
 }

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -82,7 +82,7 @@ extension Endpoint {
         case let .requestParameters(parameters: parameters, encoding: parameterEncoding):
             return try? parameterEncoding.encode(request, with: parameters)
 
-        case let .requestCompositeData(urlParameters: urlParameters, bodyData: bodyData):
+        case let .requestCompositeData(bodyData: bodyData, urlParameters: urlParameters):
             do {
                 request = try URLEncoding.default.encode(request, with: urlParameters)
             } catch {
@@ -90,7 +90,7 @@ extension Endpoint {
             }
             request.httpBody = bodyData
 
-        case let .requestCompositeParameters(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding):
+        case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
             do {
                 request = try URLEncoding.default.encode(request, with: urlParameters)
                 request = try bodyParameterEncoding.encode(request, with: bodyParameters)
@@ -98,7 +98,7 @@ extension Endpoint {
                 return nil
             }
 
-        case let .downloadParameters(_, parameters: parameters, encoding: parameterEncoding):
+        case let .downloadParameters(parameters: parameters, encoding: parameterEncoding, _):
             return try? parameterEncoding.encode(request, with: parameters)
         }
 

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -75,27 +75,20 @@ extension Endpoint {
         switch task {
         case .requestPlain, .uploadFile, .uploadMultipart, .downloadDestination:
             return request
-
         case .requestData(let data):
             request.httpBody = data
             return request
-
         case let .requestParameters(parameters, parameterEncoding):
             return try? parameterEncoding.encode(request, with: parameters)
-
         case let .uploadCompositeMultipart(_, urlParameters):
             return try? URLEncoding(destination: .queryString).encode(request, with: urlParameters)
-
         case let .downloadParameters(parameters, parameterEncoding, _):
             return try? parameterEncoding.encode(request, with: parameters)
-
         case let .requestCompositeData(bodyData: bodyData, urlParameters: urlParameters):
             request.httpBody = bodyData
             return try? URLEncoding(destination: .queryString).encode(request, with: urlParameters)
-
         case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
             if bodyParameterEncoding is URLEncoding { fatalError("URLEncoding is disallowed as bodyEncoding.") }
-
             guard let bodyfulRequest = try? bodyParameterEncoding.encode(request, with: bodyParameters) else { return nil }
             return try? URLEncoding(destination: .queryString).encode(bodyfulRequest, with: urlParameters)
         }

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -84,18 +84,18 @@ extension Endpoint {
             return try? parameterEncoding.encode(request, with: parameters)
 
         case let .uploadCompositeMultipart(_, urlParameters):
-            return try? URLEncoding.default.encode(request, with: urlParameters)
+            return try? URLEncoding(destination: .queryString).encode(request, with: urlParameters)
 
         case let .downloadParameters(parameters, parameterEncoding, _):
             return try? parameterEncoding.encode(request, with: parameters)
 
         case let .requestCompositeData(bodyData: bodyData, urlParameters: urlParameters):
             request.httpBody = bodyData
-            return try? URLEncoding.default.encode(request, with: urlParameters)
+            return try? URLEncoding(destination: .queryString).encode(request, with: urlParameters)
 
         case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
             guard let bodyfulRequest = try? bodyParameterEncoding.encode(request, with: bodyParameters) else { return nil }
-            return try? URLEncoding.default.encode(bodyfulRequest, with: urlParameters)
+            return try? URLEncoding(destination: .queryString).encode(bodyfulRequest, with: urlParameters)
         }
     }
 }

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -83,11 +83,8 @@ extension Endpoint {
         case let .requestParameters(parameters, parameterEncoding):
             return try? parameterEncoding.encode(request, with: parameters)
 
-        case let .uploadFileParameters(parameters, parameterEncoding, _):
-            return try? parameterEncoding.encode(request, with: parameters)
-
-        case let .uploadMultipartParameters(parameters, parameterEncoding, _):
-            return try? parameterEncoding.encode(request, with: parameters)
+        case let .uploadCompositeMultipart(_, urlParameters):
+            return try? URLEncoding.default.encode(request, with: urlParameters)
 
         case let .downloadParameters(parameters, parameterEncoding, _):
             return try? parameterEncoding.encode(request, with: parameters)

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -21,29 +21,18 @@ open class Endpoint<Target> {
     open let url: String
     open let method: Moya.Method
     open let sampleResponseClosure: SampleResponseClosure
-    open let parameters: [String: Any]?
-    open let parameterEncoding: Moya.ParameterEncoding
     open let httpHeaderFields: [String: String]?
 
     /// Main initializer for `Endpoint`.
     public init(url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method = Moya.Method.get,
-                parameters: [String: Any]? = nil,
-                parameterEncoding: Moya.ParameterEncoding = URLEncoding.default,
                 httpHeaderFields: [String: String]? = nil) {
 
         self.url = url
         self.sampleResponseClosure = sampleResponseClosure
         self.method = method
-        self.parameters = parameters
-        self.parameterEncoding = parameterEncoding
         self.httpHeaderFields = httpHeaderFields
-    }
-
-    /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added parameters.
-    open func adding(newParameters: [String: Any]) -> Endpoint<Target> {
-        return adding(parameters: newParameters)
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added HTTP header fields.
@@ -51,29 +40,10 @@ open class Endpoint<Target> {
         return adding(httpHeaderFields: newHTTPHeaderFields)
     }
 
-    /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with another parameter encoding.
-    open func adding(newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<Target> {
-        return adding(parameterEncoding: newParameterEncoding)
-    }
-
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
-    open func adding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
-        let newParameters = add(parameters: parameters)
+    open func adding(httpHeaderFields: [String: String]? = nil)  -> Endpoint<Target> {
         let newHTTPHeaderFields = add(httpHeaderFields: httpHeaderFields)
-        let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
-    }
-
-    fileprivate func add(parameters: [String: Any]?) -> [String: Any]? {
-        guard let unwrappedParameters = parameters, unwrappedParameters.isEmpty == false else {
-            return self.parameters
-        }
-
-        var newParameters = self.parameters ?? [:]
-        unwrappedParameters.forEach { key, value in
-            newParameters[key] = value
-        }
-        return newParameters
+        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, httpHeaderFields: newHTTPHeaderFields)
     }
 
     fileprivate func add(httpHeaderFields headers: [String: String]?) -> [String: String]? {
@@ -99,7 +69,7 @@ extension Endpoint {
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = httpHeaderFields
 
-        return try? parameterEncoding.encode(request, with: parameters)
+        return request
     }
 }
 

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -80,11 +80,7 @@ extension Endpoint {
             request.httpBody = data
 
         case let .requestParameters(parameters: parameters, encoding: parameterEncoding):
-            do {
-                request = try parameterEncoding.encode(request, with: parameters)
-            } catch {
-                return nil
-            }
+            return try? parameterEncoding.encode(request, with: parameters)
 
         case let .requestCompositeData(urlParameters: urlParameters, bodyData: bodyData):
             do {
@@ -103,11 +99,7 @@ extension Endpoint {
             }
 
         case let .downloadParameters(_, parameters: parameters, encoding: parameterEncoding):
-            do {
-                request = try parameterEncoding.encode(request, with: parameters)
-            } catch {
-                return nil
-            }
+            return try? parameterEncoding.encode(request, with: parameters)
         }
 
         return request

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -19,19 +19,22 @@ open class Endpoint<Target> {
     public typealias SampleResponseClosure = () -> EndpointSampleResponse
 
     open let url: String
-    open let method: Moya.Method
     open let sampleResponseClosure: SampleResponseClosure
+    open let method: Moya.Method
+    open let task: Task
     open let httpHeaderFields: [String: String]?
 
     /// Main initializer for `Endpoint`.
     public init(url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method = Moya.Method.get,
+                task: Task = .requestPlain,
                 httpHeaderFields: [String: String]? = nil) {
 
         self.url = url
         self.sampleResponseClosure = sampleResponseClosure
         self.method = method
+        self.task = task
         self.httpHeaderFields = httpHeaderFields
     }
 
@@ -43,7 +46,7 @@ open class Endpoint<Target> {
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
     open func adding(httpHeaderFields: [String: String]? = nil)  -> Endpoint<Target> {
         let newHTTPHeaderFields = add(httpHeaderFields: httpHeaderFields)
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, httpHeaderFields: newHTTPHeaderFields)
+        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, task: task, httpHeaderFields: newHTTPHeaderFields)
     }
 
     fileprivate func add(httpHeaderFields headers: [String: String]?) -> [String: String]? {

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -74,12 +74,22 @@ extension Endpoint {
 
         switch task {
         case .requestPlain, .uploadFile, .uploadMultipart, .downloadDestination:
-            break
+            return request
 
         case .requestData(let data):
             request.httpBody = data
+            return request
 
-        case let .requestParameters(parameters: parameters, encoding: parameterEncoding):
+        case let .requestParameters(parameters, parameterEncoding):
+            return try? parameterEncoding.encode(request, with: parameters)
+
+        case let .uploadFileParameters(parameters, parameterEncoding, _):
+            return try? parameterEncoding.encode(request, with: parameters)
+
+        case let .uploadMultipartParameters(parameters, parameterEncoding, _):
+            return try? parameterEncoding.encode(request, with: parameters)
+
+        case let .downloadParameters(parameters, parameterEncoding, _):
             return try? parameterEncoding.encode(request, with: parameters)
 
         case let .requestCompositeData(bodyData: bodyData, urlParameters: urlParameters):
@@ -89,12 +99,7 @@ extension Endpoint {
         case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
             guard let bodyfulRequest = try? bodyParameterEncoding.encode(request, with: bodyParameters) else { return nil }
             return try? URLEncoding.default.encode(bodyfulRequest, with: urlParameters)
-
-        case let .downloadParameters(parameters: parameters, encoding: parameterEncoding, _):
-            return try? parameterEncoding.encode(request, with: parameters)
         }
-
-        return request
     }
 }
 

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -83,20 +83,12 @@ extension Endpoint {
             return try? parameterEncoding.encode(request, with: parameters)
 
         case let .requestCompositeData(bodyData: bodyData, urlParameters: urlParameters):
-            do {
-                request = try URLEncoding.default.encode(request, with: urlParameters)
-            } catch {
-                return nil
-            }
             request.httpBody = bodyData
+            return try? URLEncoding.default.encode(request, with: urlParameters)
 
         case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
-            do {
-                request = try URLEncoding.default.encode(request, with: urlParameters)
-                request = try bodyParameterEncoding.encode(request, with: bodyParameters)
-            } catch {
-                return nil
-            }
+            guard let bodyfulRequest = try? bodyParameterEncoding.encode(request, with: bodyParameters) else { return nil }
+            return try? URLEncoding.default.encode(bodyfulRequest, with: urlParameters)
 
         case let .downloadParameters(parameters: parameters, encoding: parameterEncoding, _):
             return try? parameterEncoding.encode(request, with: parameters)

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -94,6 +94,8 @@ extension Endpoint {
             return try? URLEncoding(destination: .queryString).encode(request, with: urlParameters)
 
         case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
+            if bodyParameterEncoding is URLEncoding { fatalError("URLEncoding is disallowed as bodyEncoding.") }
+
             guard let bodyfulRequest = try? bodyParameterEncoding.encode(request, with: bodyParameters) else { return nil }
             return try? URLEncoding(destination: .queryString).encode(bodyfulRequest, with: urlParameters)
         }

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -8,8 +8,6 @@ public extension MoyaProvider {
             url: URL(target: target).absoluteString,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,
-            parameters: target.parameters,
-            parameterEncoding: target.parameterEncoding,
             httpHeaderFields: target.headers
         )
     }

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -8,6 +8,7 @@ public extension MoyaProvider {
             url: URL(target: target).absoluteString,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,
+            task: target.task,
             httpHeaderFields: target.headers
         )
     }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -88,7 +88,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .requestEncoded(parameters: parameters, encoding: parameterEncoding):
+                case let .requestParameters(parameters: parameters, encoding: parameterEncoding):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
                     } catch {
@@ -105,7 +105,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = bodyData
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .requestCompositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding):
+                case let .requestCompositeParameters(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                         preparedRequest = try bodyParameterEncoding.encode(preparedRequest, with: bodyParameters)
@@ -126,7 +126,7 @@ public extension MoyaProvider {
                 case .download(.destination(let destination)):
                     cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: networkCompletion)
 
-                case let .download(.encoded(destination, parameters: parameters, encoding: parameterEncoding)):
+                case let .download(.parameters(destination, parameters: parameters, encoding: parameterEncoding)):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
                     } catch {

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -88,7 +88,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .request(RequestDataType.encoded(parameters: parameters, encoding: parameterEncoding)):
+                case let .request(.encoded(parameters: parameters, encoding: parameterEncoding)):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
                     } catch {
@@ -96,7 +96,7 @@ public extension MoyaProvider {
                     }
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .request(RequestDataType.compositeData(urlParameters: urlParameters, bodyData: bodyData)):
+                case let .request(.compositeData(urlParameters: urlParameters, bodyData: bodyData)):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                     } catch {
@@ -105,7 +105,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = bodyData
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .request(RequestDataType.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):
+                case let .request(.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                         preparedRequest = try bodyParameterEncoding.encode(preparedRequest, with: bodyParameters)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -84,6 +84,9 @@ public extension MoyaProvider {
             switch stubBehavior {
             case .never:
                 switch target.task {
+                case .requestPlain:
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
+
                 case .requestData(let data):
                     preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -84,11 +84,11 @@ public extension MoyaProvider {
             switch stubBehavior {
             case .never:
                 switch target.task {
-                case .request(.data(let data)):
+                case .requestData(let data):
                     preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .request(.encoded(parameters: parameters, encoding: parameterEncoding)):
+                case let .requestEncoded(parameters: parameters, encoding: parameterEncoding):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
                     } catch {
@@ -96,7 +96,7 @@ public extension MoyaProvider {
                     }
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .request(.compositeData(urlParameters: urlParameters, bodyData: bodyData)):
+                case let .requestCompositeData(urlParameters: urlParameters, bodyData: bodyData):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                     } catch {
@@ -105,7 +105,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = bodyData
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case let .request(.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):
+                case let .requestCompositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                         preparedRequest = try bodyParameterEncoding.encode(preparedRequest, with: bodyParameters)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -83,7 +83,7 @@ public extension MoyaProvider {
 
             switch stubBehavior {
             case .never:
-                cancellableToken.innerCancellable = self.unstubbedRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion, endpoint: endpoint, stubBehavior: stubBehavior)
+                cancellableToken.innerCancellable = self.unstubbedRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
             default:
                 cancellableToken.innerCancellable = self.stubRequest(target, request: preparedRequest, callbackQueue: callbackQueue, completion: networkCompletion, endpoint: endpoint, stubBehavior: stubBehavior)
@@ -97,7 +97,7 @@ public extension MoyaProvider {
     // swiftlint:enable cyclomatic_complexity
     // swiftlint:enable function_body_length
 
-    private func unstubbedRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> Cancellable {
+    private func unstubbedRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> Cancellable {
         switch target.task {
         case .requestPlain, .requestData, .requestParameters, .requestCompositeData, .requestCompositeParameters:
             return self.sendRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -67,7 +67,7 @@ public extension MoyaProvider {
             }
 
             // Allow plugins to modify request
-            var preparedRequest = self.plugins.reduce(request) { $1.prepare($0, target: target) }
+            let preparedRequest = self.plugins.reduce(request) { $1.prepare($0, target: target) }
 
             let networkCompletion: Moya.Completion = { result in
               if self.trackInflights {
@@ -84,37 +84,7 @@ public extension MoyaProvider {
             switch stubBehavior {
             case .never:
                 switch target.task {
-                case .requestPlain:
-                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
-
-                case .requestData(let data):
-                    preparedRequest.httpBody = data
-                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
-
-                case let .requestParameters(parameters: parameters, encoding: parameterEncoding):
-                    do {
-                        preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
-                    } catch {
-                        // TODO: Add exception handling here
-                    }
-                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
-
-                case let .requestCompositeData(urlParameters: urlParameters, bodyData: bodyData):
-                    do {
-                        preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
-                    } catch {
-                        // TODO: Add exception handling here
-                    }
-                    preparedRequest.httpBody = bodyData
-                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
-
-                case let .requestCompositeParameters(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding):
-                    do {
-                        preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
-                        preparedRequest = try bodyParameterEncoding.encode(preparedRequest, with: bodyParameters)
-                    } catch {
-                        // TODO: Add exception handling here
-                    }
+                case .requestPlain, .requestData, .requestParameters, .requestCompositeData, .requestCompositeParameters:
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
                 case .uploadFile(let file):
@@ -129,12 +99,7 @@ public extension MoyaProvider {
                 case .downloadDestination(let destination):
                     cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: networkCompletion)
 
-                case let .downloadParameters(destination, parameters: parameters, encoding: parameterEncoding):
-                    do {
-                        preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
-                    } catch {
-                        // TODO: Add exception handling here
-                    }
+                case let .downloadParameters(destination, parameters: _, encoding: _):
                     cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: networkCompletion)
                 }
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -114,19 +114,19 @@ public extension MoyaProvider {
                     }
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
 
-                case .upload(.file(let file)):
+                case .uploadFile(let file):
                     cancellableToken.innerCancellable = self.sendUploadFile(target, request: preparedRequest, callbackQueue: callbackQueue, file: file, progress: progress, completion: networkCompletion)
 
-                case .upload(.multipart(let multipartBody)):
+                case .uploadMultipart(let multipartBody):
                     guard !multipartBody.isEmpty && target.method.supportsMultipart else {
                         fatalError("\(target) is not a multipart upload target.")
                     }
                     cancellableToken.innerCancellable = self.sendUploadMultipart(target, request: preparedRequest, callbackQueue: callbackQueue, multipartBody: multipartBody, progress: progress, completion: networkCompletion)
 
-                case .download(.destination(let destination)):
+                case .downloadDestination(let destination):
                     cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: networkCompletion)
 
-                case let .download(.parameters(destination, parameters: parameters, encoding: parameterEncoding)):
+                case let .downloadParameters(destination, parameters: parameters, encoding: parameterEncoding):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
                     } catch {

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -83,25 +83,7 @@ public extension MoyaProvider {
 
             switch stubBehavior {
             case .never:
-                switch target.task {
-                case .requestPlain, .requestData, .requestParameters, .requestCompositeData, .requestCompositeParameters:
-                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion)
-
-                case .uploadFile(let file):
-                    cancellableToken.innerCancellable = self.sendUploadFile(target, request: preparedRequest, callbackQueue: callbackQueue, file: file, progress: progress, completion: networkCompletion)
-
-                case .uploadMultipart(let multipartBody):
-                    guard !multipartBody.isEmpty && target.method.supportsMultipart else {
-                        fatalError("\(target) is not a multipart upload target.")
-                    }
-                    cancellableToken.innerCancellable = self.sendUploadMultipart(target, request: preparedRequest, callbackQueue: callbackQueue, multipartBody: multipartBody, progress: progress, completion: networkCompletion)
-
-                case .downloadDestination(let destination):
-                    cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: networkCompletion)
-
-                case let .downloadParameters(destination, parameters: _, encoding: _):
-                    cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: networkCompletion)
-                }
+                cancellableToken.innerCancellable = self.unstubbedRequest(target, request: preparedRequest, callbackQueue: callbackQueue, progress: progress, completion: networkCompletion, endpoint: endpoint, stubBehavior: stubBehavior)
 
             default:
                 cancellableToken.innerCancellable = self.stubRequest(target, request: preparedRequest, callbackQueue: callbackQueue, completion: networkCompletion, endpoint: endpoint, stubBehavior: stubBehavior)
@@ -114,6 +96,28 @@ public extension MoyaProvider {
     }
     // swiftlint:enable cyclomatic_complexity
     // swiftlint:enable function_body_length
+
+    private func unstubbedRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> Cancellable {
+        switch target.task {
+        case .requestPlain, .requestData, .requestParameters, .requestCompositeData, .requestCompositeParameters:
+            return self.sendRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion)
+
+        case .uploadFile(let file):
+            return self.sendUploadFile(target, request: request, callbackQueue: callbackQueue, file: file, progress: progress, completion: completion)
+
+        case .uploadMultipart(let multipartBody):
+            guard !multipartBody.isEmpty && target.method.supportsMultipart else {
+                fatalError("\(target) is not a multipart upload target.")
+            }
+            return self.sendUploadMultipart(target, request: request, callbackQueue: callbackQueue, multipartBody: multipartBody, progress: progress, completion: completion)
+
+        case .downloadDestination(let destination):
+            return self.sendDownloadRequest(target, request: request, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
+
+        case let .downloadParameters(_, _, destination):
+            return self.sendDownloadRequest(target, request: request, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
+        }
+    }
 
     func cancelCompletion(_ completion: Moya.Completion, target: Target) {
         let error = MoyaError.underlying(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil), nil)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -99,10 +99,10 @@ public extension MoyaProvider {
             case .requestPlain, .requestData, .requestParameters, .requestCompositeData, .requestCompositeParameters:
                 return self.sendRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion)
 
-            case .uploadFile(let file), .uploadFileParameters(_, _, let file):
+            case .uploadFile(let file):
                 return self.sendUploadFile(target, request: request, callbackQueue: callbackQueue, file: file, progress: progress, completion: completion)
 
-            case .uploadMultipart(let multipartBody), .uploadMultipartParameters(_, _, let multipartBody):
+            case .uploadMultipart(let multipartBody), .uploadCompositeMultipart(let multipartBody, _):
                 guard !multipartBody.isEmpty && target.method.supportsMultipart else {
                     fatalError("\(target) is not a multipart upload target.")
                 }

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -21,14 +21,6 @@ public enum MultiTarget: TargetType {
         return target.method
     }
 
-    public var parameters: [String: Any]? {
-        return target.parameters
-    }
-
-    public var parameterEncoding: ParameterEncoding {
-        return target.parameterEncoding
-    }
-
     public var sampleData: Data {
         return target.sampleData
     }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -53,14 +53,11 @@ public enum Task {
     /// A file upload task.
     case uploadFile(URL)
 
-    /// A file upload task with extra parameters using the given encoding.
-    case uploadFileParameters(parameters: [String: Any], encoding: ParameterEncoding, URL)
-
     /// A "multipart/form-data" upload task.
     case uploadMultipart([MultipartFormData])
 
-    /// A "multipart/form-data" upload task with extra parameters using the given encoding.
-    case uploadMultipartParameters(parameters: [String: Any], encoding: ParameterEncoding, [MultipartFormData])
+    /// A "multipart/form-data" upload task  combined with url parameters.
+    case uploadCompositeMultipart([MultipartFormData], urlParameters: [String: Any])
 
     /// A file download task to a destination.
     case downloadDestination(DownloadDestination)

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -13,9 +13,6 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
-    /// The default parameterEncoding for the `.encoded` RequestDataType case.
-    var defaultParameterEncoding: ParameterEncoding { get }
-
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
 
@@ -56,7 +53,7 @@ public enum DownloadType {
     case destination(DownloadDestination)
 
     /// Download a file to a destination with extra parameters using the given encoding.
-    case encoded(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
+    case parameters(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
 }
 
 /// Represents an HTTP task.
@@ -66,17 +63,24 @@ public enum Task {
     case requestData(Data)
 
     /// A requests body set with parameters and encoding.
-    case requestEncoded(parameters: [String: Any], encoding: ParameterEncoding)
+    case requestParameters(parameters: [String: Any], encoding: ParameterEncoding)
 
     /// A requests body set with data, combined with url parameters.
     case requestCompositeData(urlParameters: [String: Any], bodyData: Data)
 
     /// A requests body set with parameters and encoding, combined with url parameters.
-    case requestCompositeEncoded(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
+    case requestCompositeParameters(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 
     /// An upload task.
     case upload(UploadType)
 
     /// A download task.
     case download(DownloadType)
+}
+
+/// Extension to Parameter encoding to make using the `.requestEncoded` and `.requestCompositeEncoded` task types easier.
+extension ParameterEncoding {
+    static var `default`: ParameterEncoding {
+        return JSONEncoding.default
+    }
 }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -13,6 +13,9 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
+    /// The default parameterEncoding for the `.encoded` RequestDataType case.
+    var defaultParameterEncoding: ParameterEncoding { get }
+
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
 
@@ -27,6 +30,10 @@ public protocol TargetType {
 }
 
 public extension TargetType {
+    var defaultParameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
+
     var validate: Bool {
         return false
     }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -27,10 +27,6 @@ public protocol TargetType {
 }
 
 public extension TargetType {
-    var defaultParameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
-
     var validate: Bool {
         return false
     }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -62,28 +62,21 @@ public enum DownloadType {
 /// Represents an HTTP task.
 public enum Task {
 
-    /// A basic request task.
-    case request(RequestDataType)
+    /// A requests body set with data.
+    case requestData(Data)
+
+    /// A requests body set with parameters and encoding.
+    case requestEncoded(parameters: [String: Any], encoding: ParameterEncoding)
+
+    /// A requests body set with data, combined with url parameters.
+    case requestCompositeData(urlParameters: [String: Any], bodyData: Data)
+
+    /// A requests body set with parameters and encoding, combined with url parameters.
+    case requestCompositeEncoded(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 
     /// An upload task.
     case upload(UploadType)
 
     /// A download task.
     case download(DownloadType)
-}
-
-/// Represents a type of request.
-public enum RequestDataType {
-
-    /// A requests body set with data.
-    case data(Data)
-
-    /// A requests body set with parameters and encoding.
-    case encoded(parameters: [String: Any], encoding: ParameterEncoding)
-
-    /// A requests body set with data, combined with url parameters.
-    case compositeData(urlParameters: [String: Any], bodyData: Data)
-
-    /// A requests body set with parameters and encoding, combined with url parameters.
-    case compositeEncoded(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -59,7 +59,6 @@ public enum DownloadType {
     case encoded(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
 }
 
-
 /// Represents an HTTP task.
 public enum Task {
 

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -36,26 +36,6 @@ public extension TargetType {
     }
 }
 
-/// Represents a type of upload task.
-public enum UploadType {
-
-    /// Upload a file.
-    case file(URL)
-
-    /// Upload "multipart/form-data"
-    case multipart([MultipartFormData])
-}
-
-/// Represents a type of download task.
-public enum DownloadType {
-
-    /// Download a file to a destination.
-    case destination(DownloadDestination)
-
-    /// Download a file to a destination with extra parameters using the given encoding.
-    case parameters(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
-}
-
 /// Represents an HTTP task.
 public enum Task {
 
@@ -71,14 +51,20 @@ public enum Task {
     /// A requests body set with parameters and encoding, combined with url parameters.
     case requestCompositeParameters(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 
-    /// An upload task.
-    case upload(UploadType)
+    /// A file upload task.
+    case uploadFile(URL)
 
-    /// A download task.
-    case download(DownloadType)
+    /// A "multipart/form-data" upload task.
+    case uploadMultipart([MultipartFormData])
+
+    /// A file download task to a destination.
+    case downloadDestination(DownloadDestination)
+
+    /// A file download task to a destination with extra parameters using the given encoding.
+    case downloadParameters(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
 }
 
-/// Extension to Parameter encoding to make using the `.requestEncoded` and `.requestCompositeEncoded` task types easier.
+/// Extension to Parameter encoding to make using some task types easier.
 extension ParameterEncoding {
     static var `default`: ParameterEncoding {
         return JSONEncoding.default

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -41,13 +41,13 @@ public enum Task {
     /// A requests body set with data.
     case requestData(Data)
 
-    /// A requests body set with parameters and encoding.
+    /// A requests body set with encoded parameters.
     case requestParameters(parameters: [String: Any], encoding: ParameterEncoding)
 
     /// A requests body set with data, combined with url parameters.
     case requestCompositeData(urlParameters: [String: Any], bodyData: Data)
 
-    /// A requests body set with parameters and encoding, combined with url parameters.
+    /// A requests body set with encoded parameters combined with url parameters.
     case requestCompositeParameters(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 
     /// A file upload task.

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -53,8 +53,14 @@ public enum Task {
     /// A file upload task.
     case uploadFile(URL)
 
+    /// A file upload task with extra parameters using the given encoding.
+    case uploadFileParameters(parameters: [String: Any], encoding: ParameterEncoding, URL)
+
     /// A "multipart/form-data" upload task.
     case uploadMultipart([MultipartFormData])
+
+    /// A "multipart/form-data" upload task with extra parameters using the given encoding.
+    case uploadMultipartParameters(parameters: [String: Any], encoding: ParameterEncoding, [MultipartFormData])
 
     /// A file download task to a destination.
     case downloadDestination(DownloadDestination)

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -13,12 +13,6 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
-    /// The parameters to be encoded in the request.
-    var parameters: [String: Any]? { get }
-
-    /// The method used for parameter encoding.
-    var parameterEncoding: ParameterEncoding { get }
-
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
 
@@ -52,18 +46,38 @@ public enum UploadType {
 public enum DownloadType {
 
     /// Download a file to a destination.
-    case request(DownloadDestination)
+    case destination(DownloadDestination)
+
+    /// Download a file to a destination with extra parameters using the given encoding.
+    case encoded(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
 }
+
 
 /// Represents an HTTP task.
 public enum Task {
 
     /// A basic request task.
-    case request
+    case request(RequestDataType)
 
     /// An upload task.
     case upload(UploadType)
 
     /// A download task.
     case download(DownloadType)
+}
+
+/// Represents a type of request.
+public enum RequestDataType {
+
+    /// A requests body set with data.
+    case data(Data)
+
+    /// A requests body set with parameters and encoding.
+    case encoded(parameters: [String: Any], encoding: ParameterEncoding)
+
+    /// A requests body set with data, combined with url parameters.
+    case compositeData(urlParameters: [String: Any], bodyData: Data)
+
+    /// A requests body set with parameters and encoding, combined with url parameters.
+    case compositeEncoded(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -63,5 +63,5 @@ public enum Task {
     case downloadDestination(DownloadDestination)
 
     /// A file download task to a destination with extra parameters using the given encoding.
-    case downloadParameters(parameters: [String: Any], encoding: ParameterEncoding, DownloadDestination)
+    case downloadParameters(parameters: [String: Any], encoding: ParameterEncoding, destination: DownloadDestination)
 }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -45,10 +45,10 @@ public enum Task {
     case requestParameters(parameters: [String: Any], encoding: ParameterEncoding)
 
     /// A requests body set with data, combined with url parameters.
-    case requestCompositeData(urlParameters: [String: Any], bodyData: Data)
+    case requestCompositeData(bodyData: Data, urlParameters: [String: Any])
 
     /// A requests body set with encoded parameters combined with url parameters.
-    case requestCompositeParameters(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
+    case requestCompositeParameters(bodyParameters: [String: Any], bodyEncoding: ParameterEncoding, urlParameters: [String: Any])
 
     /// A file upload task.
     case uploadFile(URL)
@@ -60,5 +60,5 @@ public enum Task {
     case downloadDestination(DownloadDestination)
 
     /// A file download task to a destination with extra parameters using the given encoding.
-    case downloadParameters(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
+    case downloadParameters(parameters: [String: Any], encoding: ParameterEncoding, DownloadDestination)
 }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -39,6 +39,9 @@ public extension TargetType {
 /// Represents an HTTP task.
 public enum Task {
 
+    /// A request with no additional data.
+    case requestPlain
+
     /// A requests body set with data.
     case requestData(Data)
 
@@ -62,11 +65,4 @@ public enum Task {
 
     /// A file download task to a destination with extra parameters using the given encoding.
     case downloadParameters(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
-}
-
-/// Extension to Parameter encoding to make using some task types easier.
-extension ParameterEncoding {
-    static var `default`: ParameterEncoding {
-        return JSONEncoding.default
-    }
 }

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -8,9 +8,7 @@ final class AccessTokenPluginSpec: QuickSpec {
         let baseURL = URL(string: "http://www.api.com/")!
         let path = ""
         let method = Method.get
-        let parameters: [String: Any]? = nil
-        let parameterEncoding: ParameterEncoding = URLEncoding.default
-        let task = Task.request
+        let task = Task.requestPlain
         let sampleData = Data()
         let headers: [String: String]? = nil
 

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -9,35 +9,14 @@ class EndpointSpec: QuickSpec {
 
             beforeEach {
                 let target: GitHub = .zen
-                let parameters = ["Nemesis": "Harvey"]
                 let headerFields = ["Title": "Dominar"]
-                endpoint = Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, parameters: parameters, parameterEncoding: JSONEncoding.default, httpHeaderFields: headerFields)
-            }
-
-            it("returns a new endpoint for adding(newParameters:)") {
-                let message = "I hate it when villains quote Shakespeare."
-                let newEndpoint = endpoint.adding(newParameters: ["message": message])
-                let newEndpointMessageObject: Any? = newEndpoint.parameters?["message"]
-                let newEndpointMessage = newEndpointMessageObject as? String
-                let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-
-                // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
-                expect(newEndpointMessage).to(equal(message))
-
-                // Compare other properties to ensure they've been copied correctly
-                expect(newEndpoint.url).to(equal(endpoint.url))
-                expect(newEndpoint.method).to(equal(endpoint.method))
-                expect(newEndpoint.httpHeaderFields?.count).to(equal(endpoint.httpHeaderFields?.count))
-                expect(newEncodedRequest).to(equal(encodedRequest))
+                endpoint = Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, httpHeaderFields: headerFields)
             }
 
             it("returns a new endpoint for adding(newHTTPHeaderFields:)") {
                 let agent = "Zalbinian"
                 let newEndpoint = endpoint.adding(newHTTPHeaderFields: ["User-Agent": agent])
                 let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]
-                let encodedRequest = try? endpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
 
                 // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
                 expect(newEndpointAgent).to(equal(agent))
@@ -45,51 +24,11 @@ class EndpointSpec: QuickSpec {
                 // Compare other properties to ensure they've been copied correctly
                 expect(newEndpoint.url).to(equal(endpoint.url))
                 expect(newEndpoint.method).to(equal(endpoint.method))
-                expect(newEndpoint.parameters?.count).to(equal(endpoint.parameters?.count))
-                expect(newEncodedRequest).to(equal(encodedRequest))
-            }
-
-            it ("returns a new endpoint for adding(newParameterEncoding:)") {
-                let parameterEncoding = JSONEncoding.default
-                let newEndpoint = endpoint.adding(newParameterEncoding: parameterEncoding)
-                let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-
-                // Make sure we updated the parameter encoding
-                expect(newEncodedRequest).to(equal(encodedRequest))
-
-                // Compare other properties to ensure they've been copied correctly
-                expect(newEndpoint.url).to(equal(endpoint.url))
-                expect(newEndpoint.method).to(equal(endpoint.method))
-                expect(newEndpoint.parameters?.count).to(equal(endpoint.parameters?.count))
-                expect(newEndpoint.httpHeaderFields?.count).to(equal(endpoint.httpHeaderFields?.count))
-            }
-
-            it ("returns a new endpoint for endpointByAdding with all parameters") {
-                let parameterEncoding = URLEncoding.default
-                let agent = "Zalbinian"
-                let message = "I hate it when villains quote Shakespeare."
-                let newEndpoint = endpoint.adding(
-                    parameters: ["message": message],
-                    httpHeaderFields: ["User-Agent": agent],
-                    parameterEncoding: parameterEncoding
-                )
-                let encodedRequest = try? parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-                let newEncodedRequest = try? newEndpoint.parameterEncoding.encode(newEndpoint.urlRequest!, with: newEndpoint.parameters)
-
-                let newEndpointAgent = newEndpoint.httpHeaderFields?["User-Agent"]
-                let newEndpointMessage = newEndpoint.parameters?["message"] as? String
-
-                // Make sure our closure updated the sample response, as proof that it can modify the Endpoint
-                expect(newEndpointMessage).to(equal(message))
-                expect(newEndpointAgent).to(equal(agent))
-                expect(newEncodedRequest).to(equal(encodedRequest))
             }
 
             it("returns a correct URL request") {
                 let request = endpoint.urlRequest
                 expect(request!.url!.absoluteString).to(equal("https://api.github.com/zen"))
-                expect(String(data: request!.httpBody!, encoding: .utf8)).to(equal("{\"Nemesis\":\"Harvey\"}"))
                 let titleObject: Any? = endpoint.httpHeaderFields?["Title"]
                 let title = titleObject as? String
                 expect(title).to(equal("Dominar"))
@@ -114,7 +53,7 @@ extension Empty: TargetType {
     var method: Moya.Method { return .get }
     var parameters: [String: Any]? { return nil }
     var parameterEncoding: ParameterEncoding { return URLEncoding.default }
-    var task: Task { return .request }
+    var task: Task { return .requestPlain }
     var sampleData: Data { return Data() }
     var headers: [String: String]? { return nil }
 }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -139,11 +139,6 @@ class MoyaProviderSpec: QuickSpec {
             expect(called) == true
         }
 
-        it("uses the target's parameter encoding") {
-            let endpoint = MoyaProvider.defaultEndpointMapping(for: GitHub.zen)
-            expect(endpoint.parameterEncoding is JSONEncoding) == true
-        }
-
         describe("a provider with delayed stubs") {
             var provider: MoyaProvider<GitHub>!
             var plugin: TestingPlugin!
@@ -382,7 +377,7 @@ class MoyaProviderSpec: QuickSpec {
             it("returns sample data") {
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
+                    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -400,7 +395,7 @@ class MoyaProviderSpec: QuickSpec {
                 let response = HTTPURLResponse(url: URL(string: "http://example.com")!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method, parameters: target.parameters)
+                    return Endpoint(url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -418,7 +413,7 @@ class MoyaProviderSpec: QuickSpec {
                 let error = NSError(domain: "Internal iOS Error", code: -1234, userInfo: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method, parameters: target.parameters)
+                    return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -525,9 +520,7 @@ class MoyaProviderSpec: QuickSpec {
                 let baseURL = URL(string: "http://example.com")!
                 let path = "/endpoint"
                 let method = Moya.Method.get
-                let parameters: [String: Any]? = ["key": "value"]
-                let parameterEncoding: ParameterEncoding = URLEncoding.default
-                let task = Task.request
+                let task = Task.requestParameters(parameters: ["key": "value"], encoding: URLEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!
                 let headers: [String: String]? = ["headerKey": "headerValue"]
             }
@@ -551,27 +544,6 @@ class MoyaProviderSpec: QuickSpec {
                 }
 
                 expect(requestedURL) == "http://example.com/endpoint"
-            }
-
-            it("uses correct parameters") {
-                var requestParameters: [String: Any]?
-                let endpointResolution: MoyaProvider<MultiTarget>.RequestClosure = { endpoint, done in
-                    requestParameters = endpoint.parameters
-                    if let urlRequest = endpoint.urlRequest {
-                        done(.success(urlRequest))
-                    } else {
-                        done(.failure(MoyaError.requestMapping(endpoint.url)))
-                    }
-                }
-                let provider = MoyaProvider<MultiTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
-
-                waitUntil { done in
-                    provider.request(MultiTarget(StructAPI())) { _ in
-                        done()
-                    }
-                }
-
-                expect(requestParameters?.count) == 1
             }
 
             it("uses correct method") {
@@ -638,9 +610,7 @@ class MoyaProviderSpec: QuickSpec {
                 let baseURL = URL(string: "http://example.com/123/somepath?X-ABC-Asd=123")!
                 let path = ""
                 let method = Moya.Method.get
-                let parameters: [String: Any]? = ["key": "value"]
-                let parameterEncoding: ParameterEncoding = URLEncoding.default
-                let task = Task.request
+                let task = Task.requestParameters(parameters: ["key": "value"], encoding: URLEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!
                 let headers: [String: String]? = nil
             }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -377,7 +377,7 @@ class MoyaProviderSpec: QuickSpec {
             it("returns sample data") {
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method)
+                    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, task: target.task)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -395,7 +395,7 @@ class MoyaProviderSpec: QuickSpec {
                 let response = HTTPURLResponse(url: URL(string: "http://example.com")!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method)
+                    return Endpoint(url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method, task: target.task)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -413,7 +413,7 @@ class MoyaProviderSpec: QuickSpec {
                 let error = NSError(domain: "Internal iOS Error", code: -1234, userInfo: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method)
+                    return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method, task: target.task)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 

--- a/Tests/MultiTargetSpec.swift
+++ b/Tests/MultiTargetSpec.swift
@@ -34,7 +34,7 @@ class MultiTargetSpec: QuickSpec {
                     expect(parameters["key"] as? String) == "value"
                     expect(parameters.count) == 1
                 } else {
-                    fail()
+                    fail("expected task type `.requestParameters`, was \(String(describing: target.task))")
                 }
             }
 
@@ -42,7 +42,7 @@ class MultiTargetSpec: QuickSpec {
                 if case let .requestParameters(parameters: _, encoding: parameterEncoding) = target.task {
                     expect(parameterEncoding is JSONEncoding) == true
                 } else {
-                    fail()
+                    fail("expected task type `.requestParameters`, was \(String(describing: target.task))")
                 }
             }
 

--- a/Tests/MultiTargetSpec.swift
+++ b/Tests/MultiTargetSpec.swift
@@ -9,9 +9,7 @@ class MultiTargetSpec: QuickSpec {
                 let baseURL = URL(string: "http://example.com")!
                 let path = "/endpoint"
                 let method = Moya.Method.get
-                let parameters: [String: Any]? = ["key": "value"]
-                let parameterEncoding: Moya.ParameterEncoding = JSONEncoding.default
-                let task = Task.request
+                let task = Task.requestParameters(parameters: ["key": "value"], encoding: JSONEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!
                 let validate = true
                 let headers: [String: String]? = ["headerKey": "headerValue"]
@@ -32,12 +30,20 @@ class MultiTargetSpec: QuickSpec {
             }
 
             it("uses correct parameters") {
-                expect(target.parameters?["key"] as? String) == "value"
-                expect(target.parameters?.count) == 1
+                if case let .requestParameters(parameters: parameters, encoding: _) = target.task {
+                    expect(parameters["key"] as? String) == "value"
+                    expect(parameters.count) == 1
+                } else {
+                    fail()
+                }
             }
 
             it("uses correct parameter encoding.") {
-                expect(target.parameterEncoding is JSONEncoding) == true
+                if case let .requestParameters(parameters: _, encoding: parameterEncoding) = target.task {
+                    expect(parameterEncoding is JSONEncoding) == true
+                } else {
+                    fail()
+                }
             }
 
             it("uses correct method") {
@@ -45,7 +51,7 @@ class MultiTargetSpec: QuickSpec {
             }
 
             it("uses correct task") {
-                expect(String(describing: target.task)) == "request" // Hack to avoid implementing Equatable for Task
+                expect(String(describing: target.task)).to(beginWith("requestParameters")) // Hack to avoid implementing Equatable for Task
             }
 
             it("uses correct sample data") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -55,7 +55,7 @@ func url(_ route: TargetType) -> String {
 
 let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.moyaerror", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method)
+    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method, task: target.task)
 }
 
 enum HTTPBin: TargetType {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -27,16 +27,8 @@ extension GitHub: TargetType {
         return .get
     }
 
-    var parameters: [String: Any]? {
-        return nil
-    }
-
-    public var parameterEncoding: ParameterEncoding {
-        return JSONEncoding.default
-    }
-
     var task: Task {
-        return .request
+        return .requestPlain
     }
 
     var sampleData: Data {
@@ -63,7 +55,7 @@ func url(_ route: TargetType) -> String {
 
 let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.moyaerror", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method, parameters: target.parameters)
+    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method)
 }
 
 enum HTTPBin: TargetType {
@@ -81,19 +73,8 @@ enum HTTPBin: TargetType {
         return .get
     }
 
-    var parameters: [String: Any]? {
-        switch self {
-        default:
-            return [:]
-        }
-    }
-
-    var parameterEncoding: ParameterEncoding {
-        return URLEncoding.default
-    }
-
     var task: Task {
-        return .request
+        return .requestParameters(parameters: [:], encoding: URLEncoding.default)
     }
 
     var sampleData: Data {
@@ -138,7 +119,7 @@ extension GitHubUserContent: TargetType {
     public var task: Task {
         switch self {
         case .downloadMoyaWebContent:
-            return .download(.request(defaultDownloadDestination))
+            return .downloadDestination(defaultDownloadDestination)
         }
     }
     public var sampleData: Data {

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -6,8 +6,6 @@ following data:
 
 - The url.
 - The HTTP method (`GET`, `POST`, etc).
-- The request parameters.
-- The parameter encoding (`URL`, `JSON`, custom, etc).
 - The HTTP request header fields.
 - The sample response (for unit testing).
 
@@ -24,14 +22,13 @@ The first might resemble the following:
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = URL(target: target).absoluteString
-    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
+    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, task: target.task)
 }
 ```
 
 This is actually the default implementation Moya provides. If you need something
-custom, like if your API requires custom parameter mapping, or if you're
-creating a test provider that returns non-200 HTTP statuses in unit tests, this
-is where you would do it.
+custom, or if you're creating a test provider that returns non-200 HTTP statuses in unit tests,
+this is where you would do it.
 
 Notice the `URL(target:)` initializer, Moya provides a convenient extension to create a `URL` from any `TargetType`.
 
@@ -43,22 +40,6 @@ Let's take a look at an example of the flexibility mapping from a Target to
 an Endpoint can provide.
 
 ## From Target to Endpoint
-
-By default, `Endpoint` instances use the `URLEncoding.default` type parameter
-encoding. You can specify how you'd like to encode parameters on a
-target-by-target basis in the `endpointClosure` using the optional
-`parameterEncoding` parameter of the `Endpoint` initializer in your
-`endpointClosure` when setting up the provider.
-
-There are three parameter encoding types: `URLEncoding`, `JSONEncoding`,
-`PropertyListEncoding`,  which map directly to the corresponding types in
-Alamofire. Each of these types has `.default` property, that gives you a default
-instance of a specific `ParameterEncoding` type. Additionally if you want to
-create your custom type, just implement the `ParameterEncoding` protocol and you
-are good to go. Usually you just want `URLEncoding.default`, but you can use
-whichever you like. These are mapped directly to the [Alamofire parameter encodings](https://github.com/Alamofire/Alamofire/blob/95a0ad51be27d99416401e186dc390063b4a85cf/Source/ParameterEncoding.swift#L48). If you want to get more information about the
-`ParameterEncoding` types and how to create your own,
-[check out this awesome documentation piece on that matter, by Alamofire](https://github.com/Alamofire/Alamofire/blob/95a0ad51be27d99416401e186dc390063b4a85cf/README.md#parameter-encoding).
 
 You can add parameters or HTTP header fields in this closure. For example, we
 may wish to set our application name in the HTTP header fields for server-side
@@ -98,9 +79,8 @@ let provider = MoyaProvider<GitHub>(endpointClosure: endpointClosure)
 Awesome.
 
 Note that we can rely on the existing behavior of Moya and extend – instead
-of replace – it. The `adding(newParameters:)` and `adding(newHttpHeaderFields:)`
-functions allow you to rely on the existing Moya code and add your own custom
-values.
+of replace – it. The `adding(newHttpHeaderFields:)` function allows you to
+rely on the existing Moya code and add your own custom values.
 
 Sample responses are a requirement of the `TargetType` protocol. However, they
 only specify the data returned. The Target-to-Endpoint mapping closure is where

--- a/docs/Examples/OptionalParameters.md
+++ b/docs/Examples/OptionalParameters.md
@@ -9,14 +9,14 @@ public enum MyService {
 
 extension MyService: TargetType {
 //...
-    public var parameters: [String: Any]? {
+    public var task: Task {
         switch self {
         case .users(let limit):
             var params: [String: Any] = [:]
             params["limit"] = limit
-            return params
+            return .requestParameters(params, URLEncoding.default)
         default:
-            return nil
+            return .requestPlain
         }
     }
 //...
@@ -53,9 +53,9 @@ You **have to** add optional parameters like shown above, one per line. Optional
 	    switch self {
 	    case .users(let limit):
 	        let params: [String: Any] = ["limit": limit]
-	        return params
+	        return .requestParameters(params, URLEncoding.default)
         default:
-            return nil
+            return .requestPlain
         }
     }
 //...

--- a/docs/MigrationGuides.md
+++ b/docs/MigrationGuides.md
@@ -1,0 +1,15 @@
+# Migration Guides
+
+This project follows [Semantic Versioning](http://semver.org).
+
+Please follow the appropriate guide below when **upgrading to a new major version** of Moya (e.g. 8.0 -> 9.0).
+
+## Upgrade from 8.x to 9.x
+
+- Move the `parameters` and `parameterEncoding` to the `task` computed property by using the case `.requestParameters(parameters:,encoding:)`
+- Replace the task type `.request` with either `.requestPlain` (if you have no parameters) or `.requestParameters(parameters:,encoding:)`
+- There's no `parameters` and `parameterEncoding` on Endpoints any more (e.g. `addingParameters()`), provide them through the `task` on your target instead
+- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(urlParameters:,bodyParameters:,bodyEncoding:)`
+- Simplify occurences of task type `.download(.request(destination))` to `.downloadDestination(destination)`
+- Simplify occurences of task type `.upload(.file(url))` to `.uploadFile(url)`
+- Simplify occurences of task type `.upload(.multipart(data))` to `.uploadMultipart(data)`

--- a/docs/MigrationGuides.md
+++ b/docs/MigrationGuides.md
@@ -6,10 +6,10 @@ Please follow the appropriate guide below when **upgrading to a new major versio
 
 ## Upgrade from 8.x to 9.x
 
-- Move the `parameters` and `parameterEncoding` to the `task` computed property by using the case `.requestParameters(parameters:,encoding:)`
-- Replace the task type `.request` with either `.requestPlain` (if you have no parameters) or `.requestParameters(parameters:,encoding:)`
+- Move the `parameters` and `parameterEncoding` to the `task` computed property by using the case `.requestParameters(parameters:encoding:)`
+- Replace the task type `.request` with either `.requestPlain` (if you have no parameters) or `.requestParameters(parameters:encoding:)`
 - There's no `parameters` and `parameterEncoding` on Endpoints any more (e.g. `addingParameters()`), use the new `task` property instead
-- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(bodyParameters:,bodyEncoding:,urlParameters:)`
+- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(bodyParameters:bodyEncoding:urlParameters:)`
 - Simplify occurrences of task type `.download(.request(destination))` to `.downloadDestination(destination)`
 - Simplify occurrences of task type `.upload(.file(url))` to `.uploadFile(url)`
 - Simplify occurrences of task type `.upload(.multipart(data))` to `.uploadMultipart(data)`

--- a/docs/MigrationGuides.md
+++ b/docs/MigrationGuides.md
@@ -8,8 +8,8 @@ Please follow the appropriate guide below when **upgrading to a new major versio
 
 - Move the `parameters` and `parameterEncoding` to the `task` computed property by using the case `.requestParameters(parameters:,encoding:)`
 - Replace the task type `.request` with either `.requestPlain` (if you have no parameters) or `.requestParameters(parameters:,encoding:)`
-- There's no `parameters` and `parameterEncoding` on Endpoints any more (e.g. `addingParameters()`), provide them through the `task` on your target instead
-- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(urlParameters:,bodyParameters:,bodyEncoding:)`
-- Simplify occurences of task type `.download(.request(destination))` to `.downloadDestination(destination)`
-- Simplify occurences of task type `.upload(.file(url))` to `.uploadFile(url)`
-- Simplify occurences of task type `.upload(.multipart(data))` to `.uploadMultipart(data)`
+- There's no `parameters` and `parameterEncoding` on Endpoints any more (e.g. `addingParameters()`), use the new `task` property instead
+- To send URL encoded parameters AND body parameters, you can now use the task type `.requestCompositeParameters(bodyParameters:,bodyEncoding:,urlParameters:)`
+- Simplify occurrences of task type `.download(.request(destination))` to `.downloadDestination(destination)`
+- Simplify occurrences of task type `.upload(.file(url))` to `.uploadFile(url)`
+- Simplify occurrences of task type `.upload(.multipart(data))` to `.uploadMultipart(data)`

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -41,7 +41,7 @@ concrete `Endpoint` instance. Let's take a look at what one might look like.
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
     let url = URL(target: target).absoluteString
-    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
+    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, task: target.task)
 }
 let provider = MoyaProvider(endpointClosure: endpointClosure)
 ```


### PR DESCRIPTION
This solution was dicussed starting here:
https://github.com/Moya/Moya/issues/1135#issuecomment-310913115

Specifically this PR does the following:
- [x] Remove `parameters` and `parameterEncoding` from everywhere
- [x] Extend `Task` with different types of request data (e.g. `data` & `compositeEncoded`)
- [x] Flatten the `DownloadType` and `UploadType` enums into the `Task` type
- [x] Use those new task cases to set url params & http body appropriately
- [x] Update Tests
- [x] Update Docs
- [x] Write a migration guide
- [x] Add Changelog entry
- [x] Handle the `TODO:` comments (exception handling) appropriately

This solves the most apparent part of #1135 and it probably also solves #314.