### PR TITLE
Fix: Xcode 9 Beta submission bug

### DIFF
--- a/Moya.xcodeproj/xcshareddata/xcschemes/Moya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/Moya.xcscheme
@@ -7,61 +7,71 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'ED6C081A4AC105D3F62F3C49'
-               BlueprintName = 'Moya'
-               ReferencedContainer = 'container:Moya.xcodeproj'
-               BuildableName = 'Moya.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ED6C081A4AC105D3F62F3C49"
+               BuildableName = "Moya.framework"
+               BlueprintName = "Moya"
+               ReferencedContainer = "container:Moya.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug"
-      codeCoverageEnabled = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'B4751E2EBB5E193D628CF4D8'
-               BlueprintName = 'MoyaTests'
-               ReferencedContainer = 'container:Moya.xcodeproj'
-               BuildableName = 'MoyaTests.xctest'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B4751E2EBB5E193D628CF4D8"
+               BuildableName = "MoyaTests.xctest"
+               BlueprintName = "MoyaTests"
+               ReferencedContainer = "container:Moya.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ED6C081A4AC105D3F62F3C49"
+            BuildableName = "Moya.framework"
+            BlueprintName = "Moya"
+            ReferencedContainer = "container:Moya.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Moya.xcodeproj/xcshareddata/xcschemes/ReactiveMoya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/ReactiveMoya.xcscheme
@@ -7,61 +7,71 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '958A3EDB11249C16A9186F42'
-               BlueprintName = 'ReactiveMoya'
-               ReferencedContainer = 'container:Moya.xcodeproj'
-               BuildableName = 'ReactiveMoya.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "958A3EDB11249C16A9186F42"
+               BuildableName = "ReactiveMoya.framework"
+               BlueprintName = "ReactiveMoya"
+               ReferencedContainer = "container:Moya.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug"
-      codeCoverageEnabled = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'B4751E2EBB5E193D628CF4D8'
-               BlueprintName = 'MoyaTests'
-               ReferencedContainer = 'container:Moya.xcodeproj'
-               BuildableName = 'MoyaTests.xctest'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B4751E2EBB5E193D628CF4D8"
+               BuildableName = "MoyaTests.xctest"
+               BlueprintName = "MoyaTests"
+               ReferencedContainer = "container:Moya.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "958A3EDB11249C16A9186F42"
+            BuildableName = "ReactiveMoya.framework"
+            BlueprintName = "ReactiveMoya"
+            ReferencedContainer = "container:Moya.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Moya.xcodeproj/xcshareddata/xcschemes/RxMoya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/RxMoya.xcscheme
@@ -7,61 +7,71 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
-            buildForArchiving = "YES">
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = '528FF71D5A26E74522C484AD'
-               BlueprintName = 'RxMoya'
-               ReferencedContainer = 'container:Moya.xcodeproj'
-               BuildableName = 'RxMoya.framework'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "528FF71D5A26E74522C484AD"
+               BuildableName = "RxMoya.framework"
+               BlueprintName = "RxMoya"
+               ReferencedContainer = "container:Moya.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug"
-      codeCoverageEnabled = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
-               BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'B4751E2EBB5E193D628CF4D8'
-               BlueprintName = 'MoyaTests'
-               ReferencedContainer = 'container:Moya.xcodeproj'
-               BuildableName = 'MoyaTests.xctest'>
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B4751E2EBB5E193D628CF4D8"
+               BuildableName = "MoyaTests.xctest"
+               BlueprintName = "MoyaTests"
+               ReferencedContainer = "container:Moya.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "528FF71D5A26E74522C484AD"
+            BuildableName = "RxMoya.framework"
+            BlueprintName = "RxMoya"
+            ReferencedContainer = "container:Moya.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
In Xcode 9 (Beta 2) the binaries are instrumented to gather coverage data if a build scheme has "Gather coverage data" option enabled in Test action.
See discussion here for more details: https://forums.developer.apple.com/message/243580

The simplest solution to remedy the issue is to disable "Gather coverage data" option in build schemes, which this commit does.