### PR TITLE
Set probot closeComment to false in stale.yml configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -24,10 +24,7 @@ markComment: >
 unmarkComment: false
 
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
-closeComment: >
-  This issue has been auto-closed because there hasn't been any activity for 59 days.
-  However, we really appreciate your contribution, so thank you for that!
-  Also, feel free to open a new issue if you still experience this problem.
+closeComment: false
 
 # Limit to only `issues`
 only: issues


### PR DESCRIPTION
@pedrovereza What about setting `closeComment` to false to test if this problem is comment related or if we have another problem? I think the effects should be applied immediately if the PR is a success.