### PR TITLE
Add .custom option to AuthorizationType of AccessTokenPlugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Next
+### Added
+- Added a `.custom` case to `AuthorizationType`. [#1393](https://github.com/Moya/Moya/pull/1393) by [ffittschen](https://github.com/ffittschen).
 
 # [10.0.0] - 2017-10-21
 ### Fixed

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -13,10 +13,45 @@ public protocol AccessTokenAuthorizable {
 // MARK: - AuthorizationType
 
 /// An enum representing the header to use with an `AccessTokenPlugin`
-public enum AuthorizationType: String {
+public enum AuthorizationType {
     case none
-    case basic = "Basic"
-    case bearer = "Bearer"
+    case basic
+    case bearer
+    case custom(headerField: String?, tokenPrefix: String?)
+}
+
+private extension AuthorizationType {
+    static let defaultHeaderField = "Authorization"
+
+    var headerField: String {
+        switch self {
+        case .basic, .bearer:
+            return AuthorizationType.defaultHeaderField
+        case .custom(let headerField, _):
+            guard let headerField = headerField, !headerField.isEmpty else {
+                return AuthorizationType.defaultHeaderField
+            }
+            return headerField
+        case .none:
+            return ""
+        }
+    }
+
+    var tokenPrefix: String {
+        switch self {
+        case .basic:
+            return "Basic "
+        case .bearer:
+            return "Bearer "
+        case .custom(_, let tokenPrefix):
+            guard let tokenPrefix = tokenPrefix, !tokenPrefix.isEmpty else {
+                return ""
+            }
+            return tokenPrefix + " "
+        case .none:
+            return ""
+        }
+    }
 }
 
 // MARK: - AccessTokenPlugin
@@ -27,6 +62,7 @@ public enum AuthorizationType: String {
  ```
  Authorization: Bearer <token>
  Authorization: Basic <token>
+ X-Access-Token: <token>
  ```
 
 */
@@ -39,7 +75,7 @@ public struct AccessTokenPlugin: PluginType {
      Initialize a new `AccessTokenPlugin`.
 
      - parameters:
-       - tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthorizationType> <token>`
+       - tokenClosure: A closure returning the token to be applied in the pattern `<HeaderField>: <AuthorizationType> <token>`
     */
     public init(tokenClosure: @escaping @autoclosure () -> String) {
         self.tokenClosure = tokenClosure
@@ -55,15 +91,13 @@ public struct AccessTokenPlugin: PluginType {
     */
     public func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
         guard let authorizable = target as? AccessTokenAuthorizable else { return request }
-
         let authorizationType = authorizable.authorizationType
-
         var request = request
 
         switch authorizationType {
-        case .basic, .bearer:
-            let authValue = authorizationType.rawValue + " " + tokenClosure()
-            request.addValue(authValue, forHTTPHeaderField: "Authorization")
+        case .basic, .bearer, .custom:
+            let authValue = authorizationType.tokenPrefix + tokenClosure()
+            request.addValue(authValue, forHTTPHeaderField: authorizationType.headerField)
         case .none:
             break
         }

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -47,5 +47,30 @@ final class AccessTokenPluginSpec: QuickSpec {
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Basic eyeAm.AJsoN.weBTOKen"]
         }
 
+        it("adds a custom header to AccessTokenAuthorizables when AuthorizationType is .custom") {
+            let target = TestTarget(authorizationType: .custom(headerField: "X-Access-Token", tokenPrefix: "Bearer"))
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            expect(preparedRequest.allHTTPHeaderFields) == ["X-Access-Token": "Bearer eyeAm.AJsoN.weBTOKen"]
+        }
+
+        describe(".custom AuthorizationType") {
+            context("when custom header is empty") {
+                it("uses the default 'Authorization' header") {
+                    let target = TestTarget(authorizationType: .custom(headerField: "", tokenPrefix: "Bearer"))
+                    let request = URLRequest(url: target.baseURL)
+                    let preparedRequest = plugin.prepare(request, target: target)
+                    expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Bearer eyeAm.AJsoN.weBTOKen"]
+                }
+            }
+            context("when token prefix is empty") {
+                it("does not prepend anything to the token") {
+                    let target = TestTarget(authorizationType: .custom(headerField: "X-Access-Token", tokenPrefix: ""))
+                    let request = URLRequest(url: target.baseURL)
+                    let preparedRequest = plugin.prepare(request, target: target)
+                    expect(preparedRequest.allHTTPHeaderFields) == ["X-Access-Token": "eyeAm.AJsoN.weBTOKen"]
+                }
+            }
+        }
     }
 }

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -34,7 +34,7 @@ let provider = MoyaProvider<YourAPI>(plugins: [CredentialsPlugin { target -> URL
 ## Access Token Auth
 Another common method of authentication is by using an access token.
 Moya provides an `AccessTokenPlugin` that supports both `Bearer` authentication
-using a [JWT](https://jwt.io/introduction/) and `Basic` authentication for API keys.
+using a [JWT](https://jwt.io/introduction/) and `Basic` authentication for API keys, and it also allows customization of the header field or token prefix.
 
 There are two steps required to start using an `AccessTokenPlugin`.
 
@@ -53,6 +53,7 @@ for returning the token to be applied to the header of the request.
 extension YourAPI: TargetType, AccessTokenAuthorizable {
     case targetThatNeedsBearerAuth
     case targetThatNeedsBasicAuth
+    case targetThatNeedsCustomAuth
     case targetDoesNotNeedAuth
 
     var authorizationType: AuthorizationType {
@@ -61,6 +62,8 @@ extension YourAPI: TargetType, AccessTokenAuthorizable {
                 return .bearer
             case .targetThatNeedsBasicAuth:
                 return .basic
+            case .targetThatNeedsCustomAuth:
+                return .custom(headerField: "X-Access-Token", tokenPrefix: nil)
             case .targetDoesNotNeedAuth:
                 return .none
             }
@@ -85,6 +88,22 @@ Basic requests are authorized by adding a HTTP header of the following form:
 ```
 Authorization: Basic <token>
 ```
+
+**Custom Auth**
+Requests that require a custom header field (that differs from the default `Authorization` header), or requests that require a custom prefix for the token are authorized by adding a HTTP header of the following form:
+
+```
+<headerField>: <tokenPrefix> <token>
+
+// Examples:
+// .custom(headerField: nil, tokenPrefix: "JWT")
+Authorization: JWT <token>
+
+// .custom(headerField: "X-Access-Token", tokenPrefix: nil)
+X-Access-Token: <token>
+```
+
+Note: When the `headerField` is `nil` or an empty String, the default header of `Authorization` will be used.
 
 ## OAuth
 


### PR DESCRIPTION
#### Description
This PR adds a `.custom` option to the `AuthorizationType` of the `AccessTokenPlugin`, which enables to specify a custom header field and a custom token prefix.

```swift
// Examples:
.custom(headerField: nil, tokenPrefix: "JWT")
// will result in this header 'Authorization: JWT <token>'

.custom(headerField: "X-Access-Token", tokenPrefix: nil)
// will result in this header 'X-Access-Token: <token>'
```

#### Motivation
I recently used Moya in a project of mine and the backend it interacts with requires me to use `x-access-token` as header field and it also requires that only the token value is set as value in that header. I was about to create a `CustomAccessTokenPlugin` in my project, but I thought that there might be other developers who are in a similar situation, so I created this PR instead.

Please let me know what you think and if you require any changes :)