### PR TITLE
Remove ReactiveCocoa subspec

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -27,10 +27,6 @@ Pod::Spec.new do |s|
     ss.framework  = "Foundation"
   end
 
-  s.subspec "ReactiveCocoa" do |ss|
-    ss.dependency "Moya/ReactiveSwift"
-  end
-
   s.subspec "ReactiveSwift" do |ss|
     ss.source_files = "Sources/ReactiveMoya/"
     ss.dependency "Moya/Core"

--- a/docs/MigrationGuides/migration_9_to_10.md
+++ b/docs/MigrationGuides/migration_9_to_10.md
@@ -15,3 +15,6 @@ This project follows [Semantic Versioning](http://semver.org).
 
 ### NetworkActivityPlugin Migration
 - Add `TargetType` as second argument of `NetworkActivityClosure` in `NetworkActivityPlugin` initializer.
+
+### ReactiveCocoa subspec Migration
+- Replace `pod 'Moya/ReactiveCocoa'` with `pod 'Moya/ReactiveSwift'` in your Podfile.


### PR DESCRIPTION
This has been deprecated for quite some time. Only thing is that we can't really let the user know that it has been deprecated. If we do not feel like removing it, feel free to close this PR.