### PR TITLE
`Progress` into the response when calling progress callback on completion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,8 +8,8 @@
 - Added all the `filter`/`map` operators that were available for `Observable<Response>` to `Single<Response>` as well.
 - Added `AuthorizationType` to `AccessTokenAuthorizable` representing request headers of `.none`, `.basic`, and `.bearer`. 
 - Added tests for `Single<Response>` operators.
-- Fixed a bug where you weren't notified on progress callback for data request.
 - Added `Progress` object into the response when calling progress callback on completion.
+- Fixed a bug where you weren't notified on progress callback for data request.
 
 # 9.0.0-alpha.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
 - Added `AuthorizationType` to `AccessTokenAuthorizable` representing request headers of `.none`, `.basic`, and `.bearer`. 
 - Added tests for `Single<Response>` operators.
 - Fixed a bug where you weren't notified on progress callback for data request.
+- Added `Progress` object into the response when calling progress callback on completion.
 
 # 9.0.0-alpha.1
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -250,7 +250,18 @@ private extension MoyaProvider {
             let result = convertResponseToResult(response, request: request, data: data, error: error)
             // Inform all plugins about the response
             plugins.forEach { $0.didReceive(result, target: target) }
-            progressCompletion?(ProgressResponse(response: result.value))
+            if let progressCompletion = progressCompletion {
+                switch progressAlamoRequest {
+                case let downloadRequest as DownloadRequest:
+                    progressCompletion(ProgressResponse(progress: downloadRequest.progress, response: result.value))
+                case let uploadRequest as UploadRequest:
+                    progressCompletion(ProgressResponse(progress: uploadRequest.uploadProgress, response: result.value))
+                case let dataRequest as DataRequest:
+                    progressCompletion(ProgressResponse(progress: dataRequest.progress, response: result.value))
+                default:
+                    progressCompletion(ProgressResponse(response: result.value))
+                }
+            }
             completion(result)
         }
 

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -709,12 +709,14 @@ class MoyaProviderSpec: QuickSpec {
 
                 let target: GitHubUserContent = .downloadMoyaWebContent("logo_github.png")
 
+                var progressObjects: [Progress?] = []
                 var progressValues: [Double] = []
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
                 waitUntil(timeout: 5.0) { done in
                     let progressClosure: ProgressBlock = { progress in
+                        progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
                         completedValues.append(progress.completed)
                     }
@@ -732,18 +734,21 @@ class MoyaProviderSpec: QuickSpec {
                 expect(error).to(beNil())
                 expect(progressValues) == [0.25, 0.5, 0.75, 1.0, 1.0]
                 expect(completedValues) == [false, false, false, false, true]
+                expect(progressObjects.filter{$0 != nil}.count) == 5
             }
 
             it("tracks progress of request") {
 
                 let target: GitHubUserContent = .requestMoyaWebContent("logo_github.png")
 
+                var progressObjects: [Progress?] = []
                 var progressValues: [Double] = []
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
                 waitUntil(timeout: 5.0) { done in
                     let progressClosure: ProgressBlock = { progress in
+                        progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
                         completedValues.append(progress.completed)
                     }
@@ -761,6 +766,7 @@ class MoyaProviderSpec: QuickSpec {
                 expect(error).to(beNil())
                 expect(progressValues) == [0.25, 0.5, 0.75, 1.0, 1.0]
                 expect(completedValues) == [false, false, false, false, true]
+                expect(progressObjects.filter{$0 != nil}.count) == 5
             }
 
         }


### PR DESCRIPTION
The object is accessible, why not receive it.
At completion, some information into `Progress` object could be very useful