### PR TITLE
[Documentation] Move threading docs to Threading.md & expand it a bit.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,24 +242,6 @@ for filtering out certain status codes. This means that you can place your code 
 handling API errors like 400's in the same places as code for handling invalid
 responses.
 
-By default, all of your requests will be put onto a background thread by `Alamofire`, and the 
-response will be called on the main scheduler.
-If you want your response called on a different thread, you can either initialize your `Provider` with a thread
-```swift
-provider = RxMoyaProvider<GitHub>(queue: DispatchQueue.global(.utility))
-provider.request(.userProfile("ashfurrow"))
-  .map { /* this is called on a utility thread */ }
-```
-
-or, you can choose to `.observeOn` the response on a specific scheduler:
-```swift
-provider = RxMoyaProvider<GitHub>()
-provider.request(.userProfile("ashfurrow"))
-  .map { /* this is called on the current thread */ }
-  .observeOn(ConcurrentDispatchQueueScheduler(qos: .utility))
-  .map { /* this is called on a utility thread */ }
-```
-
 ## Community Projects
 
 [Moya has a great community around it and some people have created some very helpful extensions.](https://github.com/Moya/Moya/blob/master/docs/CommunityProjects.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ It accomplishes this with the following pipeline.
 ----------------
 
 <p align="center">
-    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveSwift.md">ReactiveSwift</a> &bull; <a href="RxSwift.md">RxSwift</a> &bull; <a href="Plugins.md">Plugins</a>
+    <a href="Targets.md">Targets</a> &bull; <a href="Endpoints.md">Endpoints</a> &bull; <a href="Providers.md">Providers</a> &bull; <a href="Authentication.md">Authentication</a> &bull; <a href="ReactiveSwift.md">ReactiveSwift</a> &bull; <a href="RxSwift.md">RxSwift</a> &bull; <a href="Threading.md">Threading</a> &bull; <a href="Plugins.md">Plugins</a>
 </p>
 
 ----------------

--- a/docs/Threading.md
+++ b/docs/Threading.md
@@ -1,0 +1,30 @@
+# Threading
+
+By default, all of your requests will be put onto a background thread by `Alamofire`, and the 
+response will be called on the main thread. If you want your response called on a different thread, you can initialize your `Provider` with a specified `callbackQueue`:
+```swift
+provider = MoyaProvider<GitHub>(callbackQueue: DispatchQueue.global(.utility))
+provider.request(.userProfile("ashfurrow")) {
+    /* this is called on a utility thread */
+}
+```
+
+Using `RxSwift` & `ReactiveSwift` you can achieve similar behavior using `observeOn(_:)` & `observe(on:)` operators:
+
+## RxSwift
+```swift
+provider = MoyaProvider<GitHub>()
+provider.rx.request(.userProfile("ashfurrow"))
+  .map { /* this is called on the current thread */ }
+  .observeOn(ConcurrentDispatchQueueScheduler(qos: .utility))
+  .map { /* this is called on a utility thread */ }
+```
+
+## ReactiveSwift
+```swift
+provider = MoyaProvider<GitHub>()
+provider.reactive.request(.userProfile("ashfurrow"))
+  .map { /* this is called on the current thread */ }
+  .observe(on: QueueScheduler(qos: .utility))
+  .map { /* this is called on a utility thread */ }
+```


### PR DESCRIPTION
So this should be a final step to merge queues (#762). I've moved the docs from `Readme.md` to its own `Threading.md` + added examples for both normal usage and `ReactiveSwift`. 

Also, I've checked the docs but didn't found anything on `queues` I needed to change, so it should be all set 👍 