### PR TITLE
[SPM] Fix warnings when building Moya module.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .Package(url: "https://github.com/antitypical/Result.git", majorVersion: 3)
     ],
     exclude: [
-        "Tests"
+        "Tests",
+        "Sources/Supporting Files"
     ]
 )

--- a/Sources/ReactiveMoya/ReactiveMoyaAvailability.swift
+++ b/Sources/ReactiveMoya/ReactiveMoyaAvailability.swift
@@ -1,6 +1,7 @@
 #if !COCOAPODS
     import Moya
 #endif
+import Foundation
 import ReactiveSwift
 
 /// Subclass of MoyaProvider that returns SignalProducer instances when requests are made. Much better than using completion closures.

--- a/Sources/RxMoya/RxMoyaAvailability.swift
+++ b/Sources/RxMoya/RxMoyaAvailability.swift
@@ -1,6 +1,7 @@
 #if !COCOAPODS
     import Moya
 #endif
+import Foundation
 import RxSwift
 
 /// Subclass of MoyaProvider that returns Observable instances when requests are made. Much better than using completion closures.


### PR DESCRIPTION
`Supporting files` directory included prints a warning and I get an error from not including `Foundation` in these two files, so this should fix it 🤞 

Also, we might need to add compatibility checks on our CI soon.