### PR TITLE
Updates documentation for URL(target:) init

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -23,7 +23,7 @@ The first might resemble the following:
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let url = target.baseURL.appendingPathComponent(target.path).absoluteString
+    let url = URL(target: target).absoluteString
     return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 }
 ```
@@ -32,6 +32,8 @@ This is actually the default implementation Moya provides. If you need something
 custom, like if your API requires custom parameter mapping, or if you're
 creating a test provider that returns non-200 HTTP statuses in unit tests, this
 is where you would do it.
+
+Notice the `URL(target:)` initializer, Moya provides a convenient extension to create a `URL` from any `TargetType`.
 
 The second use is very uncommon. Moya tries to prevent you from having to worry
 about low-level details. But it's there if you need it. Its use is covered

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -40,7 +40,7 @@ concrete `Endpoint` instance. Let's take a look at what one might look like.
 
 ```swift
 let endpointClosure = { (target: MyTarget) -> Endpoint<MyTarget> in
-    let url = target.baseURL.appendingPathComponent(target.path).absoluteString
+    let url = URL(target: target).absoluteString
     return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, parameters: target.parameters)
 }
 let provider = MoyaProvider(endpointClosure: endpointClosure)
@@ -49,6 +49,8 @@ let provider = MoyaProvider(endpointClosure: endpointClosure)
 Notice that we don't have to specify the generic type in the `MoyaProvider`
 initializer anymore, since Swift will infer it from the type of our
 `endpointClosure`. Neat!
+
+You may also notice the `URL(target:)` initializer, Moya provides a convenient extension to create a `URL` from any `TargetType`.
 
 This `endpointClosure` is about as simple as you can get. It's actually the
 default implementation, too, stored in `MoyaProvider.defaultEndpointMapping`.


### PR DESCRIPTION
This updates the docs for the `URL(target:)` initializer added by #1178. I've updated all code snippets where we can use this extension and made notice of its use.