### PR TITLE
NetworkActivityPlugin to have target in networkActivityClosure.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Next
+### Changed
+- **Breaking Change** `NetworkActivityPlugin` so its `networkActivityClosure` has now `target: TargetType` argument in addition to `change: NetworkActivityChangeType`. [#1290](https://github.com/Moya/Moya/pull/1290) by [@sunshinejr](https://github.com/sunshinejr).
 
 # 9.0.0
 - Removed default value for task from `Endpoint` initializer

--- a/Sources/Moya/Plugins/NetworkActivityPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkActivityPlugin.swift
@@ -9,7 +9,7 @@ public enum NetworkActivityChangeType {
 /// Notify a request's network activity changes (request begins or ends).
 public final class NetworkActivityPlugin: PluginType {
 
-    public typealias NetworkActivityClosure = (_ change: NetworkActivityChangeType) -> Void
+    public typealias NetworkActivityClosure = (_ change: NetworkActivityChangeType, _ target: TargetType) -> Void
     let networkActivityClosure: NetworkActivityClosure
 
     public init(networkActivityClosure: @escaping NetworkActivityClosure) {
@@ -20,11 +20,11 @@ public final class NetworkActivityPlugin: PluginType {
 
     /// Called by the provider as soon as the request is about to start
     public func willSend(_ request: RequestType, target: TargetType) {
-        networkActivityClosure(.began)
+        networkActivityClosure(.began, target)
     }
 
     /// Called by the provider as soon as a response arrives, even if the request is canceled.
     public func didReceive(_ result: Result<Moya.Response, MoyaError>, target: TargetType) {
-        networkActivityClosure(.ended)
+        networkActivityClosure(.ended, target)
     }
 }

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -188,12 +188,12 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a provider with network activity plugin") {
                     it("notifies at the beginning of network requests") {
                         var called = false
-                        var calledTarget: TargetType?
+                        var calledTarget: GitHub?
 
                         let plugin = NetworkActivityPlugin { change, target in
                             if change == .began {
                                 called = true
-                                calledTarget = target
+                                calledTarget = target as? GitHub
                             }
                         }
 
@@ -204,17 +204,17 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         }
 
                         expect(called) == true
-                        expect(calledTarget).toNot(beNil())
+                        expect(calledTarget) == target
                     }
 
                     it("notifies at the end of network requests") {
                         var called = false
-                        var calledTarget: TargetType?
+                        var calledTarget: GitHub?
 
                         let plugin = NetworkActivityPlugin { change, target in
                             if change == .ended {
                                 called = true
-                                calledTarget = target
+                                calledTarget = target as? GitHub
                             }
                         }
 
@@ -225,7 +225,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         }
 
                         expect(called) == true
-                        expect(calledTarget).toNot(beNil())
+                        expect(calledTarget) == target
                     }
                 }
 

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -188,34 +188,44 @@ class MoyaProviderIntegrationTests: QuickSpec {
                 describe("a provider with network activity plugin") {
                     it("notifies at the beginning of network requests") {
                         var called = false
-                        let plugin = NetworkActivityPlugin { change in
+                        var calledTarget: TargetType?
+
+                        let plugin = NetworkActivityPlugin { change, target in
                             if change == .began {
                                 called = true
+                                calledTarget = target
                             }
                         }
 
                         let provider = MoyaProvider<GitHub>(plugins: [plugin])
+                        let target: GitHub = .zen
                         waitUntil { done in
-                            provider.request(.zen) { _ in done() }
+                            provider.request(target) { _ in done() }
                         }
 
                         expect(called) == true
+                        expect(calledTarget).toNot(beNil())
                     }
 
                     it("notifies at the end of network requests") {
                         var called = false
-                        let plugin = NetworkActivityPlugin { change in
+                        var calledTarget: TargetType?
+
+                        let plugin = NetworkActivityPlugin { change, target in
                             if change == .ended {
                                 called = true
+                                calledTarget = target
                             }
                         }
 
                         let provider = MoyaProvider<GitHub>(plugins: [plugin])
+                        let target: GitHub = .zen
                         waitUntil { done in
-                            provider.request(.zen) { _ in done() }
+                            provider.request(target) { _ in done() }
                         }
 
                         expect(called) == true
+                        expect(calledTarget).toNot(beNil())
                     }
                 }
 

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -110,12 +110,12 @@ class MoyaProviderSpec: QuickSpec {
 
         it("notifies at the beginning of network requests") {
             var called = false
-            var calledTarget: TargetType?
+            var calledTarget: GitHub?
 
             let plugin = NetworkActivityPlugin { change, target in
                 if change == .began {
                     called = true
-                    calledTarget = target
+                    calledTarget = target as? GitHub
                 }
             }
 
@@ -124,17 +124,17 @@ class MoyaProviderSpec: QuickSpec {
             provider.request(target) { _ in  }
 
             expect(called) == true
-            expect(calledTarget).toNot(beNil())
+            expect(calledTarget) == target
         }
 
         it("notifies at the end of network requests") {
             var called = false
-            var calledTarget: TargetType?
+            var calledTarget: GitHub?
 
             let plugin = NetworkActivityPlugin { change, target in
                 if change == .ended {
                     called = true
-                    calledTarget = target
+                    calledTarget = target as? GitHub
                 }
             }
 
@@ -143,7 +143,7 @@ class MoyaProviderSpec: QuickSpec {
             provider.request(target) { _ in  }
 
             expect(called) == true
-            expect(calledTarget).toNot(beNil())
+            expect(calledTarget) == target
         }
 
         describe("a provider with delayed stubs") {

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -110,9 +110,12 @@ class MoyaProviderSpec: QuickSpec {
 
         it("notifies at the beginning of network requests") {
             var called = false
-            let plugin = NetworkActivityPlugin { (change) -> Void in
+            var calledTarget: TargetType?
+
+            let plugin = NetworkActivityPlugin { change, target in
                 if change == .began {
                     called = true
+                    calledTarget = target
                 }
             }
 
@@ -121,13 +124,17 @@ class MoyaProviderSpec: QuickSpec {
             provider.request(target) { _ in  }
 
             expect(called) == true
+            expect(calledTarget).toNot(beNil())
         }
 
         it("notifies at the end of network requests") {
             var called = false
-            let plugin = NetworkActivityPlugin { (change) -> Void in
+            var calledTarget: TargetType?
+
+            let plugin = NetworkActivityPlugin { change, target in
                 if change == .ended {
                     called = true
+                    calledTarget = target
                 }
             }
 
@@ -136,6 +143,7 @@ class MoyaProviderSpec: QuickSpec {
             provider.request(target) { _ in  }
 
             expect(called) == true
+            expect(calledTarget).toNot(beNil())
         }
 
         describe("a provider with delayed stubs") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -50,6 +50,17 @@ extension GitHub: TargetType {
     }
 }
 
+extension GitHub: Equatable {
+
+    static func ==(lhs: GitHub, rhs: GitHub) -> Bool {
+        switch (lhs, rhs) {
+        case (.zen, .zen): return true
+        case let (.userProfile(username1), .userProfile(username2)): return username1 == username2
+        default: return false
+        }
+    }
+}
+
 func url(_ route: TargetType) -> String {
     return route.baseURL.appendingPathComponent(route.path).absoluteString
 }

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -147,29 +147,29 @@ For example you can enable the logger plugin by simply passing `[NetworkLoggerPl
 ```swift
 public final class NetworkActivityPlugin: PluginType {
 
-    public typealias NetworkActivityClosure = (change: NetworkActivityChangeType) -> ()
+    public typealias NetworkActivityClosure = (_ change: NetworkActivityChangeType, _ target: TargetType) -> Void
     let networkActivityClosure: NetworkActivityClosure
 
-    public init(networkActivityClosure: NetworkActivityClosure) {
+    public init(networkActivityClosure: @escaping NetworkActivityClosure) {
         self.networkActivityClosure = networkActivityClosure
     }
 
     // MARK: Plugin
 
     /// Called by the provider as soon as the request is about to start
-    public func willSend(request: RequestType, target: TargetType) {
-        networkActivityClosure(change: .began)
+    public func willSend(_ request: RequestType, target: TargetType) {
+        networkActivityClosure(.began, target)
     }
 
-    /// Called by the provider as soon as a response arrives
-    public func didReceive(data: Data?, statusCode: Int?, response: URLResponse?, error: ErrorType?, target: TargetType) {
-        networkActivityClosure(change: .ended)
+    /// Called by the provider as soon as a response arrives, even if the request is canceled.
+    public func didReceive(_ result: Result<Moya.Response, MoyaError>, target: TargetType) {
+        networkActivityClosure(.ended, target)
     }
 }
 ```
 
 The `networkActivityClosure` is a closure that you can provide to be notified whenever a network request begins or
 ends. This is useful for working with the [network activity indicator](https://github.com/thoughtbot/BOTNetworkActivityIndicator).
-Note that signature of this closure is `(change: NetworkActivityChangeType) -> ()`,
-so you will only be notified when a request has `.began` or `.ended` –
+Note that signature of this closure is `(_ change: NetworkActivityChangeType, _ target: TargetType) -> Void`,
+so you will only be notified when a request has `.began`/`.ended` and for which `target` –
 you aren't provided any other details about the request itself.


### PR DESCRIPTION
Related: #1184 and #1253. I'm also using new Changelog guidelines which are in progress ([here](https://github.com/Moya/contributors/pull/16#issuecomment-329842616) is the PR with it so you can discuss it), if anything we will just change the syntax later.