### PR TITLE
raised ReactiveSwift version dependency 2.0 -> 3.0

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.subspec "ReactiveSwift" do |ss|
     ss.source_files = "Sources/ReactiveMoya/"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveSwift", "~> 2.0"
+    ss.dependency "ReactiveSwift", "~> 3.0"
   end
 
   s.subspec "RxSwift" do |ss|


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  develop: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->

raised version to allow Swift 4 builds using subspecs and third-party dependencies such as https://github.com/ivanbruel/Moya-ObjectMapper which requires ReactiveSwift (3.0.0) and ReactiveCocoa (7.0.0)