### PR TITLE
Test out danger swift on a mac CI build

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,8 @@
+import Danger
+
+let danger = Danger()
+for file in danger.git.modifiedFiles {
+    print(" - " + file)
+}
+
+message("Just verifying this works")

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'cocoapods'
 gem 'rake'
 gem 'octokit', '~> 4.3'
 
-gem 'danger'
-gem 'danger-swiftlint'
+# gem 'danger'
+# gem 'danger-swiftlint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,6 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     claide (1.0.1)
-    claide-plugins (0.9.2)
-      cork
-      nap
-      open4 (~> 1.3)
     cocoapods (1.2.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.1, < 2.0)
@@ -48,34 +44,13 @@ GEM
       netrc (= 0.7.8)
     cocoapods-try (1.1.0)
     colored2 (3.1.2)
-    cork (0.3.0)
-      colored2 (~> 3.1)
-    danger (5.2.1)
-      claide (~> 1.0)
-      claide-plugins (>= 0.9.2)
-      colored2 (~> 3.1)
-      cork (~> 0.1)
-      faraday (~> 0.9)
-      faraday-http-cache (~> 1.0)
-      git (~> 1)
-      kramdown (~> 1.5)
-      octokit (~> 4.2)
-      terminal-table (~> 1)
-    danger-swiftlint (0.5.0)
-      danger
-      rake (~> 10.0)
-      thor (~> 0.19)
     escape (0.0.4)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.1)
-      faraday (~> 0.8)
     fourflusher (2.0.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.0.3)
-    git (1.3.0)
     i18n (0.8.1)
-    kramdown (1.13.2)
     minitest (5.10.1)
     molinillo (0.5.7)
     multipart-post (2.0.0)
@@ -84,7 +59,6 @@ GEM
     netrc (0.7.8)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    open4 (1.3.4)
     public_suffix (2.0.5)
     rake (10.5.0)
     rouge (2.0.7)
@@ -92,13 +66,9 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    terminal-table (1.7.3)
-      unicode-display_width (~> 1.1.1)
-    thor (0.19.4)
     thread_safe (0.3.6)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    unicode-display_width (1.1.3)
     xcodeproj (1.4.4)
       CFPropertyList (~> 2.3.3)
       claide (>= 1.0.1, < 2.0)
@@ -112,11 +82,9 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods
-  danger
-  danger-swiftlint
   octokit (~> 4.3)
   rake
   xcpretty
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/circle.yml
+++ b/circle.yml
@@ -20,5 +20,8 @@ test:
   override:
   - rake test && rake test:carthage && rake build_example
   post:
-    - bundle exec danger
+    - npm install -g danger@alpha
+    - brew install danger/tap/danger-swift
+    - danger process danger-swift
+
     - bash <(curl -s https://codecov.io/bash) -J Moya

--- a/circle.yml
+++ b/circle.yml
@@ -6,19 +6,20 @@ machine:
 
 dependencies:
   pre:
-    - curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
+    # - curl -sS https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
   override:
-    - brew update ; brew update # Due to a problem with Homebrew, see: https://github.com/Homebrew/brew/issues/991
-    - brew install swiftlint
-    - bundle install
-    - scripts/bootstrap-if-needed.sh # only bootstrap if we have updated dependencies since our last cache.
+    # - brew update ; brew update # Due to a problem with Homebrew, see: https://github.com/Homebrew/brew/issues/991
+    # - brew install swiftlint
+    # - bundle install
+    # - scripts/bootstrap-if-needed.sh # only bootstrap if we have updated dependencies since our last cache.
   cache_directories:
     - "Carthage" # Cache carthage to speed up builds.
 
 test:
   pre:
   override:
-  - rake test && rake test:carthage && rake build_example
+    - echo 'hi'
+  # - rake test && rake test:carthage && rake build_example
   post:
     - npm install -g danger@alpha
     - brew install danger/tap/danger-swift


### PR DESCRIPTION
Circle CI has always been a dodgy case with Danger ( they don't reliably set CI env vars ) so it's hard to tell whether this will work, but now  that https://github.com/danger/danger-swift/pull/27 is in, this should allow libs to use Danger Swift.