### PR TITLE
Fix SPM instructions for Moya 10.0.0-beta.1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,12 +95,12 @@ let package = Package(
             targets: ["MyPackage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Moya/Moya.git", .exact(Version(10, 0, 0, prereleaseIdentifiers: ["beta", "1"])))
+        .package(url: "https://github.com/Moya/Moya.git", .exact("10.0.0-beta.1")
     ],
     targets: [
         .target(
             name: "MyPackage",
-            dependencies: ["Moya", "ReactiveMoya"])
+            dependencies: ["ReactiveMoya"])
     ]
 )
 ```


### PR DESCRIPTION
Basically, we don't have to write this long Version initializer - `String` literal works as well! Also when you specify that you want `ReactiveMoya` as a dependency, it has `Moya` as a dependency itself so no need to dupe.