### PR TITLE
[WIP] Refactoring Moya's stubbing API

### DIFF
--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		149749431F8923EC00FA4900 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749421F8923EC00FA4900 /* AnyEncodable.swift */; };
 		149749451F892E2F00FA4900 /* URLRequest+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */; };
 		15D3A2BD1223B59E2BBE09F0 /* MoyaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D47F3DC51C28D950491FAAB /* MoyaError.swift */; };
+		1F8AA0BA1FDF45F100C9D7B6 /* MoyaProvider+Stubbing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8AA0B91FDF45F100C9D7B6 /* MoyaProvider+Stubbing.swift */; };
 		1FD44D9E21CEA6B6221807EF /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4553E5591EE96535C5310C02 /* NetworkLoggerPlugin.swift */; };
 		2ADDFC96D7F7912333534C46 /* SignalProducer+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */; };
 		2C7132B56A7B129E12BAACAC /* EndpointSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E825A32256FC030B8BA2684D /* EndpointSpec.swift */; };
@@ -148,6 +149,7 @@
 		149749421F8923EC00FA4900 /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Encoding.swift"; sourceTree = "<group>"; };
 		14FB7A3E1F3E089900308949 /* Single+Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Single+Response.swift"; sourceTree = "<group>"; };
+		1F8AA0B91FDF45F100C9D7B6 /* MoyaProvider+Stubbing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Stubbing.swift"; sourceTree = "<group>"; };
 		225C397C03E17F7DFBCA2848 /* MoyaProvider+Internal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Internal.swift"; sourceTree = "<group>"; };
 		269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SignalProducer+Response.swift"; sourceTree = "<group>"; };
 		2AD20F6A819D899E3278E903 /* NetworkActivityPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkActivityPlugin.swift; sourceTree = "<group>"; };
@@ -335,6 +337,7 @@
 				851FFE6DC58E873408D0E8E7 /* MoyaProvider.swift */,
 				39F87B4349AC772FF766904B /* MoyaProvider+Defaults.swift */,
 				225C397C03E17F7DFBCA2848 /* MoyaProvider+Internal.swift */,
+				1F8AA0B91FDF45F100C9D7B6 /* MoyaProvider+Stubbing.swift */,
 				B184F8E91A84A02E209EEB91 /* MultipartFormData.swift */,
 				8F4EAC41B82FF5081DEC4808 /* MultiTarget.swift */,
 				61A693AF0E88E83E91A47A99 /* Plugin.swift */,
@@ -835,6 +838,7 @@
 				4A609CED953E8A6C59AD01A1 /* NetworkActivityPlugin.swift in Sources */,
 				1FD44D9E21CEA6B6221807EF /* NetworkLoggerPlugin.swift in Sources */,
 				A8C55515DFA147BE4159B40A /* Response.swift in Sources */,
+				1F8AA0BA1FDF45F100C9D7B6 /* MoyaProvider+Stubbing.swift in Sources */,
 				A2B64B2383FB0BC3C17B3160 /* TargetType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -18,20 +18,17 @@ open class Endpoint<Target> {
     public typealias SampleResponseClosure = () -> EndpointSampleResponse
 
     open let url: String
-    open let sampleResponseClosure: SampleResponseClosure
     open let method: Moya.Method
     open let task: Task
     open let httpHeaderFields: [String: String]?
 
     /// Main initializer for `Endpoint`.
     public init(url: String,
-                sampleResponseClosure: @escaping SampleResponseClosure,
                 method: Moya.Method,
                 task: Task,
                 httpHeaderFields: [String: String]?) {
 
         self.url = url
-        self.sampleResponseClosure = sampleResponseClosure
         self.method = method
         self.task = task
         self.httpHeaderFields = httpHeaderFields
@@ -39,12 +36,12 @@ open class Endpoint<Target> {
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with added HTTP header fields.
     open func adding(newHTTPHeaderFields: [String: String]) -> Endpoint<Target> {
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, task: task, httpHeaderFields: add(httpHeaderFields: newHTTPHeaderFields))
+        return Endpoint(url: url, method: method, task: task, httpHeaderFields: add(httpHeaderFields: newHTTPHeaderFields))
     }
 
     /// Convenience method for creating a new `Endpoint` with the same properties as the receiver, but with replaced `task` parameter.
     open func replacing(task: Task) -> Endpoint<Target> {
-        return Endpoint(url: url, sampleResponseClosure: sampleResponseClosure, method: method, task: task, httpHeaderFields: httpHeaderFields)
+        return Endpoint(url: url, method: method, task: task, httpHeaderFields: httpHeaderFields)
     }
 
     fileprivate func add(httpHeaderFields headers: [String: String]?) -> [String: String]? {

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -5,7 +5,6 @@ public extension MoyaProvider {
     public final class func defaultEndpointMapping(for target: Target) -> Endpoint<Target> {
         return Endpoint(
             url: URL(target: target).absoluteString,
-            sampleResponseClosure: { .networkResponse(200, target.sampleData) },
             method: target.method,
             task: target.task,
             httpHeaderFields: target.headers

--- a/Sources/Moya/MoyaProvider+Stubbing.swift
+++ b/Sources/Moya/MoyaProvider+Stubbing.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Mark: Stubbing
+
+/// A TargetType configurable for testing responses
+public protocol TestTargetType {
+
+    var stubBehavior: Moya.StubBehavior { get }
+
+    var sampleResponse: EndpointSampleResponse { get }
+
+}
+
+/// Controls how stub responses are returned.
+public enum StubBehavior {
+
+    /// Do not stub.
+    case never
+
+    /// Return a response immediately.
+    case immediate
+
+    /// Return a response after a delay.
+    case delayed(seconds: TimeInterval)
+}
+
+extension MoyaProvider where Target: TestTargetType {
+
+    // swiftlint:disable function_parameter_count
+    /// When overriding this method, take care to `notifyPluginsOfImpendingStub` and to perform the stub using the `createStubFunction` method.
+    /// Note: this was previously in an extension, however it must be in the original class declaration to allow subclasses to override.
+    @discardableResult
+    open func stubRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
+        let callbackQueue = callbackQueue ?? self.callbackQueue
+        let cancellableToken = CancellableToken { }
+        notifyPluginsOfImpendingStub(for: request, target: target)
+        let plugins = self.plugins
+        let stub: () -> Void = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
+        switch stubBehavior {
+        case .immediate:
+            switch callbackQueue {
+            case .none:
+                stub()
+            case .some(let callbackQueue):
+                callbackQueue.async(execute: stub)
+            }
+        case .delayed(let delay):
+            let killTimeOffset = Int64(CDouble(delay) * CDouble(NSEC_PER_SEC))
+            let killTime = DispatchTime.now() + Double(killTimeOffset) / Double(NSEC_PER_SEC)
+            (callbackQueue ?? DispatchQueue.main).asyncAfter(deadline: killTime) {
+                stub()
+            }
+        case .never:
+            fatalError("Method called to stub request when stubbing is disabled.")
+        }
+
+        return cancellableToken
+    }
+    // swiftlint:enable function_parameter_count
+
+    /// Creates a function which, when called, executes the appropriate stubbing behavior for the given parameters.
+    public final func createStubFunction(_ token: CancellableToken, forTarget target: Target, withCompletion completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, plugins: [PluginType], request: URLRequest) -> (() -> Void) { // swiftlint:disable:this function_parameter_count
+        return {
+            if token.isCancelled {
+                self.cancelCompletion(completion, target: target)
+                return
+            }
+
+            switch target.sampleResponse {
+            case .networkResponse(let statusCode, let data):
+                let response = Moya.Response(statusCode: statusCode, data: data, request: request, response: nil)
+                plugins.forEach { $0.didReceive(.success(response), target: target) }
+                completion(.success(response))
+            case .response(let customResponse, let data):
+                let response = Moya.Response(statusCode: customResponse.statusCode, data: data, request: request, response: customResponse)
+                plugins.forEach { $0.didReceive(.success(response), target: target) }
+                completion(.success(response))
+            case .networkError(let error):
+                let error = MoyaError.underlying(error, nil)
+                plugins.forEach { $0.didReceive(.failure(error), target: target) }
+                completion(.failure(error))
+            }
+        }
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    private func performRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>) -> Cancellable {
+        switch target.stubBehavior {
+        case .never:
+            return self.performNormalRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion, endpoint: endpoint)
+        default:
+            return self.stubRequest(target, request: request, callbackQueue: callbackQueue, completion: completion, endpoint: endpoint, stubBehavior: target.stubBehavior)
+        }
+    }
+
+    /// Notify all plugins that a stub is about to be performed. You must call this if overriding `stubRequest`.
+    final func notifyPluginsOfImpendingStub(for request: URLRequest, target: Target) {
+        let alamoRequest = manager.request(request as URLRequestConvertible)
+        plugins.forEach { $0.willSend(alamoRequest, target: target) }
+        alamoRequest.cancel()
+    }
+}

--- a/Sources/Moya/MoyaProvider.swift
+++ b/Sources/Moya/MoyaProvider.swift
@@ -43,12 +43,8 @@ open class MoyaProvider<Target: TargetType>: MoyaProviderType {
     /// Closure that resolves an `Endpoint` into a `RequestResult`.
     public typealias RequestClosure = (Endpoint<Target>, @escaping RequestResultClosure) -> Void
 
-    /// Closure that decides if/how a request should be stubbed.
-    public typealias StubClosure = (Target) -> Moya.StubBehavior
-
     open let endpointClosure: EndpointClosure
     open let requestClosure: RequestClosure
-    open let stubClosure: StubClosure
     open let manager: Manager
 
     /// A list of plugins
@@ -65,7 +61,6 @@ open class MoyaProvider<Target: TargetType>: MoyaProviderType {
     /// Initializes a provider.
     public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
                 requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
-                stubClosure: @escaping StubClosure = MoyaProvider.neverStub,
                 callbackQueue: DispatchQueue? = nil,
                 manager: Manager = MoyaProvider<Target>.defaultAlamofireManager(),
                 plugins: [PluginType] = [],
@@ -73,7 +68,6 @@ open class MoyaProvider<Target: TargetType>: MoyaProviderType {
 
         self.endpointClosure = endpointClosure
         self.requestClosure = requestClosure
-        self.stubClosure = stubClosure
         self.manager = manager
         self.plugins = plugins
         self.trackInflights = trackInflights
@@ -94,71 +88,6 @@ open class MoyaProvider<Target: TargetType>: MoyaProviderType {
 
         let callbackQueue = callbackQueue ?? self.callbackQueue
         return requestNormal(target, callbackQueue: callbackQueue, progress: progress, completion: completion)
-    }
-
-    // swiftlint:disable function_parameter_count
-    /// When overriding this method, take care to `notifyPluginsOfImpendingStub` and to perform the stub using the `createStubFunction` method.
-    /// Note: this was previously in an extension, however it must be in the original class declaration to allow subclasses to override.
-    @discardableResult
-    open func stubRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> CancellableToken {
-        let callbackQueue = callbackQueue ?? self.callbackQueue
-        let cancellableToken = CancellableToken { }
-        notifyPluginsOfImpendingStub(for: request, target: target)
-        let plugins = self.plugins
-        let stub: () -> Void = createStubFunction(cancellableToken, forTarget: target, withCompletion: completion, endpoint: endpoint, plugins: plugins, request: request)
-        switch stubBehavior {
-        case .immediate:
-            switch callbackQueue {
-            case .none:
-                stub()
-            case .some(let callbackQueue):
-                callbackQueue.async(execute: stub)
-            }
-        case .delayed(let delay):
-            let killTimeOffset = Int64(CDouble(delay) * CDouble(NSEC_PER_SEC))
-            let killTime = DispatchTime.now() + Double(killTimeOffset) / Double(NSEC_PER_SEC)
-            (callbackQueue ?? DispatchQueue.main).asyncAfter(deadline: killTime) {
-                stub()
-            }
-        case .never:
-            fatalError("Method called to stub request when stubbing is disabled.")
-        }
-
-        return cancellableToken
-    }
-    // swiftlint:enable function_parameter_count
-}
-
-/// Mark: Stubbing
-
-/// Controls how stub responses are returned.
-public enum StubBehavior {
-
-    /// Do not stub.
-    case never
-
-    /// Return a response immediately.
-    case immediate
-
-    /// Return a response after a delay.
-    case delayed(seconds: TimeInterval)
-}
-
-public extension MoyaProvider {
-
-    // Swift won't let us put the StubBehavior enum inside the provider class, so we'll
-    // at least add some class functions to allow easy access to common stubbing closures.
-
-    public final class func neverStub(_: Target) -> Moya.StubBehavior {
-        return .never
-    }
-
-    public final class func immediatelyStub(_: Target) -> Moya.StubBehavior {
-        return .immediate
-    }
-
-    public final class func delayedStub(_ seconds: TimeInterval) -> (Target) -> Moya.StubBehavior {
-        return { _ in return .delayed(seconds: seconds) }
     }
 }
 

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -21,9 +21,10 @@ public enum MultiTarget: TargetType {
         return target.method
     }
 
-    public var sampleData: Data {
-        return target.sampleData
-    }
+// TODO: - Not sure how this would affect sample data
+//    public var sampleData: Data {
+//        return target.sampleData
+//    }
 
     public var task: Task {
         return target.task

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -12,9 +12,6 @@ public protocol TargetType {
     /// The HTTP method used in the request.
     var method: Moya.Method { get }
 
-    /// Provides stub data for use in testing.
-    var sampleData: Data { get }
-
     /// The type of HTTP task to be performed.
     var task: Task { get }
 

--- a/Tests/EndpointSpec.swift
+++ b/Tests/EndpointSpec.swift
@@ -47,7 +47,7 @@ final class EndpointSpec: QuickSpec {
     private var simpleGitHubEndpoint: Endpoint<GitHub> {
         let target: GitHub = .zen
         let headerFields = ["Title": "Dominar"]
-        return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: Moya.Method.get, task: .requestPlain, httpHeaderFields: headerFields)
+        return Endpoint<GitHub>(url: url(target), method: Moya.Method.get, task: .requestPlain, httpHeaderFields: headerFields)
     }
 
     override func spec() {
@@ -71,7 +71,7 @@ final class EndpointSpec: QuickSpec {
         }
 
         it("returns a nil urlRequest for an invalid URL") {
-            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) }, method: .get, task: .requestPlain, httpHeaderFields: nil)
+            let badEndpoint = Endpoint<Empty>(url: "some invalid URL", method: .get, task: .requestPlain, httpHeaderFields: nil)
             let urlRequest = try? badEndpoint.urlRequest()
             expect(urlRequest).to(beNil())
         }
@@ -252,7 +252,7 @@ final class EndpointSpec: QuickSpec {
         describe("unsuccessful converting to urlRequest") {
             context("when url String is invalid") {
                 it("throws a .requestMapping error") {
-                    let badEndpoint = Endpoint<Empty>(url: "some invalid URL", sampleResponseClosure: { .networkResponse(200, Data()) }, method: .get, task: .requestPlain, httpHeaderFields: nil)
+                    let badEndpoint = Endpoint<Empty>(url: "some invalid URL", method: .get, task: .requestPlain, httpHeaderFields: nil)
                     let expectedError = MoyaError.requestMapping("some invalid URL")
                     var recievedError: MoyaError?
                     do {

--- a/Tests/MoyaProvider+ReactiveSpec.swift
+++ b/Tests/MoyaProvider+ReactiveSpec.swift
@@ -12,7 +12,7 @@ final class MoyaProviderReactiveSpec: QuickSpec {
             var provider: MoyaProvider<GitHub>!
 
             beforeEach {
-                provider = MoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.immediatelyStub)
+                provider = MoyaProvider<GitHub>(endpointClosure: failureEndpointClosure)
             }
 
             it("returns the correct error message") {
@@ -49,7 +49,7 @@ final class MoyaProviderReactiveSpec: QuickSpec {
             var provider: MoyaProvider<GitHub>!
 
             beforeEach {
-                provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.immediatelyStub)
+                provider = MoyaProvider<GitHub>()
             }
 
             it("returns a Response object") {

--- a/Tests/MoyaProvider+RxSpec.swift
+++ b/Tests/MoyaProvider+RxSpec.swift
@@ -12,7 +12,7 @@ final class MoyaProviderRxSpec: QuickSpec {
             var provider: MoyaProvider<GitHub>!
 
             beforeEach {
-                provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.immediatelyStub)
+                provider = MoyaProvider<GitHub>()
             }
 
             it("emits a Response object") {
@@ -58,7 +58,7 @@ final class MoyaProviderRxSpec: QuickSpec {
             var provider: MoyaProvider<GitHub>!
 
             beforeEach {
-                provider = MoyaProvider<GitHub>(endpointClosure: failureEndpointClosure, stubClosure: MoyaProvider.immediatelyStub)
+                provider = MoyaProvider<GitHub>(endpointClosure: failureEndpointClosure)
             }
 
             it("emits the correct error message") {

--- a/Tests/MultiTargetSpec.swift
+++ b/Tests/MultiTargetSpec.swift
@@ -54,10 +54,10 @@ class MultiTargetSpec: QuickSpec {
                 expect(String(describing: target.task)).to(beginWith("requestParameters")) // Hack to avoid implementing Equatable for Task
             }
 
-            it("uses correct sample data") {
-                let expectedData = "sample data".data(using: .utf8)!
-                expect(target.sampleData).to(equal(expectedData))
-            }
+//            it("uses correct sample data") {
+//                let expectedData = "sample data".data(using: .utf8)!
+//                expect(target.sampleData).to(equal(expectedData))
+//            }
 
             it("uses correct validate") {
                 expect(target.validate) == true

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -32,6 +32,17 @@ extension GitHub: TargetType {
         return .requestPlain
     }
 
+    var validate: Bool {
+        return true
+    }
+
+    var headers: [String: String]? {
+        return nil
+    }
+}
+
+extension GitHub: TestTargetType {
+
     var sampleData: Data {
         switch self {
         case .zen:
@@ -41,12 +52,12 @@ extension GitHub: TargetType {
         }
     }
 
-    var validate: Bool {
-        return true
+    var stubBehavior: Moya.StubBehavior {
+        return .immediate
     }
 
-    var headers: [String: String]? {
-        return nil
+    var sampleResponse: EndpointSampleResponse {
+        return .networkResponse(200, sampleData)
     }
 }
 
@@ -67,7 +78,7 @@ func url(_ route: TargetType) -> String {
 
 let failureEndpointClosure = { (target: GitHub) -> Endpoint<GitHub> in
     let error = NSError(domain: "com.moya.moyaerror", code: 0, userInfo: [NSLocalizedDescriptionKey: "Houston, we have a problem"])
-    return Endpoint<GitHub>(url: url(target), sampleResponseClosure: {.networkError(error)}, method: target.method, task: target.task, httpHeaderFields: target.headers)
+    return Endpoint<GitHub>(url: url(target), method: target.method, task: target.task, httpHeaderFields: target.headers)
 }
 
 enum HTTPBin: TargetType {


### PR DESCRIPTION
### Summary
This is purely experimental but I was dabbling with the idea of defining the stubbing API in terms of `TestTargetType` as opposed to configuring a `MoyaProvider`.

@Moya/contributors I would appreciate if any of you could review this and provide feedback 🙏 

### How?
We add a protocol that allows Moya users to provide the sample response and stub behavior:
```Swift
protocol TestTargetType {
    var sampleResponse: EndpointSampleResponse { get }
    var stubBehavior: Moya.StubBehavior { get }
}
```

Then internally, we use a `where` clause on `MoyaProvider` to determine if the `Target` we are handling is capable of stubbing requests.

```Swift
extension MoyaProvider where Target: TestTargetType {
/// ... stubbing methods here
}
```

It all comes down to this method:
```Swift
func performRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>) -> Cancellable
```

When `Target` != `TestTargetType` this version is called:
```Swift
extension MoyaProvider {
    private func performRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>) -> Cancellable {
        return self.performNormalRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion, endpoint: endpoint)
    }
}
```

When `Target` == `TestTargetType` this version is called:
```Swift
extension MoyaProvider where Target: TestTargetType {
    private func performRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>) -> Cancellable {
        switch target.stubBehavior {
        case .never:
            return self.performNormalRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion, endpoint: endpoint)
        default:
            return self.stubRequest(target, request: request, callbackQueue: callbackQueue, completion: completion, endpoint: endpoint, stubBehavior: target.stubBehavior)
        }
    }
}
```

Pros:
- Removes `stubClosure` from MoyaProvider because you can control behavior in `TestTargetType`
- Moves all stubbing behavior to `MoyaProvider+Stubbing.swift`
- Providers not using a `TestTargetType` need not be concerned with anything related to stubbing and perform no checks regarding stubbing at runtime

Cons:
- That's what I want to hear from you all 😅 I'm biased and blind to my own system

### Final thoughts
This breaks a lot of tests, I have not fixed them because it will take some work and I didn't want to start if people think this may not be a good change for the project. However, I think that fixing those tests would help me better understand any drawbacks to this approach.