### PR TITLE
Update stale.yml label to "stale"

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,7 +13,7 @@ exemptLabels:
   - "chore"
 
 # Label to use when marking as stale
-staleLabel: no recent activity
+staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >


### PR DESCRIPTION
### Please don't merge until we create the backing label for this.

This fixes the problem where issues aren't being closed due to our previous label 'no recent activity' containing spaces. 

I literally set the label to `stale` but if someone would prefer another name discuss it here.

i.e) `no_recent_activity` or `no-recent-activity`