### PR TITLE
Propagate parameter encoding error for URLRequest mapping

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,11 @@
 # Next
+### Added
+- **Breaking Change** `.parameterEncoding(Swift.Error)` case to `MoyaError`. [#1248](https://github.com/Moya/Moya/pull/1248) by [@SD10](https://github.com/SD10).
+
 ### Changed
 - **Breaking Change** `Endpoint.init` so it doesn't have any default arguments (removing default argument `.get` for `method` parameter and `nil` for  `httpHeaderFields` parameter). [#1289](https://github.com/Moya/Moya/pull/1289) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** `NetworkActivityPlugin` so its `networkActivityClosure` has now `target: TargetType` argument in addition to `change: NetworkActivityChangeType`. [#1290](https://github.com/Moya/Moya/pull/1290) by [@sunshinejr](https://github.com/sunshinejr).
+- **Breaking Change** `Endpoint`'s `urlRequest` property to `urlRequest()` a throwing method. [#1248](https://github.com/Moya/Moya/pull/1248) by [@SD10](https://github.com/SD10).
 
 # 9.0.0
 - Removed default value for task from `Endpoint` initializer

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -60,9 +60,9 @@ open class Endpoint<Target> {
     }
 }
 
-/// Extension for converting an `Endpoint` into an optional `URLRequest`.
+/// Extension for converting an `Endpoint` into a `URLRequest`.
 extension Endpoint {
-    /// Returns the `Endpoint` converted to a `URLRequest` if valid. Returns `nil` otherwise.
+    /// Returns the `Endpoint` converted to a `URLRequest` if valid. Throws an error otherwise.
     public func urlRequest() throws -> URLRequest {
         guard let requestURL = Foundation.URL(string: url) else {
             throw MoyaError.requestMapping(url)

--- a/Sources/Moya/MoyaError.swift
+++ b/Sources/Moya/MoyaError.swift
@@ -19,6 +19,9 @@ public enum MoyaError: Swift.Error {
 
     /// Indicates that an `Endpoint` failed to map to a `URLRequest`.
     case requestMapping(String)
+
+    /// Indicates that an `Endpoint` failed to encode the parameters for the `URLRequest`.
+    case parameterEncoding(Swift.Error)
 }
 
 public extension MoyaError {
@@ -31,6 +34,7 @@ public extension MoyaError {
         case .statusCode(let response): return response
         case .underlying(_, let response): return response
         case .requestMapping: return nil
+        case .parameterEncoding: return nil
         }
     }
 }
@@ -50,6 +54,8 @@ extension MoyaError: LocalizedError {
             return "Status code didn't fall within the given range."
         case .requestMapping:
             return "Failed to map Endpoint to a URLRequest."
+        case .parameterEncoding(let error):
+            return "Failed to encode parameters for URLRequest. \(error.localizedDescription)"
         case .underlying(let error, _):
             return error.localizedDescription
         }

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -13,10 +13,13 @@ public extension MoyaProvider {
     }
 
     public final class func defaultRequestMapping(for endpoint: Endpoint<Target>, closure: RequestResultClosure) {
-        if let urlRequest = endpoint.urlRequest {
+        do {
+            let urlRequest = try endpoint.urlRequest()
             closure(.success(urlRequest))
-        } else {
-            closure(.failure(MoyaError.requestMapping(endpoint.url)))
+        } catch MoyaError.requestMapping(let url) {
+            closure(.failure(MoyaError.requestMapping(url)))
+        } catch {
+            closure(.failure(MoyaError.parameterEncoding(error)))
         }
     }
 

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -18,8 +18,10 @@ public extension MoyaProvider {
             closure(.success(urlRequest))
         } catch MoyaError.requestMapping(let url) {
             closure(.failure(MoyaError.requestMapping(url)))
-        } catch {
+        } catch MoyaError.parameterEncoding(let error) {
             closure(.failure(MoyaError.parameterEncoding(error)))
+        } catch {
+            closure(.failure(MoyaError.underlying(error, nil)))
         }
     }
 

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -8,7 +8,7 @@ final class NonUpdatingRequestEndpointConfiguration: QuickConfiguration {
             let task = context()["task"] as! Task
             let oldEndpoint = context()["endpoint"] as! Endpoint<GitHub>
             let endpoint = oldEndpoint.replacing(task: task)
-            let request = endpoint.urlRequest!
+            let request = try! endpoint.urlRequest()
 
             it("didn't update any of the request properties") {
                 expect(request.httpBody).to(beNil())
@@ -26,12 +26,12 @@ final class ParametersEncodedEndpointConfiguration: QuickConfiguration {
             let parameters = context()["parameters"] as! [String: Any]
             let encoding = context()["encoding"] as! ParameterEncoding
             let endpoint = context()["endpoint"] as! Endpoint<GitHub>
-            let request = endpoint.urlRequest!
+            let request = try! endpoint.urlRequest()
 
             it("updated the request correctly") {
                 let newEndpoint = endpoint.replacing(task: .requestPlain)
-                let newRequest = newEndpoint.urlRequest
-                let newEncodedRequest = try? encoding.encode(newRequest!, with: parameters)
+                let newRequest = try! newEndpoint.urlRequest()
+                let newEncodedRequest = try? encoding.encode(newRequest, with: parameters)
 
                 expect(request.httpBody).to(equal(newEncodedRequest?.httpBody))
                 expect(request.url?.absoluteString).to(equal(newEncodedRequest?.url?.absoluteString))
@@ -71,9 +71,9 @@ final class EndpointSpec: QuickSpec {
         }
 
         it("returns a nil urlRequest for an invalid URL") {
-            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) }, method: .get, task: .requestPlain, httpHeaderFields: nil)
-
-            expect(badEndpoint.urlRequest).to(beNil())
+            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) })
+            let urlRequest = try? badEndpoint.urlRequest()
+            expect(urlRequest).to(beNil())
         }
 
         describe("successful converting to urlRequest") {
@@ -132,7 +132,7 @@ final class EndpointSpec: QuickSpec {
                 beforeEach {
                     data = "test data".data(using: .utf8)
                     endpoint = endpoint.replacing(task: .requestData(data))
-                    request = endpoint.urlRequest
+                    request = try! endpoint.urlRequest()
                 }
 
                 it("updates httpBody") {
@@ -155,7 +155,7 @@ final class EndpointSpec: QuickSpec {
                     parameters = ["Nemesis": "Harvey"]
                     data = "test data".data(using: .utf8)
                     endpoint = endpoint.replacing(task: .requestCompositeData(bodyData: data, urlParameters: parameters))
-                    request = endpoint.urlRequest
+                    request = try! endpoint.urlRequest()
                 }
 
                 it("updates url") {
@@ -184,7 +184,7 @@ final class EndpointSpec: QuickSpec {
                     urlParameters = ["Harvey": "Nemesis"]
                     encoding = JSONEncoding.default
                     endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: encoding, urlParameters: urlParameters))
-                    request = endpoint.urlRequest
+                    request = try! endpoint.urlRequest()
                 }
 
                 it("updates url") {
@@ -194,8 +194,8 @@ final class EndpointSpec: QuickSpec {
 
                 it("updates the request correctly") {
                     let newEndpoint = endpoint.replacing(task: .requestPlain)
-                    let newRequest = newEndpoint.urlRequest
-                    let newEncodedRequest = try? encoding.encode(newRequest!, with: bodyParameters)
+                    let newRequest = try! newEndpoint.urlRequest()
+                    let newEncodedRequest = try? encoding.encode(newRequest, with: bodyParameters)
 
                     expect(request.httpBody).to(equal(newEncodedRequest?.httpBody))
                     expect(request.allHTTPHeaderFields).to(equal(newEncodedRequest?.allHTTPHeaderFields))
@@ -210,7 +210,7 @@ final class EndpointSpec: QuickSpec {
                 beforeEach {
                     urlParameters = ["Harvey": "Nemesis"]
                     endpoint = endpoint.replacing(task: .uploadCompositeMultipart([], urlParameters: urlParameters))
-                    request = endpoint.urlRequest
+                    request = try! endpoint.urlRequest()
                 }
 
                 it("updates url") {
@@ -224,7 +224,7 @@ final class EndpointSpec: QuickSpec {
             context("when task is .requestCompositeParameters") {
                 it("throws an error when bodyEncoding is an URLEncoding") {
                     endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: [:], bodyEncoding: URLEncoding.queryString, urlParameters: [:]))
-                    expect { _ = endpoint.urlRequest }.to(throwAssertion())
+                    expect { _ = try? endpoint.urlRequest() }.to(throwAssertion())
                 }
             }
         }

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -71,7 +71,7 @@ final class EndpointSpec: QuickSpec {
         }
 
         it("returns a nil urlRequest for an invalid URL") {
-            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) })
+            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) }, method: .get, task: .requestPlain, httpHeaderFields: nil)
             let urlRequest = try? badEndpoint.urlRequest()
             expect(urlRequest).to(beNil())
         }

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -1,7 +1,6 @@
 import Quick
 import Moya
 import Nimble
-import enum Alamofire.AFError
 
 final class NonUpdatingRequestEndpointConfiguration: QuickConfiguration {
     override static func configure(_ configuration: Configuration) {

--- a/Tests/Error+MoyaSpec.swift
+++ b/Tests/Error+MoyaSpec.swift
@@ -48,6 +48,13 @@ public func beOfSameErrorType(_ expectedValue: MoyaError) -> Predicate<MoyaError
                 default:
                     test = false
                 }
+            case .parameterEncoding:
+                switch expectedValue {
+                case .parameterEncoding:
+                    test = true
+                default:
+                    test = false
+                }
             }
         } else {
             test = false

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -57,8 +57,10 @@ class MoyaProviderSpec: QuickSpec {
 
             let endpoint1 = provider.endpoint(target)
             let endpoint2 = provider.endpoint(target)
-            expect(endpoint1.urlRequest).toNot(beNil())
-            expect(endpoint1.urlRequest).to(equal(endpoint2.urlRequest))
+            let urlRequest1 = try? endpoint1.urlRequest()
+            let urlRequest2 = try? endpoint2.urlRequest()
+            expect(urlRequest1).toNot(beNil())
+            expect(urlRequest1).to(equal(urlRequest2))
         }
 
         it("returns a cancellable object when a request is made") {
@@ -263,10 +265,13 @@ class MoyaProviderSpec: QuickSpec {
             beforeEach {
                 let endpointResolution: MoyaProvider<GitHub>.RequestClosure = { endpoint, done in
                     delay(requestTime) {
-                        if let urlRequest = endpoint.urlRequest {
+                        do {
+                            let urlRequest = try endpoint.urlRequest()
                             done(.success(urlRequest))
-                        } else {
-                            done(.failure(MoyaError.requestMapping(endpoint.url)))
+                        } catch MoyaError.requestMapping(let url) {
+                            done(.failure(MoyaError.requestMapping(url)))
+                        } catch {
+                            done(.failure(MoyaError.parameterEncoding(error)))
                         }
                     }
                 }
@@ -363,10 +368,13 @@ class MoyaProviderSpec: QuickSpec {
                 executed = false
                 let endpointResolution: MoyaProvider<GitHub>.RequestClosure = { endpoint, done in
                     executed = true
-                    if let urlRequest = endpoint.urlRequest {
+                    do {
+                        let urlRequest = try endpoint.urlRequest()
                         done(.success(urlRequest))
-                    } else {
-                        done(.failure(MoyaError.requestMapping(endpoint.url)))
+                    } catch MoyaError.requestMapping(let url) {
+                        done(.failure(MoyaError.requestMapping(url)))
+                    } catch {
+                        done(.failure(MoyaError.parameterEncoding(error)))
                     }
                 }
                 provider = MoyaProvider<GitHub>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
@@ -536,10 +544,13 @@ class MoyaProviderSpec: QuickSpec {
                 var requestedURL: String?
                 let endpointResolution: MoyaProvider<MultiTarget>.RequestClosure = { endpoint, done in
                     requestedURL = endpoint.url
-                    if let urlRequest = endpoint.urlRequest {
+                    do {
+                        let urlRequest = try endpoint.urlRequest()
                         done(.success(urlRequest))
-                    } else {
-                        done(.failure(MoyaError.requestMapping(endpoint.url)))
+                    } catch MoyaError.requestMapping(let url) {
+                        done(.failure(MoyaError.requestMapping(url)))
+                    } catch {
+                        done(.failure(MoyaError.parameterEncoding(error)))
                     }
                 }
                 let provider = MoyaProvider<MultiTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
@@ -557,10 +568,13 @@ class MoyaProviderSpec: QuickSpec {
                 var requestMethod: Moya.Method?
                 let endpointResolution: MoyaProvider<MultiTarget>.RequestClosure = { endpoint, done in
                     requestMethod = endpoint.method
-                    if let urlRequest = endpoint.urlRequest {
+                    do {
+                        let urlRequest = try endpoint.urlRequest()
                         done(.success(urlRequest))
-                    } else {
-                        done(.failure(MoyaError.requestMapping(endpoint.url)))
+                    } catch MoyaError.requestMapping(let url) {
+                        done(.failure(MoyaError.requestMapping(url)))
+                    } catch {
+                        done(.failure(MoyaError.parameterEncoding(error)))
                     }
                 }
                 let provider = MoyaProvider<MultiTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
@@ -594,10 +608,13 @@ class MoyaProviderSpec: QuickSpec {
                 var headers: [String : String]?
                 let endpointResolution: MoyaProvider<MultiTarget>.RequestClosure = { endpoint, done in
                     headers = endpoint.httpHeaderFields
-                    if let urlRequest = endpoint.urlRequest {
+                    do {
+                        let urlRequest = try endpoint.urlRequest()
                         done(.success(urlRequest))
-                    } else {
-                        done(.failure(MoyaError.requestMapping(endpoint.url)))
+                    } catch MoyaError.requestMapping(let url) {
+                        done(.failure(MoyaError.requestMapping(url)))
+                    } catch {
+                        done(.failure(MoyaError.parameterEncoding(error)))
                     }
                 }
                 let provider = MoyaProvider<MultiTarget>(requestClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -99,8 +99,9 @@ itself sometimes require network requests be performed _first_, so signing
 a request for Moya is an asynchronous process. Let's see an example.
 
 ```swift
-let requestClosure = { (endpoint: Endpoint<YourAPI>, done: MoyaProvider.RequestResultClosure) in
-    let request = endpoint.urlRequest // This is the request Moya generates
+let requestClosure = { (endpoint: Endpoint<YourAPI>, done: URLRequest -> Void) in
+    let request = try! endpoint.urlRequest() // This is the request Moya generates
+
     YourAwesomeOAuthProvider.signRequest(request, completion: { signedRequest in
         // The OAuth provider can make its own network calls to sign your request.
         // However, you *must* call `done()` with the signed so that Moya can

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -109,7 +109,12 @@ That's what the `requestClosure` parameter is for.
 
 The `requestClosure` is an optional, last-minute way to modify the request
 that hits the network. It has a default value of `MoyaProvider.defaultRequestMapping`,
-which simply uses the `urlRequest` property of the `Endpoint` instance.
+which uses the `urlRequest()` method of the `Endpoint` instance. The `urlRequest()` 
+method throws two possible errors: `MoyaError.requestMapping(String)` error in the 
+case that an `URLRequest` could not be created for the given path and a `Swift.Error`
+in the case of an error related to the encoding of the parameters for a request. 
+This `Swift.Error` is wrapped up as a `MoyaError.parameterEncoding(Swift.Error)` by the 
+`MoyaProvider.defaultRequestMapping` closure. 
 
 This closure receives an `Endpoint` instance and is responsible for invoking a
 its argument of `RequestResultClosure` (shorthand for `Result<URLRequest, MoyaError> -> Void`) with a request that represents the Endpoint.
@@ -119,11 +124,14 @@ Instead of modifying the request, you could simply log it, instead.
 
 ```swift
 let requestClosure = { (endpoint: Endpoint<GitHub>, done: MoyaProvider.RequestResultClosure) in
-    var request = endpoint.urlRequest
+    do {
+        var request = try endpoint.urlRequest()
+        // Modify the request however you like.
+        done(.success(request))
+    } catch {
+	done(.failure(MoyaError.underlying(error)))
+    }
 
-    // Modify the request however you like.
-
-    done(.success(request))
 }
 let provider = MoyaProvider<GitHub>(requestClosure: requestClosure)
 ```
@@ -136,9 +144,13 @@ all cookies on requests:
 
 ```swift
 { (endpoint: Endpoint<ArtsyAPI>, done: MoyaProvider.RequestResultClosure) in
-    var request: URLRequest = endpoint.urlRequest
-    request.httpShouldHandleCookies = false
-    done(.success(request))
+    do {
+    	var request: URLRequest = try endpoint.urlRequest
+    	request.httpShouldHandleCookies = false
+   	done(.success(request))
+    } catch {
+    	done(.failure(MoyaError.underlying(error)))
+    }
 }
 ```
 

--- a/docs/Examples/ErrorTypes.md
+++ b/docs/Examples/ErrorTypes.md
@@ -42,7 +42,9 @@ case .underlying(let nsError as NSError, let response):
 case .underlying(let error, let response):
     print(error)
     print(response)
-case .requestMapping:
-    print("nil")
+case .requestMapping(let url):
+    print(url)
+case .parameterEncoding(let error):
+    print(error)
 }
 ```


### PR DESCRIPTION
### Changes:

**Adds:**
`MoyaError.parameterEncoding(Swift.Error) case`

**Refactors:**
`urlRequest` -> `urlRequest()` (now throwing)

### Summary of Pull Request:

As discussed in #1247 I saw that it would be really easy to pass on the errors thrown when attempting to encode `URLRequest` parameters.

All that had to be done is convert `Endpoint`'s `urlRequest` property to a throwing function and pass the error to the `.failure` closure in `MoyaProvider.defaultRequestMapping`.

Personally, I'm not too fond of having to call `try` now when accessing an `Endpoint`'s `urlRequest`. Therefore, I mostly consider this "research" unless any of you think there's value in it. 