### PR TITLE
Update stale.yml configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -27,7 +27,7 @@ unmarkComment: false
 closeComment: >
   This issue has been auto-closed because there hasn't been any activity for 59 days.
   However, we really appreciate your contribution, so thank you for that! 🙏
-  Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem :+1:
+  Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem :+1:.
 
 # Limit to only `issues`
 only: issues


### PR DESCRIPTION
![screen shot 2017-07-03 at 2 14 49 pm](https://user-images.githubusercontent.com/7445580/27805395-02a22a70-5ffa-11e7-93b2-6e9dcde1ae5b.png)

I'm not sure if the discoloration in the syntax highlighting is what is causing `stale` to not close issues. I've compared our `stale.yml` to other projects and this is the only difference.