### PR TITLE
Remove emojis from stale.yml configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -26,8 +26,8 @@ unmarkComment: false
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
 closeComment: >
   This issue has been auto-closed because there hasn't been any activity for 59 days.
-  However, we really appreciate your contribution, so thank you for that! 🙏
-  Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem :+1:.
+  However, we really appreciate your contribution, so thank you for that!
+  Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem.
 
 # Limit to only `issues`
 only: issues


### PR DESCRIPTION
@pedrovereza per your recommendation I've removed the emojis from the `stale.yml` configuration. I've been able to find other GitHub repos with the close comment feature working as of 3 days ago, but none containing emojis. 