### PR TITLE
Update AccessTokenPlugin to be able to pass token as url parameter

### DIFF
--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -12,7 +12,7 @@ public protocol AccessTokenAuthorizable {
 
 // MARK: - AuthorizationType
 
-/// An enum representing the header and url parameter to use with an `AccessTokenPlugin`
+/// An enum representing the header or url parameter to use with an `AccessTokenPlugin`
 public enum AuthorizationType: String {
     case none
     case basic = "Basic"
@@ -68,16 +68,19 @@ public struct AccessTokenPlugin: PluginType {
             request.addValue(authValue, forHTTPHeaderField: "Authorization")
           
         case .urlParameter:
-          var existingComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)
+          guard let requestUrl = request.url,
+            var existingComponents = URLComponents(url: requestUrl, resolvingAgainstBaseURL: true)
+            else { return request }
+          
           let tokenQueryItem = URLQueryItem(name: authorizationType.rawValue, value: tokenClosure())
           var updatedQueryItems = [tokenQueryItem]
           
-          if let queryItems = existingComponents?.queryItems {
-            queryItems.forEach { updatedQueryItems.append($0) }
+          if let currentQueryItems = existingComponents.queryItems {
+            updatedQueryItems.append(contentsOf: currentQueryItems)
           }
           
-          existingComponents?.queryItems = updatedQueryItems
-          request.url = existingComponents?.url
+          existingComponents.queryItems = updatedQueryItems
+          request.url = existingComponents.url
           
         case .none:
             break

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -6,47 +6,49 @@ import Result
 /// A protocol for controlling the behavior of `AccessTokenPlugin`.
 public protocol AccessTokenAuthorizable {
 
-    /// Represents the authorization header to use for requests.
+    /// Represents the authorization header or url parameter to use for requests.
     var authorizationType: AuthorizationType { get }
 }
 
 // MARK: - AuthorizationType
 
-/// An enum representing the header to use with an `AccessTokenPlugin`
+/// An enum representing the header and url parameter to use with an `AccessTokenPlugin`
 public enum AuthorizationType: String {
     case none
     case basic = "Basic"
     case bearer = "Bearer"
+    case urlParameter = "access_token"
 }
 
 // MARK: - AccessTokenPlugin
 
 /**
- A plugin for adding basic or bearer-type authorization headers to requests. Example:
+ A plugin for adding basic or bearer-type authorization headers, or url parameter to requests. Example:
 
  ```
  Authorization: Bearer <token>
  Authorization: Basic <token>
+ access_token=<token>
  ```
 
 */
 public struct AccessTokenPlugin: PluginType {
 
-    /// A closure returning the access token to be applied in the header.
+    /// A closure returning the access token to be applied in the header or url parameter.
     public let tokenClosure: () -> String
 
     /**
      Initialize a new `AccessTokenPlugin`.
 
      - parameters:
-       - tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthorizationType> <token>`
+       - tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthorizationType> <token>` or `access_token=<token>`
     */
     public init(tokenClosure: @escaping @autoclosure () -> String) {
         self.tokenClosure = tokenClosure
     }
 
     /**
-     Prepare a request by adding an authorization header if necessary.
+     Prepare a request by adding an authorization header or url parameter if necessary.
 
      - parameters:
        - request: The request to modify.
@@ -64,6 +66,19 @@ public struct AccessTokenPlugin: PluginType {
         case .basic, .bearer:
             let authValue = authorizationType.rawValue + " " + tokenClosure()
             request.addValue(authValue, forHTTPHeaderField: "Authorization")
+          
+        case .urlParameter:
+          var existingComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: true)
+          let tokenQueryItem = URLQueryItem(name: authorizationType.rawValue, value: tokenClosure())
+          var updatedQueryItems = [tokenQueryItem]
+          
+          if let queryItems = existingComponents?.queryItems {
+            queryItems.forEach { updatedQueryItems.append($0) }
+          }
+          
+          existingComponents?.queryItems = updatedQueryItems
+          request.url = existingComponents?.url
+          
         case .none:
             break
         }

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -52,8 +52,6 @@ final class AccessTokenPluginSpec: QuickSpec {
           let request = URLRequest(url: target.baseURL)
           let preparedRequest = plugin.prepare(request, target: target)
           let urlComponents = URLComponents(url: preparedRequest.url!, resolvingAgainstBaseURL: true)
-          expect(preparedRequest.url).to(beTruthy())
-          expect(urlComponents).to(beTruthy())
           expect(urlComponents!.queryItems!.first!.name) == "access_token"
           expect(urlComponents!.queryItems!.first!.value!) == "eyeAm.AJsoN.weBTOKen"
         }

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -46,6 +46,17 @@ final class AccessTokenPluginSpec: QuickSpec {
             let preparedRequest = plugin.prepare(request, target: target)
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Basic eyeAm.AJsoN.weBTOKen"]
         }
+      
+        it("adds a primitive access token as url parameter when AuthorizationType is .urlParameter") {
+          let target = TestTarget(authorizationType: .urlParameter)
+          let request = URLRequest(url: target.baseURL)
+          let preparedRequest = plugin.prepare(request, target: target)
+          let urlComponents = URLComponents(url: preparedRequest.url!, resolvingAgainstBaseURL: true)
+          expect(preparedRequest.url).to(beTruthy())
+          expect(urlComponents).to(beTruthy())
+          expect(urlComponents!.queryItems!.first!.name) == "access_token"
+          expect(urlComponents!.queryItems!.first!.value!) == "eyeAm.AJsoN.weBTOKen"
+        }
 
     }
 }


### PR DESCRIPTION
Some sites let you access to their api via access token which is passed as a parameter in the URL path. This commit allows to use AccessTokenPlugin also in this task. #1273 