### PR TITLE
Delete the redundant import statement.

### DIFF
--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// Used for stubbing responses.
 public enum EndpointSampleResponse {

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// These functions are default mappings to `MoyaProvider`'s properties: endpoints, requests, manager, etc.
 public extension MoyaProvider {

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Alamofire
 
 /// The protocol used to define the specifications necessary for a `MoyaProvider`.
 public protocol TargetType {

--- a/Tests/MoyaProvider+ReactiveSpec.swift
+++ b/Tests/MoyaProvider+ReactiveSpec.swift
@@ -2,7 +2,6 @@ import Quick
 import Nimble
 import ReactiveSwift
 import OHHTTPStubs
-import Alamofire
 
 @testable import Moya
 @testable import ReactiveMoya

--- a/Tests/MoyaProvider+RxSpec.swift
+++ b/Tests/MoyaProvider+RxSpec.swift
@@ -1,7 +1,6 @@
 import Quick
 import Nimble
 import RxSwift
-import Alamofire
 import OHHTTPStubs
 
 @testable import Moya

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -1,7 +1,6 @@
 import Quick
 import Nimble
 import OHHTTPStubs
-import Alamofire
 
 @testable import Moya
 @testable import ReactiveMoya

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -1,6 +1,5 @@
 import Quick
 import Nimble
-import Alamofire
 import Foundation
 import OHHTTPStubs
 @testable import Moya

--- a/Tests/TestPlugin.swift
+++ b/Tests/TestPlugin.swift
@@ -1,5 +1,4 @@
 import enum Result.Result
-import Alamofire
 @testable import Moya
 
 final class TestingPlugin: PluginType {


### PR DESCRIPTION
Only `Moya+Alamofire.swift` need to import Alamofire to avoid leaking abstractions.