### PR TITLE
Be notified of progress using the callback closure also for data request

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 - Added all the `filter`/`map` operators that were available for `Observable<Response>` to `Single<Response>` as well.
 - Added `AuthorizationType` to `AccessTokenAuthorizable` representing request headers of `.none`, `.basic`, and `.bearer`. 
 - Added tests for `Single<Response>` operators.
-- Be notified on progress callback also for data request.
+- Fixed a bug where you are not notified on progress callback for data request.
 
 # 9.0.0-alpha.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
 - Added all the `filter`/`map` operators that were available for `Observable<Response>` to `Single<Response>` as well.
 - Added `AuthorizationType` to `AccessTokenAuthorizable` representing request headers of `.none`, `.basic`, and `.bearer`. 
 - Added tests for `Single<Response>` operators.
-- Fixed a bug where you are not notified on progress callback for data request.
+- Fixed a bug where you weren't notified on progress callback for data request.
 
 # 9.0.0-alpha.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 - Added all the `filter`/`map` operators that were available for `Observable<Response>` to `Single<Response>` as well.
 - Added `AuthorizationType` to `AccessTokenAuthorizable` representing request headers of `.none`, `.basic`, and `.bearer`. 
 - Added tests for `Single<Response>` operators.
+- Be notified on progress callback also for data request.
 
 # 9.0.0-alpha.1
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -238,6 +238,10 @@ private extension MoyaProvider {
                 if let uploadRequest = uploadRequest.uploadProgress(closure: progressClosure) as? T {
                     progressAlamoRequest = uploadRequest
                 }
+            case let dataRequest as DataRequest:
+                if let dataRequest = dataRequest.downloadProgress(closure: progressClosure) as? T {
+                    progressAlamoRequest = dataRequest
+                }
             default: break
             }
         }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -705,7 +705,7 @@ class MoyaProviderSpec: QuickSpec {
                 provider = MoyaProvider<GitHubUserContent>()
             }
 
-            it("tracks progress of request") {
+            it("tracks progress of download request") {
 
                 let target: GitHubUserContent = .downloadMoyaWebContent("logo_github.png")
 
@@ -733,6 +733,36 @@ class MoyaProviderSpec: QuickSpec {
                 expect(progressValues) == [0.25, 0.5, 0.75, 1.0, 1.0]
                 expect(completedValues) == [false, false, false, false, true]
             }
+
+            it("tracks progress of request") {
+
+                let target: GitHubUserContent = .requestMoyaWebContent("logo_github.png")
+
+                var progressValues: [Double] = []
+                var completedValues: [Bool] = []
+                var error: MoyaError?
+
+                waitUntil(timeout: 5.0) { done in
+                    let progressClosure: ProgressBlock = { progress in
+                        progressValues.append(progress.progress)
+                        completedValues.append(progress.completed)
+                    }
+
+                    let progressCompletionClosure: Completion = { (result) in
+                        if case .failure(let err) = result {
+                            error = err
+                        }
+                        done()
+                    }
+
+                    provider.request(target, callbackQueue: nil, progress: progressClosure, completion: progressCompletionClosure)
+                }
+
+                expect(error).to(beNil())
+                expect(progressValues) == [0.25, 0.5, 0.75, 1.0, 1.0]
+                expect(completedValues) == [false, false, false, false, true]
+            }
+
         }
 
         describe("using a custom callback queue") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -100,9 +100,7 @@ extension GitHubUserContent: TargetType {
     public var baseURL: URL { return URL(string: "https://raw.githubusercontent.com")! }
     public var path: String {
         switch self {
-        case .downloadMoyaWebContent(let contentPath):
-            return "/Moya/Moya/master/web/\(contentPath)"
-        case .requestMoyaWebContent(let contentPath):
+        case .downloadMoyaWebContent(let contentPath), .requestMoyaWebContent(let contentPath):
             return "/Moya/Moya/master/web/\(contentPath)"
         }
     }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -93,6 +93,7 @@ enum HTTPBin: TargetType {
 
 public enum GitHubUserContent {
     case downloadMoyaWebContent(String)
+    case requestMoyaWebContent(String)
 }
 
 extension GitHubUserContent: TargetType {
@@ -101,17 +102,19 @@ extension GitHubUserContent: TargetType {
         switch self {
         case .downloadMoyaWebContent(let contentPath):
             return "/Moya/Moya/master/web/\(contentPath)"
+        case .requestMoyaWebContent(let contentPath):
+            return "/Moya/Moya/master/web/\(contentPath)"
         }
     }
     public var method: Moya.Method {
         switch self {
-        case .downloadMoyaWebContent:
+        case .downloadMoyaWebContent, .requestMoyaWebContent:
             return .get
         }
     }
     public var parameters: [String: Any]? {
         switch self {
-        case .downloadMoyaWebContent:
+        case .downloadMoyaWebContent, .requestMoyaWebContent:
             return nil
         }
     }
@@ -122,11 +125,13 @@ extension GitHubUserContent: TargetType {
         switch self {
         case .downloadMoyaWebContent:
             return .downloadDestination(defaultDownloadDestination)
+        case .requestMoyaWebContent:
+            return .requestPlain
         }
     }
     public var sampleData: Data {
         switch self {
-        case .downloadMoyaWebContent:
+        case .downloadMoyaWebContent, .requestMoyaWebContent:
             return Data(count: 4000)
         }
     }


### PR DESCRIPTION
Alamofire provide also `Progress` for `DataRequest`.

Any reason to not use it? _Maybe not available when implementing the new progress callback in Moya_

This PR is for 9.0.0-dev ask requested #1232

---

`Progress` could be also provided at the end with response
phimage/Moya@c13fcd6
I will PR that after the merge of this PR
