### PR TITLE
Remove quotes around 'no recent activity' label in stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,7 +13,7 @@ exemptLabels:
   - "chore"
 
 # Label to use when marking as stale
-staleLabel: "no recent activity"
+staleLabel: no recent activity
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -24,7 +24,10 @@ markComment: >
 unmarkComment: false
 
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
-closeComment: false
+closeComment: >
+  This issue has been auto-closed because there hasn't been any activity for 59 days.
+  However, we really appreciate your contribution, so thank you for that! 🙏
+  Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem 👍.
 
 # Limit to only `issues`
 only: issues


### PR DESCRIPTION
So setting the `closeComment` variable to false had no effect. This leads me to believe we have a different problem. I took a look at the source and this is the method that gets the stale issues:

```javascript
  getStaleIssues() {
    const labels = [this.config.staleLabel].concat(this.config.exemptLabels);
    const query = labels.map(label => `-label:"${label}"`).join(' ');
    const days = this.config.days || this.config.daysUntilStale;
    return this.search(days, query);
  }
```

It looks like when it creates the `query` it wraps the label in quotes. Since the current `stale.yml` already provides these quotes I think it results in an invalid query. I suggest we remove them with this PR and see if it has any effect. Sorry for the PR spam 😓 