### PR TITLE
Be notified of progress using the callback closure also for data request

### DIFF
--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -228,6 +228,10 @@ private extension MoyaProvider {
         // Perform the actual request
         if progressCompletion != nil {
             switch progressAlamoRequest {
+            case let dataRequest as DataRequest:
+                if let dataRequest = dataRequest.downloadProgress(closure: progressClosure) as? T {
+                    progressAlamoRequest = dataRequest
+                }
             case let downloadRequest as DownloadRequest:
                 if let downloadRequest = downloadRequest.downloadProgress(closure: progressClosure) as? T {
                     progressAlamoRequest = downloadRequest

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -735,7 +735,7 @@ class MoyaProviderSpec: QuickSpec {
                 provider = MoyaProvider<GitHubUserContent>()
             }
 
-            it("tracks progress of request") {
+            it("tracks progress of download request") {
 
                 let target: GitHubUserContent = .downloadMoyaWebContent("logo_github.png")
 
@@ -763,6 +763,36 @@ class MoyaProviderSpec: QuickSpec {
                 expect(progressValues) == [0.25, 0.5, 0.75, 1.0, 1.0]
                 expect(completedValues) == [false, false, false, false, true]
             }
+
+            it("tracks progress of request") {
+                
+                let target: GitHubUserContent = .requestMoyaWebContent("logo_github.png")
+                
+                var progressValues: [Double] = []
+                var completedValues: [Bool] = []
+                var error: MoyaError?
+                
+                waitUntil(timeout: 5.0) { done in
+                    let progressClosure: ProgressBlock = { progress in
+                        progressValues.append(progress.progress)
+                        completedValues.append(progress.completed)
+                    }
+                    
+                    let progressCompletionClosure: Completion = { (result) in
+                        if case .failure(let err) = result {
+                            error = err
+                        }
+                        done()
+                    }
+                    
+                    provider.request(target, callbackQueue: nil, progress: progressClosure, completion: progressCompletionClosure)
+                }
+                
+                expect(error).to(beNil())
+                expect(progressValues) == [0.25, 0.5, 0.75, 1.0, 1.0]
+                expect(completedValues) == [false, false, false, false, true]
+            }
+
         }
 
         describe("using a custom callback queue") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -110,6 +110,7 @@ enum HTTPBin: TargetType {
 
 public enum GitHubUserContent {
     case downloadMoyaWebContent(String)
+    case requestMoyaWebContent(String)
 }
 
 extension GitHubUserContent: TargetType {
@@ -118,17 +119,19 @@ extension GitHubUserContent: TargetType {
         switch self {
         case .downloadMoyaWebContent(let contentPath):
             return "/Moya/Moya/master/web/\(contentPath)"
+        case .requestMoyaWebContent(let contentPath):
+            return "/Moya/Moya/master/web/\(contentPath)"
         }
     }
     public var method: Moya.Method {
         switch self {
-        case .downloadMoyaWebContent:
+        case .downloadMoyaWebContent, .requestMoyaWebContent:
             return .get
         }
     }
     public var parameters: [String: Any]? {
         switch self {
-        case .downloadMoyaWebContent:
+        case .downloadMoyaWebContent, .requestMoyaWebContent:
             return nil
         }
     }
@@ -139,11 +142,13 @@ extension GitHubUserContent: TargetType {
         switch self {
         case .downloadMoyaWebContent:
             return .download(.request(defaultDownloadDestination))
+        case .requestMoyaWebContent:
+            return .request
         }
     }
     public var sampleData: Data {
         switch self {
-        case .downloadMoyaWebContent:
+        case .downloadMoyaWebContent, .requestMoyaWebContent:
             return Data(count: 4000)
         }
     }


### PR DESCRIPTION
Alamofire provide also `Progress`for `DataRequest`.
Any reason to not use it? Maybe not available when implementing the new progress callback in Moya

Following that `Progress` could be also provided at the end with response
https://github.com/phimage/Moya/commit/c13fcd6ded55309cd6cf5e6d789f50420fedd04d