### PR TITLE
tighten up our stale rules to 2 weeks #fortnight

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -25,7 +25,7 @@ unmarkComment: false
 
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
 closeComment: >
-  This issue has been auto-closed because there hasn't been any activity for at least 37 days.
+  This issue has been auto-closed because there hasn't been any activity for at least 21 days.
   However, we really appreciate your contribution, so thank you for that! 🙏
   Also, feel free to [open a new issue](https://github.com/Moya/Moya/issues/new) if you still experience this problem 👍.
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 30
+daysUntilStale: 14
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed
 daysUntilClose: 7


### PR DESCRIPTION
I think we're doing a good job at dealing with issues and even better than our stalebot. I think leaning on our bot is a good idea, and I can see us changing this to just a week some time in the future.

2 weeks is a good target for now (+1 week for it to actually close)