### PR TITLE
[CI] Enable tvOS/macOS builds.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ end
 
 def targets
   return [
-    # :macos, # Note: we're experiencing macOS build problems on circle, commenting out.
+    :macos,
     :tvos,
     :ios
   ]

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ end
 def targets
   return [
     # :macos, # Note: we're experiencing macOS build problems on circle, commenting out.
-    # :tvos, # Note: tvos simulator is currently not in the newest Xcode9b6 on CircleCI.
+    :tvos, # Note: tvos simulator is currently not in the newest Xcode9b6 on CircleCI.
     :ios
   ]
 end

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ end
 def targets
   return [
     # :macos, # Note: we're experiencing macOS build problems on circle, commenting out.
-    :tvos, # Note: tvos simulator is currently not in the newest Xcode9b6 on CircleCI.
+    :tvos,
     :ios
   ]
 end
@@ -57,7 +57,7 @@ end
 def device_names
   return {
     ios: "iPhone 6s",
-    tvos: "Apple TV 1080p"
+    tvos: "Apple TV 4K (at 1080p) (11.0)"
   }
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ end
 def device_names
   return {
     ios: "iPhone 6s",
-    tvos: "Apple TV 4K (at 1080p) (11.0)"
+    tvos: "Apple TV 4K (at 1080p)"
   }
 end
 


### PR DESCRIPTION
Fixes #1238. TL;DR we had to turn off the `tvOS` builds for a while because Xcode9b6 didn't have Apple TV simulators. 

I also added `macOS` as it should work just fine right now (tested on this branch). It was removed a year ago because it wasn't working properly for Swift 3 - #649 for anyone interested in it.

Oh, and I'm targeting `master` branch - will rebase 10.0 once it is merged. We should have it on both anyways.