### PR TITLE
Add support for mapping response to Decodable object

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 ### Added
 - **Breaking Change** `.parameterEncoding(Swift.Error)` case to `MoyaError`. [#1248](https://github.com/Moya/Moya/pull/1248) by [@SD10](https://github.com/SD10).
+- **Breaking Change** Added `Decodable` object mapping methods to `Moya.Response`. [#1335](https://github.com/Moya/Moya/pull/1335) by [@devxoul](https://github.com/devxoul).
 
 ### Changed
 - **Breaking Change** `Endpoint.init` so it doesn't have any default arguments (removing default argument `.get` for `method` parameter and `nil` for  `httpHeaderFields` parameter). [#1289](https://github.com/Moya/Moya/pull/1289) by [@sunshinejr](https://github.com/sunshinejr).

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Next
 ### Added
 - **Breaking Change** `.parameterEncoding(Swift.Error)` case to `MoyaError`. [#1248](https://github.com/Moya/Moya/pull/1248) by [@SD10](https://github.com/SD10).
-- **Breaking Change** Added `Decodable` object mapping methods to `Moya.Response`. [#1335](https://github.com/Moya/Moya/pull/1335) by [@devxoul](https://github.com/devxoul).
+- **Breaking Change** `Decodable` object mapping methods to `Moya.Response`. [#1335](https://github.com/Moya/Moya/pull/1335) by [@devxoul](https://github.com/devxoul).
 
 ### Changed
 - **Breaking Change** `Endpoint.init` so it doesn't have any default arguments (removing default argument `.get` for `method` parameter and `nil` for  `httpHeaderFields` parameter). [#1289](https://github.com/Moya/Moya/pull/1289) by [@sunshinejr](https://github.com/sunshinejr).

--- a/Sources/Moya/MoyaError.swift
+++ b/Sources/Moya/MoyaError.swift
@@ -11,6 +11,9 @@ public enum MoyaError: Swift.Error {
     /// Indicates a response failed to map to a String.
     case stringMapping(Response)
 
+    /// Indicates a response failed to map to a Decodable object.
+    case objectMapping(Swift.Error, Response)
+
     /// Indicates a response failed with an invalid HTTP status code.
     case statusCode(Response)
 
@@ -31,6 +34,7 @@ public extension MoyaError {
         case .imageMapping(let response): return response
         case .jsonMapping(let response): return response
         case .stringMapping(let response): return response
+        case .objectMapping(_, let response): return response
         case .statusCode(let response): return response
         case .underlying(_, let response): return response
         case .requestMapping: return nil
@@ -50,6 +54,8 @@ extension MoyaError: LocalizedError {
             return "Failed to map data to JSON."
         case .stringMapping:
             return "Failed to map data to a String."
+        case .objectMapping:
+            return "Failed to map data to a Decodable object."
         case .statusCode:
             return "Status code didn't fall within the given range."
         case .requestMapping:

--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -116,4 +116,29 @@ public extension Response {
             return string
         }
     }
+
+    /// Maps data received from the signal into a Decodable object.
+    ///
+    /// - parameter atKeyPath: Optional key path at which to parse object.
+    /// - parameter using: A `JSONDecoder` instance which is used to decode data to an object.
+    func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder()) throws -> D {
+        let jsonData: Data
+        if let keyPath = keyPath {
+            guard let jsonDictionary = (try mapJSON() as? NSDictionary)?.value(forKeyPath: keyPath) as? [String: Any] else {
+                throw MoyaError.jsonMapping(self)
+            }
+            do {
+                jsonData = try JSONSerialization.data(withJSONObject: jsonDictionary, options: [])
+            } catch {
+                throw MoyaError.jsonMapping(self)
+            }
+        } else {
+            jsonData = data
+        }
+        do {
+            return try decoder.decode(D.self, from: jsonData)
+        } catch let error {
+            throw MoyaError.objectMapping(error, self)
+        }
+    }
 }

--- a/Sources/ReactiveMoya/SignalProducer+Response.swift
+++ b/Sources/ReactiveMoya/SignalProducer+Response.swift
@@ -52,6 +52,13 @@ extension SignalProducerProtocol where Value == Response, Error == MoyaError {
             return unwrapThrowable { try response.mapString(atKeyPath: keyPath) }
         }
     }
+
+    /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
+    public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder()) -> SignalProducer<D, MoyaError> {
+        return producer.flatMap(.latest) { response -> SignalProducer<D, MoyaError> in
+            return unwrapThrowable { try response.map(type, atKeyPath: keyPath, using: decoder) }
+        }
+    }
 }
 
 /// Maps throwable to SignalProducer.

--- a/Sources/RxMoya/Observable+Response.swift
+++ b/Sources/RxMoya/Observable+Response.swift
@@ -52,6 +52,13 @@ extension ObservableType where E == Response {
             return Observable.just(try response.mapString(atKeyPath: keyPath))
         }
     }
+
+    /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
+    public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder()) -> Observable<D> {
+        return flatMap { response -> Observable<D> in
+            return Observable.just(try response.map(type, atKeyPath: keyPath, using: decoder))
+        }
+    }
 }
 
 extension ObservableType where E == ProgressResponse {

--- a/Sources/RxMoya/Single+Response.swift
+++ b/Sources/RxMoya/Single+Response.swift
@@ -52,4 +52,11 @@ extension PrimitiveSequence where TraitType == SingleTrait, ElementType == Respo
             return Single.just(try response.mapString(atKeyPath: keyPath))
         }
     }
+
+    /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
+    public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder()) -> Single<D> {
+        return flatMap { response -> Single<D> in
+            return Single.just(try response.map(type, atKeyPath: keyPath, using: decoder))
+        }
+    }
 }

--- a/Tests/Error+MoyaSpec.swift
+++ b/Tests/Error+MoyaSpec.swift
@@ -27,6 +27,13 @@ public func beOfSameErrorType(_ expectedValue: MoyaError) -> Predicate<MoyaError
                 default:
                     test = false
                 }
+            case .objectMapping:
+                switch expectedValue {
+                case .objectMapping:
+                    test = true
+                default:
+                    test = false
+                }
             case .statusCode:
                 switch expectedValue {
                 case .statusCode:

--- a/Tests/Observable+MoyaSpec.swift
+++ b/Tests/Observable+MoyaSpec.swift
@@ -266,5 +266,92 @@ class ObservableMoyaSpec: QuickSpec {
                 expect(receivedError).to(beOfSameErrorType(expectedError))
             }
         }
+
+        describe("object mapping") {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .formatted(formatter)
+
+            let json: [String: Any] = [
+                "title": "Hello, Moya!",
+                "createdAt": "1995-01-14T12:34:56"
+            ]
+
+            it("maps data representing a json to a decodable object") {
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let observable = Response(statusCode: 200, data: data).asObservable()
+
+                var receivedObject: Issue?
+                _ = observable.map(Issue.self, using: decoder).subscribe(onNext: { object in
+                    receivedObject = object
+                })
+                expect(receivedObject).notTo(beNil())
+                expect(receivedObject?.title) == "Hello, Moya!"
+                expect(receivedObject?.createdAt) == formatter.date(from: "1995-01-14T12:34:56")!
+            }
+
+            it("maps data representing a json array to an array of decodable objects") {
+                let jsonArray = [json, json, json]
+                guard let data = try? JSONSerialization.data(withJSONObject: jsonArray, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let observable = Response(statusCode: 200, data: data).asObservable()
+
+                var receivedObjects: [Issue]?
+                _ = observable.map([Issue].self, using: decoder).subscribe(onNext: { objects in
+                    receivedObjects = objects
+                })
+                expect(receivedObjects).notTo(beNil())
+                expect(receivedObjects?.count) == 3
+                expect(receivedObjects?.map { $0.title }) == ["Hello, Moya!", "Hello, Moya!", "Hello, Moya!"]
+            }
+
+            it("maps data representing a json at a key path to a decodable object") {
+                let json: [String: Any] = ["issue": json] // nested json
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let observable = Response(statusCode: 200, data: data).asObservable()
+
+                var receivedObject: Issue?
+                _ = observable.map(Issue.self, atKeyPath: "issue", using: decoder).subscribe(onNext: { object in
+                    receivedObject = object
+                })
+                expect(receivedObject).notTo(beNil())
+                expect(receivedObject?.title) == "Hello, Moya!"
+                expect(receivedObject?.createdAt) == formatter.date(from: "1995-01-14T12:34:56")!
+            }
+
+            it("ignores invalid data") {
+                var json = json
+                json["createdAt"] = "Hahaha" // invalid date string
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let observable = Response(statusCode: 200, data: data).asObservable()
+
+                var receivedError: Error?
+                _ = observable.map(Issue.self, using: decoder).subscribe { event in
+                    switch event {
+                    case .next:
+                        fail("next called for invalid data")
+                    case .error(let error):
+                        receivedError = error
+                    default:
+                        break
+                    }
+                }
+
+                if case let MoyaError.objectMapping(nestedError, _)? = receivedError {
+                    expect(nestedError).to(beAKindOf(DecodingError.self))
+                } else {
+                    fail("expected <MoyaError.objectMapping>, got <\(String(describing: receivedError))>")
+                }
+            }
+        }
     }
 }

--- a/Tests/SignalProducer+MoyaSpec.swift
+++ b/Tests/SignalProducer+MoyaSpec.swift
@@ -251,5 +251,90 @@ class SignalProducerMoyaSpec: QuickSpec {
                 expect(receivedError).to(beOfSameErrorType(expectedError))
             }
         }
+
+        describe("object mapping") {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .formatted(formatter)
+
+            let json: [String: Any] = [
+                "title": "Hello, Moya!",
+                "createdAt": "1995-01-14T12:34:56"
+            ]
+
+            it("maps data representing a json to a decodable object") {
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let signal = signalSendingData(data)
+
+                var receivedObject: Issue?
+                _ = signal.map(Issue.self, using: decoder).startWithResult { result in
+                    receivedObject = result.value
+                }
+                expect(receivedObject).notTo(beNil())
+                expect(receivedObject?.title) == "Hello, Moya!"
+                expect(receivedObject?.createdAt) == formatter.date(from: "1995-01-14T12:34:56")!
+            }
+
+            it("maps data representing a json array to an array of decodable objects") {
+                let jsonArray = [json, json, json]
+                guard let data = try? JSONSerialization.data(withJSONObject: jsonArray, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let signal = signalSendingData(data)
+
+                var receivedObjects: [Issue]?
+                _ = signal.map([Issue].self, using: decoder).startWithResult { result in
+                    receivedObjects = result.value
+                }
+                expect(receivedObjects).notTo(beNil())
+                expect(receivedObjects?.count) == 3
+                expect(receivedObjects?.map { $0.title }) == ["Hello, Moya!", "Hello, Moya!", "Hello, Moya!"]
+            }
+
+            it("maps data representing a json at a key path to a decodable object") {
+                let json: [String: Any] = ["issue": json] // nested json
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let signal = signalSendingData(data)
+
+                var receivedObject: Issue?
+                _ = signal.map(Issue.self, atKeyPath: "issue", using: decoder).startWithResult { result in
+                    receivedObject = result.value
+                }
+                expect(receivedObject).notTo(beNil())
+                expect(receivedObject?.title) == "Hello, Moya!"
+                expect(receivedObject?.createdAt) == formatter.date(from: "1995-01-14T12:34:56")!
+            }
+
+            it("ignores invalid data") {
+                var json = json
+                json["createdAt"] = "Hahaha" // invalid date string
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    preconditionFailure("Failed creating Data from JSON dictionary")
+                }
+                let signal = signalSendingData(data)
+
+                var receivedError: Error?
+                _ = signal.map(Issue.self, using: decoder).startWithResult { result in
+                    switch result {
+                    case .success:
+                        fail("next called for invalid data")
+                    case .failure(let error):
+                        receivedError = error
+                    }
+                }
+
+                if case let MoyaError.objectMapping(nestedError, _)? = receivedError {
+                    expect(nestedError).to(beAKindOf(DecodingError.self))
+                } else {
+                    fail("expected <MoyaError.objectMapping>, got <\(String(describing: receivedError))>")
+                }
+            }
+        }
     }
 }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -220,3 +220,9 @@ extension ImageType {
         }
     #endif
 }
+
+// A fixture for testing Decodable mapping
+struct Issue: Codable {
+    let title: String
+    let createdAt: Date
+}

--- a/docs/Examples/ErrorTypes.md
+++ b/docs/Examples/ErrorTypes.md
@@ -33,6 +33,9 @@ case .statusCode(let response):
     print(response)
 case .stringMapping(let response):
     print(response)
+case objectMapping(let error, let response):
+    // error is DecodingError
+    print(response)
 case .underlying(let nsError as NSError, let response):
     // now can access NSError error.code or whatever
     // e.g. NSURLErrorTimedOut or NSURLErrorNotConnectedToInternet


### PR DESCRIPTION
* Resolves #1118
* I recommend you to see commit logs first before reading code.
* Adds `MoyaError.objectMapping(Error, Response)` which contains a `DecodingError` to make it easy to inspect a decoding error.
* Interfaces:

    ```swift
    // Response -> D
    func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder) throws -> D

    // Obsevable<Response> -> Observable<D>
    func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder) throws -> Observable<D>

    // Single<Response> -> Single<D>
    func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder) throws -> Single<D>

    // SignalProducer<Response, MoyaError> -> SignalProducer<D, MoyaError>
    func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder) throws -> SignalProducer<D, MoyaError>
    ```
