### PR TITLE
Update core to support Swift 4.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Next
+- Added Swift 4.0 support.
 
 # 9.0.0-alpha.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -63,8 +63,8 @@ end
 
 def device_os
   return {
-    ios: "10.2",
-    tvos: "10.0"
+    ios: "11.0",
+    tvos: "11.0"
   }
 end
 

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -17,10 +17,10 @@ public final class NetworkLoggerPlugin: PluginType {
     public let isVerbose: Bool
     public let cURL: Bool
 
-    public init(verbose: Bool = false, cURL: Bool = false, output: @escaping (_ separator: String, _ terminator: String, _ items: Any...) -> Void = NetworkLoggerPlugin.reversedPrint, requestDataFormatter: ((Data) -> (String))? = nil, responseDataFormatter: ((Data) -> (Data))? = nil) {
+    public init(verbose: Bool = false, cURL: Bool = false, output: ((_ separator: String, _ terminator: String, _ items: Any...) -> Void)? = nil, requestDataFormatter: ((Data) -> (String))? = nil, responseDataFormatter: ((Data) -> (Data))? = nil) {
         self.cURL = cURL
         self.isVerbose = verbose
-        self.output = output
+        self.output = output ?? NetworkLoggerPlugin.reversedPrint
         self.requestDataFormatter = requestDataFormatter
         self.responseDataFormatter = responseDataFormatter
     }

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "8.3"
+    version: 9.0
   environment:
     LANG: en_US.UTF-8
 


### PR DESCRIPTION
In this PR I've updated `NetworkLoggerPlugin` as it was the only reason Swift 4 compiler was having troubles with moya. I've also updated our CI to use Xcode 9. In the future we should look to support 2 builds - with Swift 3.2 & 4.0. 

Right now, with this changes, 9.0.0 release should support:
- Swift 3.1
- Swift 3.2
- Swift 4.0

I've tested it locally and it seems to be working correctly.

**Edit:** Oh, and also I've created a new **9.0.0-dev** branch. 