### PR TITLE
Remove redundant reactive abstractions

### DIFF
--- a/Sources/RxMoya/MoyaProvider+Rx.swift
+++ b/Sources/RxMoya/MoyaProvider+Rx.swift
@@ -15,20 +15,8 @@ public extension Reactive where Base: MoyaProviderType {
     ///   - callbackQueue: Callback queue. If nil - queue from provider initializer will be used.
     /// - Returns: Single response object.
     public func request(_ token: Base.Target, callbackQueue: DispatchQueue? = nil) -> Single<Response> {
-        return base.rxRequest(token, callbackQueue: callbackQueue)
-    }
-
-    /// Designated request-making method with progress.
-    public func requestWithProgress(_ token: Base.Target, callbackQueue: DispatchQueue? = nil) -> Observable<ProgressResponse> {
-        return base.rxRequestWithProgress(token, callbackQueue: callbackQueue)
-    }
-}
-
-internal extension MoyaProviderType {
-
-    internal func rxRequest(_ token: Target, callbackQueue: DispatchQueue? = nil) -> Single<Response> {
-        return Single.create { [weak self] single in
-            let cancellableToken = self?.request(token, callbackQueue: callbackQueue, progress: nil) { result in
+        return Single.create { [weak base] single in
+            let cancellableToken = base?.request(token, callbackQueue: callbackQueue, progress: nil) { result in
                 switch result {
                 case let .success(response):
                     single(.success(response))
@@ -43,15 +31,16 @@ internal extension MoyaProviderType {
         }
     }
 
-    internal func rxRequestWithProgress(_ token: Target, callbackQueue: DispatchQueue? = nil) -> Observable<ProgressResponse> {
+    /// Designated request-making method with progress.
+    public func requestWithProgress(_ token: Base.Target, callbackQueue: DispatchQueue? = nil) -> Observable<ProgressResponse> {
         let progressBlock: (AnyObserver) -> (ProgressResponse) -> Void = { observer in
             return { progress in
                 observer.onNext(progress)
             }
         }
 
-        let response: Observable<ProgressResponse> = Observable.create { [weak self] observer in
-            let cancellableToken = self?.request(token, callbackQueue: callbackQueue, progress: progressBlock(observer)) { result in
+        let response: Observable<ProgressResponse> = Observable.create { [weak base] observer in
+            let cancellableToken = base?.request(token, callbackQueue: callbackQueue, progress: progressBlock(observer)) { result in
                 switch result {
                 case .success:
                     observer.onCompleted()


### PR DESCRIPTION
Fixes #1372.  I also created new branch, `development`, that we should use for the next features/fixes before we make a release (it doesn't need to be the next major, could be a minor/patch, thus general name `development` instead of `11.0.0-dev`).