### PR TITLE
[WIP] Remove default arguments for Endpoint initializer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Next
+- **Breaking Change** Remove all default arguments from `Endpoint` initializer.
 
 # 9.0.0-beta.1
 - **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Next
+
+# 9.0.0-beta.1
 - **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
 - **Breaking Change** Flattened `UploadType` and `DownloadType` into `Task` cases.
 - **Breaking Change** Replaced `shouldAuthorize: Bool` in `AccessTokenAuthorizable` with `authorizationType: AuthorizationType`.

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - Alamofire (4.5.0)
-  - Moya (9.0.0-alpha.1):
-    - Moya/Core (= 9.0.0-alpha.1)
-  - Moya/Core (9.0.0-alpha.1):
+  - Moya (9.0.0-beta.1):
+    - Moya/Core (= 9.0.0-beta.1)
+  - Moya/Core (9.0.0-beta.1):
     - Alamofire (~> 4.1)
     - Result (~> 3.0)
-  - Moya/ReactiveSwift (9.0.0-alpha.1):
+  - Moya/ReactiveSwift (9.0.0-beta.1):
     - Moya/Core
     - ReactiveSwift (~> 2.0)
-  - Moya/RxSwift (9.0.0-alpha.1):
+  - Moya/RxSwift (9.0.0-beta.1):
     - Moya/Core
     - RxSwift (~> 3.3)
   - ReactiveSwift (2.0.0):
@@ -30,7 +30,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
-  Moya: d104801616468247e5a9abd258c838c5ca6b1389
+  Moya: 585a852353b58c57657694c8a0f99894a4d9334e
   ReactiveSwift: 36339167e571774d936482d0f6512f5118a74731
   Result: 128640a6347e8d2ae48b142556739a2d13f90ce6
   RxSwift: f9de85ea20cd2f7716ee5409fc13523dc638e4e4

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Moya"
-  s.version      = "9.0.0-alpha.1"
+  s.version      = "9.0.0-beta.1"
   s.summary      = "Network abstraction layer written in Swift"
   s.description  = <<-EOS
   Moya abstracts network commands using Swift Generics to provide developers

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -26,9 +26,9 @@ open class Endpoint<Target> {
     /// Main initializer for `Endpoint`.
     public init(url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
-                method: Moya.Method = Moya.Method.get,
-                task: Task = .requestPlain,
-                httpHeaderFields: [String: String]? = nil) {
+                method: Moya.Method,
+                task: Task,
+                httpHeaderFields: [String: String]?) {
 
         self.url = url
         self.sampleResponseClosure = sampleResponseClosure

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -47,7 +47,9 @@ final class EndpointSpec: QuickSpec {
     private var simpleGitHubEndpoint: Endpoint<GitHub> {
         let target: GitHub = .zen
         let headerFields = ["Title": "Dominar"]
-        return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, task: .requestPlain, httpHeaderFields: headerFields)
+        return Endpoint<GitHub>(url: url(target),
+                                sampleResponseClosure: {.networkResponse(200, target.sampleData)},
+                                method: Moya.Method.get, task: .requestPlain, httpHeaderFields: headerFields)
     }
 
     override func spec() {
@@ -71,7 +73,9 @@ final class EndpointSpec: QuickSpec {
         }
 
         it("returns a nil urlRequest for an invalid URL") {
-            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) })
+            let badEndpoint = Endpoint<Empty>(url: "some invalid URL",
+                                              sampleResponseClosure: { .networkResponse(200, Data()) },
+                                              method: .get, task: .requestPlain, httpHeaderFields: nil)
 
             expect(badEndpoint.urlRequest).to(beNil())
         }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -376,7 +376,9 @@ class MoyaProviderSpec: QuickSpec {
             it("returns sample data") {
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, task: target.task)
+                    return Endpoint(url: url,
+                                    sampleResponseClosure: {.networkResponse(200, target.sampleData)},
+                                    method: target.method, task: target.task, httpHeaderFields: nil)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -394,7 +396,9 @@ class MoyaProviderSpec: QuickSpec {
                 let response = HTTPURLResponse(url: URL(string: "http://example.com")!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .response(response, Data()) }, method: target.method, task: target.task)
+                    return Endpoint(url: url,
+                                    sampleResponseClosure: { .response(response, Data()) },
+                                    method: target.method, task: target.task, httpHeaderFields: nil)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 
@@ -412,7 +416,9 @@ class MoyaProviderSpec: QuickSpec {
                 let error = NSError(domain: "Internal iOS Error", code: -1234, userInfo: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     let url = target.baseURL.appendingPathComponent(target.path).absoluteString
-                    return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method, task: target.task)
+                    return Endpoint(url: url,
+                                    sampleResponseClosure: { .networkError(error) },
+                                    method: target.method, task: target.task, httpHeaderFields: nil)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -56,7 +56,9 @@ func url(_ route: TargetType) -> String {
 
 let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.moyaerror", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method, task: target.task)
+    return Endpoint<GitHub>(url: url(target),
+                            sampleResponseClosure: {.networkError(error)},
+                            method: target.method, task: target.task, httpHeaderFields: nil)
 }
 
 enum HTTPBin: TargetType {


### PR DESCRIPTION
As discussed in #1247, the fact that `Endpoint` has default values of `.get` & `.requestPlain` can be a point of confusion when users are creating their own Endpoints.