### PR TITLE
[WIP] Support Encodable types natively

### DIFF
--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -21,29 +21,18 @@ open class Endpoint<Target> {
     open let url: String
     open let method: Moya.Method
     open let sampleResponseClosure: SampleResponseClosure
-    open let parameters: [String: Any]?
-    open let parameterEncoding: Moya.ParameterEncoding
     open let httpHeaderFields: [String: String]?
 
     /// Main initializer for `Endpoint`.
     public init(url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method = Moya.Method.get,
-                parameters: [String: Any]? = nil,
-                parameterEncoding: Moya.ParameterEncoding = URLEncoding.default,
                 httpHeaderFields: [String: String]? = nil) {
 
         self.url = url
         self.sampleResponseClosure = sampleResponseClosure
         self.method = method
-        self.parameters = parameters
-        self.parameterEncoding = parameterEncoding
         self.httpHeaderFields = httpHeaderFields
-    }
-
-    /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added parameters.
-    open func adding(newParameters: [String: Any]) -> Endpoint<Target> {
-        return adding(parameters: newParameters)
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added HTTP header fields.
@@ -51,29 +40,10 @@ open class Endpoint<Target> {
         return adding(httpHeaderFields: newHTTPHeaderFields)
     }
 
-    /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with another parameter encoding.
-    open func adding(newParameterEncoding: Moya.ParameterEncoding) -> Endpoint<Target> {
-        return adding(parameterEncoding: newParameterEncoding)
-    }
-
     /// Convenience method for creating a new `Endpoint`, with changes only to the properties we specify as parameters
-    open func adding(parameters: [String: Any]? = nil, httpHeaderFields: [String: String]? = nil, parameterEncoding: Moya.ParameterEncoding? = nil)  -> Endpoint<Target> {
-        let newParameters = add(parameters: parameters)
+    open func adding(httpHeaderFields: [String: String]? = nil)  -> Endpoint<Target> {
         let newHTTPHeaderFields = add(httpHeaderFields: httpHeaderFields)
-        let newParameterEncoding = parameterEncoding ?? self.parameterEncoding
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, parameters: newParameters, parameterEncoding: newParameterEncoding, httpHeaderFields: newHTTPHeaderFields)
-    }
-
-    fileprivate func add(parameters: [String: Any]?) -> [String: Any]? {
-        guard let unwrappedParameters = parameters, unwrappedParameters.isEmpty == false else {
-            return self.parameters
-        }
-
-        var newParameters = self.parameters ?? [:]
-        unwrappedParameters.forEach { key, value in
-            newParameters[key] = value
-        }
-        return newParameters
+        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, httpHeaderFields: newHTTPHeaderFields)
     }
 
     fileprivate func add(httpHeaderFields headers: [String: String]?) -> [String: String]? {
@@ -99,7 +69,7 @@ extension Endpoint {
         request.httpMethod = method.rawValue
         request.allHTTPHeaderFields = httpHeaderFields
 
-        return try? parameterEncoding.encode(request, with: parameters)
+        return request
     }
 }
 

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -7,9 +7,7 @@ public extension MoyaProvider {
         return Endpoint(
             url: url(for: target).absoluteString,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
-            method: target.method,
-            parameters: target.parameters,
-            parameterEncoding: target.parameterEncoding
+            method: target.method
         )
     }
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -88,7 +88,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
 
-                case let .request(RequestDataType.encoded(parameters: parameters, encoding: parameterEncoding)):
+                case let .request(.encoded(parameters: parameters, encoding: parameterEncoding)):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
                     } catch {
@@ -96,7 +96,7 @@ public extension MoyaProvider {
                     }
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
 
-                case let .request(RequestDataType.compositeData(urlParameters: urlParameters, bodyData: bodyData)):
+                case let .request(.compositeData(urlParameters: urlParameters, bodyData: bodyData)):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                     } catch {
@@ -105,7 +105,7 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = bodyData
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
 
-                case let .request(RequestDataType.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):
+                case let .request(.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):
                     do {
                         preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
                         preparedRequest = try bodyParameterEncoding.encode(preparedRequest, with: bodyParameters)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -88,6 +88,14 @@ public extension MoyaProvider {
                     preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
 
+                case let .request(.jsonEncodable(encodable, encoder)):
+                    preparedRequest.httpBody = encoder.encode(encodable)
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
+                case let .request(.propertyListEncodable(encodable, encoder)):
+                    preparedRequest.httpBody = encoder.encode(encodable)
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
                 case let .request(.encoded(parameters: parameters, encoding: parameterEncoding)):
                     do {
                         preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
@@ -103,6 +111,24 @@ public extension MoyaProvider {
                         // TODO: Add exception handling here
                     }
                     preparedRequest.httpBody = bodyData
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
+                case let .request(.compositeJsonEncodable(urlParameters: urlParameters, encodable: encodable, encoder: encoder)):
+                    do {
+                        preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
+                    } catch {
+                        // TODO: Add exception handling here
+                    }
+                    preparedRequest.httpBody = encoder.encode(encodable)
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
+                case let .request(.compositePropertyListEncodable(urlParameters: urlParameters, encodable: encodable, encoder: encoder)):
+                    do {
+                        preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
+                    } catch {
+                        // TODO: Add exception handling here
+                    }
+                    preparedRequest.httpBody = encoder.encode(encodable)
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
 
                 case let .request(.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -60,13 +60,14 @@ public extension MoyaProvider {
             switch requestResult {
             case .success(let urlRequest):
                 request = urlRequest
+
             case .failure(let error):
                 pluginsWithCompletion(.failure(error))
                 return
             }
 
             // Allow plugins to modify request
-            let preparedRequest = self.plugins.reduce(request) { $1.prepare($0, target: target) }
+            var preparedRequest = self.plugins.reduce(request) { $1.prepare($0, target: target) }
 
             switch stubBehavior {
             case .never:
@@ -81,19 +82,59 @@ public extension MoyaProvider {
                         pluginsWithCompletion(result)
                     }
                 }
+
                 switch target.task {
-                case .request:
+                case .request(.data(let data)):
+                    preparedRequest.httpBody = data
                     cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
+                case let .request(RequestDataType.encoded(parameters: parameters, encoding: parameterEncoding)):
+                    do {
+                        preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
+                    } catch {
+                        // TODO: Add exception handling here
+                    }
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
+                case let .request(RequestDataType.compositeData(urlParameters: urlParameters, bodyData: bodyData)):
+                    do {
+                        preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
+                    } catch {
+                        // TODO: Add exception handling here
+                    }
+                    preparedRequest.httpBody = bodyData
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
+                case let .request(RequestDataType.compositeEncoded(urlParameters: urlParameters, bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding)):
+                    do {
+                        preparedRequest = try URLEncoding.default.encode(preparedRequest, with: urlParameters)
+                        preparedRequest = try bodyParameterEncoding.encode(preparedRequest, with: bodyParameters)
+                    } catch {
+                        // TODO: Add exception handling here
+                    }
+                    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
+
                 case .upload(.file(let file)):
                     cancellableToken.innerCancellable = self.sendUploadFile(target, request: preparedRequest, queue: queue, file: file, progress: progress, completion: networkCompletion)
+
                 case .upload(.multipart(let multipartBody)):
                     guard !multipartBody.isEmpty && target.method.supportsMultipart else {
                         fatalError("\(target) is not a multipart upload target.")
                     }
                     cancellableToken.innerCancellable = self.sendUploadMultipart(target, request: preparedRequest, queue: queue, multipartBody: multipartBody, progress: progress, completion: networkCompletion)
-                case .download(.request(let destination)):
+
+                case .download(.destination(let destination)):
+                    cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, queue: queue, destination: destination, progress: progress, completion: networkCompletion)
+
+                case let .download(.encoded(destination, parameters: parameters, encoding: parameterEncoding)):
+                    do {
+                        preparedRequest = try parameterEncoding.encode(preparedRequest, with: parameters)
+                    } catch {
+                        // TODO: Add exception handling here
+                    }
                     cancellableToken.innerCancellable = self.sendDownloadRequest(target, request: preparedRequest, queue: queue, destination: destination, progress: progress, completion: networkCompletion)
                 }
+
             default:
                 cancellableToken.innerCancellable = self.stubRequest(target, request: preparedRequest, completion: { result in
                     if self.trackInflights {
@@ -135,10 +176,12 @@ public extension MoyaProvider {
                 let response = Moya.Response(statusCode: statusCode, data: data, request: request, response: nil)
                 plugins.forEach { $0.didReceive(.success(response), target: target) }
                 completion(.success(response))
+
             case .response(let customResponse, let data):
                 let response = Moya.Response(statusCode: customResponse.statusCode, data: data, request: request, response: customResponse)
                 plugins.forEach { $0.didReceive(.success(response), target: target) }
                 completion(.success(response))
+
             case .networkError(let error):
                 let error = MoyaError.underlying(error)
                 plugins.forEach { $0.didReceive(.failure(error), target: target) }
@@ -168,16 +211,6 @@ private extension MoyaProvider {
                     self.append(fileURL: url, bodyPart: bodyPart, to: form)
                 case .stream(let stream, let length):
                     self.append(stream: stream, length: length, bodyPart: bodyPart, to: form)
-                }
-            }
-
-            if let parameters = target.parameters {
-                parameters
-                    .flatMap { key, value in multipartQueryComponents(key, value) }
-                    .forEach { key, value in
-                        if let data = value.data(using: .utf8, allowLossyConversion: false) {
-                            form.append(data, withName: key)
-                        }
                 }
             }
         }

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -21,14 +21,6 @@ public enum MultiTarget: TargetType {
         return target.method
     }
 
-    public var parameters: [String: Any]? {
-        return target.parameters
-    }
-
-    public var parameterEncoding: ParameterEncoding {
-        return target.parameterEncoding
-    }
-
     public var sampleData: Data {
         return target.sampleData
     }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -13,6 +13,9 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
+    /// The default parameterEncoding for the `.encoded` RequestDataType case.
+    var defaultParameterEncoding: ParameterEncoding { get }
+
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
 
@@ -24,6 +27,10 @@ public protocol TargetType {
 }
 
 public extension TargetType {
+    var defaultParameterEncoding: ParameterEncoding {
+        return URLEncoding.default
+    }
+
     var validate: Bool {
         return false
     }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -31,6 +31,14 @@ public extension TargetType {
         return URLEncoding.default
     }
 
+    var defaultJsonEncoder: JSONEncoder {
+        return JSONEncoder()
+    }
+
+    var defaultPropertyListEncoder: PropertyListEncoder {
+        return PropertyListEncoder()
+    }
+
     var validate: Bool {
         return false
     }
@@ -71,15 +79,26 @@ public enum Task {
 
 /// Represents a type of request.
 public enum RequestDataType {
-
     /// A requests body set with data.
     case data(Data)
+
+    /// A request body set as JSON from an encodable type with a JSONEncoder.
+    case jsonEncodable(encodable: Encodable, encoder: JSONEncoder)
+
+    /// A request body set as Property List from an encodable type with a PropertyListEncoder.
+    case propertyListEncodable(encodable: Encodable, encoder: PropertyListEncoder)
 
     /// A requests body set with parameters and encoding.
     case encoded(parameters: [String: Any], encoding: ParameterEncoding)
 
     /// A requests body set with data, combined with url parameters.
     case compositeData(urlParameters: [String: Any], bodyData: Data)
+
+    /// A request body set as JSON from an encodable type with a JSONEncoder, combined with url parameters
+    case compositeJsonEncodable(urlParameters: [String: Any], encodable: Encodable, encoder: JSONEncoder)
+
+    /// A request body set as Property List from an encodable type with a PropertyListEncoder, combined with url parameters
+    case compositePropertyListEncodable(urlParameters: [String: Any], encodable: Encodable, encoder: PropertyListEncoder)
 
     /// A requests body set with parameters and encoding, combined with url parameters.
     case compositeEncoded(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -13,12 +13,6 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
-    /// The parameters to be encoded in the request.
-    var parameters: [String: Any]? { get }
-
-    /// The method used for parameter encoding.
-    var parameterEncoding: ParameterEncoding { get }
-
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
 
@@ -49,18 +43,38 @@ public enum UploadType {
 public enum DownloadType {
 
     /// Download a file to a destination.
-    case request(DownloadDestination)
+    case destination(DownloadDestination)
+
+    /// Download a file to a destination with extra parameters using the given encoding.
+    case encoded(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
 }
+
 
 /// Represents an HTTP task.
 public enum Task {
 
     /// A basic request task.
-    case request
+    case request(RequestDataType)
 
     /// An upload task.
     case upload(UploadType)
 
     /// A download task.
     case download(DownloadType)
+}
+
+/// Represents a type of request.
+public enum RequestDataType {
+
+    /// A requests body set with data.
+    case data(Data)
+
+    /// A requests body set with parameters and encoding.
+    case encoded(parameters: [String: Any], encoding: ParameterEncoding)
+
+    /// A requests body set with data, combined with url parameters.
+    case compositeData(urlParameters: [String: Any], bodyData: Data)
+
+    /// A requests body set with parameters and encoding, combined with url parameters.
+    case compositeEncoded(urlParameters: [String: Any], bodyParameters: [String: Any], bodyEncoding: ParameterEncoding)
 }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -56,7 +56,6 @@ public enum DownloadType {
     case encoded(DownloadDestination, parameters: [String: Any], encoding: ParameterEncoding)
 }
 
-
 /// Represents an HTTP task.
 public enum Task {
 


### PR DESCRIPTION
This is a follow-up on #1136 and is based on the current state of #1147. We should not merge this until #1147 was merged and Swift 4 nears completion.

What I have done here is to implement the intention behind #1136 with the new approach we have taken in #1147. Although the code is like I would expect it to work, the Swift compiler (currently) seems not to be able to work with this code. I'm still getting the same error as in #1136, for example:

```swift
case let .request(.jsonEncodable(encodable, encoder)):
    preparedRequest.httpBody = encoder.encode(encodable) // ERROR: Cannot invoke 'encode' with an argument list of type '(Encodable)'
    cancellableToken.innerCancellable = self.sendRequest(target, request: preparedRequest, queue: queue, progress: progress, completion: networkCompletion)
```

If you know how we can work around this issue, then please let me know. I couldn't find a good alternative solution or quick fix for this.

Here's what is done in this PR:

- [x] Add `jsonEncodable` and `propertyListEncodable` cases to `RequestDataType`
- [x] Add `compositeJsonEncodable` and `compositePropertyListEncodable`, too
- [x] Integrate the new cases into the request creation logic

The following are TODOs:

- [ ] Fix the above mentioned compiler error (find alternative)
- [ ] Update Changelog
- [ ] Update Tests
- [ ] Update Documentation