### PR TITLE
Set indentWith and tabWidth in project settings

### DIFF
--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -264,7 +264,9 @@
 				9A58CD622B8FBB54907843BE /* Sources */,
 				1952C4A00E2EF89FFE965603 /* Tests */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		536E44826931EEDF3B8DFED4 /* Plugins */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
These settings help people to use same indentation in Moya.xcodeproj. These settings have higher priority than the indentation setting in Xcode.

<img width="1512" alt="screen shot 2017-09-26 at 9 17 00 pm" src="https://user-images.githubusercontent.com/931655/30859809-195c92d4-a300-11e7-9626-dd32c83d5120.png">
