### PR TITLE
Remove default value from Endpoint for task parameter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Next
+- Removed default value for task from `Endpoint` initializer
 
 # 9.0.0-beta.1
 - **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Next
+
+# 9.0.0-beta.1
 - **Breaking Change** Replaced `parameters` & `parameterEncoding` in `TargetType` with extended `Task` cases.
 - **Breaking Change** Flattened `UploadType` and `DownloadType` into `Task` cases.
 - **Breaking Change** Replaced `shouldAuthorize: Bool` in `AccessTokenAuthorizable` with `authorizationType: AuthorizationType`.

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - Alamofire (4.5.0)
-  - Moya (9.0.0-alpha.1):
-    - Moya/Core (= 9.0.0-alpha.1)
-  - Moya/Core (9.0.0-alpha.1):
+  - Moya (9.0.0-beta.1):
+    - Moya/Core (= 9.0.0-beta.1)
+  - Moya/Core (9.0.0-beta.1):
     - Alamofire (~> 4.1)
     - Result (~> 3.0)
-  - Moya/ReactiveSwift (9.0.0-alpha.1):
+  - Moya/ReactiveSwift (9.0.0-beta.1):
     - Moya/Core
     - ReactiveSwift (~> 2.0)
-  - Moya/RxSwift (9.0.0-alpha.1):
+  - Moya/RxSwift (9.0.0-beta.1):
     - Moya/Core
     - RxSwift (~> 3.3)
   - ReactiveSwift (2.0.0):
@@ -30,7 +30,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
-  Moya: d104801616468247e5a9abd258c838c5ca6b1389
+  Moya: 585a852353b58c57657694c8a0f99894a4d9334e
   ReactiveSwift: 36339167e571774d936482d0f6512f5118a74731
   Result: 128640a6347e8d2ae48b142556739a2d13f90ce6
   RxSwift: f9de85ea20cd2f7716ee5409fc13523dc638e4e4

--- a/Moya.podspec
+++ b/Moya.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Moya"
-  s.version      = "9.0.0-alpha.1"
+  s.version      = "9.0.0-beta.1"
   s.summary      = "Network abstraction layer written in Swift"
   s.description  = <<-EOS
   Moya abstracts network commands using Swift Generics to provide developers

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -27,7 +27,7 @@ open class Endpoint<Target> {
     public init(url: String,
                 sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method = Moya.Method.get,
-                task: Task = .requestPlain,
+                task: Task,
                 httpHeaderFields: [String: String]? = nil) {
 
         self.url = url

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -71,7 +71,7 @@ final class EndpointSpec: QuickSpec {
         }
 
         it("returns a nil urlRequest for an invalid URL") {
-            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) })
+            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) }, task: .requestPlain)
 
             expect(badEndpoint.urlRequest).to(beNil())
         }


### PR DESCRIPTION
In favor of #1249

As discussed in #1247, the fact that `Endpoint` has default values for the `task` parameter can be a source of confusion for users creating their own endpoints.

No changes to docs or demo app.