### PR TITLE
Removes markdown from stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -27,7 +27,7 @@ unmarkComment: false
 closeComment: >
   This issue has been auto-closed because there hasn't been any activity for 59 days.
   However, we really appreciate your contribution, so thank you for that!
-  Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem.
+  Also, feel free to open a new issue if you still experience this problem.
 
 # Limit to only `issues`
 only: issues


### PR DESCRIPTION
Related to #1071, #1157 and #1158.

Stale-bot is still not closing stale issues. I'm guessing this could be related to having markdown in the close comment 🤔.

Also confirmed that having `closingComment: false` worked on a test repo (https://github.com/pedrovereza/stale-bot-test/issues/1) 