### PR TITLE
Chore: replace addDisposableTo method from RxSwift

### DIFF
--- a/Tests/MoyaProvider+RxSpec.swift
+++ b/Tests/MoyaProvider+RxSpec.swift
@@ -223,7 +223,7 @@ final class MoyaProviderRxSpec: QuickSpec {
                                     .subscribe(onSuccess: { _ in
                                         callbackQueueLabel = DispatchQueue.currentLabel
                                         completion()
-                                    }).addDisposableTo(disposeBag)
+                                    }).disposed(by: disposeBag)
                             })
 
                             expect(callbackQueueLabel) == requestQueue.label
@@ -239,7 +239,7 @@ final class MoyaProviderRxSpec: QuickSpec {
                                     .subscribe(onSuccess: { _ in
                                         callbackQueueLabel = DispatchQueue.currentLabel
                                         completion()
-                                    }).addDisposableTo(disposeBag)
+                                    }).disposed(by: disposeBag)
                             })
 
                             expect(callbackQueueLabel) == callbackQueue.label
@@ -267,7 +267,7 @@ final class MoyaProviderRxSpec: QuickSpec {
                                     .subscribe(onSuccess: { _ in
                                         callbackQueueLabel = DispatchQueue.currentLabel
                                         completion()
-                                    }).addDisposableTo(disposeBag)
+                                    }).disposed(by: disposeBag)
                             })
 
                             expect(callbackQueueLabel) == requestQueue.label
@@ -283,7 +283,7 @@ final class MoyaProviderRxSpec: QuickSpec {
                                     .subscribe(onSuccess: { _ in
                                         callbackQueueLabel = DispatchQueue.currentLabel
                                         completion()
-                                    }).addDisposableTo(disposeBag)
+                                    }).disposed(by: disposeBag)
                             })
 
                             expect(callbackQueueLabel) == DispatchQueue.main.label


### PR DESCRIPTION

Replacing the method `addDisposableTo` for `disposed(by:)` since the former as been deprecated as of RxSwift 4.0.