### PR TITLE
Replace TargetType validate: Bool with validationType: ValidationType

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Changed
 - **Breaking Change** Updated minimum version of `ReactiveSwift` to 3.0.
 [#1470](https://github.com/Moya/Moya/pull/1470) by [@larryonoff](https://github.com/larryonoff).
+- **Breaking Change** Changed the `validate` property of `TargetType` to use new `ValidationType` enum representing valid status codes. [#1505](https://github.com/Moya/Moya/pull/1505) by [@SD10](https://github.com/sd10), [@amaurydavid](https://github.com/amaurydavid). 
 
 # [10.0.1] - 2017-11-23
 ### Fixed

--- a/Examples/_shared/GitHubAPI.swift
+++ b/Examples/_shared/GitHubAPI.swift
@@ -54,12 +54,12 @@ extension GitHub: TargetType {
             return .requestPlain
         }
     }
-    public var validate: Bool {
+    public var validationType: ValidationType {
         switch self {
         case .zen:
-            return true
+            return .successCodes
         default:
-            return false
+            return .none
         }
     }
     public var sampleData: Data {

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		149749431F8923EC00FA4900 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749421F8923EC00FA4900 /* AnyEncodable.swift */; };
 		149749451F892E2F00FA4900 /* URLRequest+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */; };
 		15D3A2BD1223B59E2BBE09F0 /* MoyaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D47F3DC51C28D950491FAAB /* MoyaError.swift */; };
+		1F8AA0BC1FE0630300C9D7B6 /* ValidationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */; };
 		1FD44D9E21CEA6B6221807EF /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4553E5591EE96535C5310C02 /* NetworkLoggerPlugin.swift */; };
 		2ADDFC96D7F7912333534C46 /* SignalProducer+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */; };
 		2C7132B56A7B129E12BAACAC /* EndpointSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E825A32256FC030B8BA2684D /* EndpointSpec.swift */; };
@@ -148,6 +149,7 @@
 		149749421F8923EC00FA4900 /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Encoding.swift"; sourceTree = "<group>"; };
 		14FB7A3E1F3E089900308949 /* Single+Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Single+Response.swift"; sourceTree = "<group>"; };
+		1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationType.swift; sourceTree = "<group>"; };
 		225C397C03E17F7DFBCA2848 /* MoyaProvider+Internal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Internal.swift"; sourceTree = "<group>"; };
 		269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SignalProducer+Response.swift"; sourceTree = "<group>"; };
 		2AD20F6A819D899E3278E903 /* NetworkActivityPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkActivityPlugin.swift; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 				147E26EB1F5B14B300C1F513 /* Task.swift */,
 				1446FBB21F214C5200C1EFF2 /* URL+Moya.swift */,
 				149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */,
+				1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */,
 			);
 			path = Moya;
 			sourceTree = "<group>";
@@ -815,6 +818,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F8AA0BC1FE0630300C9D7B6 /* ValidationType.swift in Sources */,
 				3AF7063CBE1F9626FB32D933 /* Cancellable.swift in Sources */,
 				49C61E884A595E94758B5643 /* Endpoint.swift in Sources */,
 				FB223B5C3B7D4AA5261E25EA /* Image.swift in Sources */,

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -181,19 +181,22 @@ private extension MoyaProvider {
 
     func sendUploadFile(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, file: URL, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let uploadRequest = manager.upload(file, with: request)
-        let alamoRequest = target.validate ? uploadRequest.validate() : uploadRequest
+        let validationCodes = target.validationType.statusCodes
+        let alamoRequest = validationCodes.isEmpty ? uploadRequest : uploadRequest.validate(statusCode: validationCodes)
         return self.sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
     }
 
     func sendDownloadRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let downloadRequest = manager.download(request, to: destination)
-        let alamoRequest = target.validate ? downloadRequest.validate() : downloadRequest
+        let validationCodes = target.validationType.statusCodes
+        let alamoRequest = validationCodes.isEmpty ? downloadRequest : downloadRequest.validate(statusCode: validationCodes)
         return self.sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
     }
 
     func sendRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
         let initialRequest = manager.request(request as URLRequestConvertible)
-        let alamoRequest = target.validate ? initialRequest.validate() : initialRequest
+        let validationCodes = target.validationType.statusCodes
+        let alamoRequest = validationCodes.isEmpty ? initialRequest : initialRequest.validate(statusCode: validationCodes)
         return sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
     }
 

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -29,8 +29,8 @@ public enum MultiTarget: TargetType {
         return target.task
     }
 
-    public var validate: Bool {
-        return target.validate
+    public var validationType: ValidationType {
+        return target.validationType
     }
 
     public var headers: [String: String]? {

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -32,3 +32,13 @@ public extension TargetType {
         return .none
     }
 }
+
+// MARK: - Deprecated
+
+extension TargetType {
+    @available(*, deprecated: 11.0, message:
+    "TargetType's validate property has been deprecated in 11.0. Please use validationType: ValidationType.")
+    var validate: Bool {
+        return false
+    }
+}

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -18,16 +18,16 @@ public protocol TargetType {
     /// The type of HTTP task to be performed.
     var task: Task { get }
 
-
+    /// The type of validation to perform on the request. Default is `.none`.
     var validationType: ValidationType { get }
 
     /// The headers to be used in the request.
     var headers: [String: String]? { get }
 }
 
-
-
 public extension TargetType {
+
+    /// The type of validation to perform on the request. Default is `.none`.
     var validationType: ValidationType {
         return .none
     }

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -18,15 +18,17 @@ public protocol TargetType {
     /// The type of HTTP task to be performed.
     var task: Task { get }
 
-    /// Whether or not to perform Alamofire validation. Defaults to `false`.
-    var validate: Bool { get }
+
+    var validationType: ValidationType { get }
 
     /// The headers to be used in the request.
     var headers: [String: String]? { get }
 }
 
+
+
 public extension TargetType {
-    var validate: Bool {
-        return false
+    var validationType: ValidationType {
+        return .none
     }
 }

--- a/Sources/Moya/ValidationType.swift
+++ b/Sources/Moya/ValidationType.swift
@@ -1,0 +1,48 @@
+
+import Foundation
+
+/// Represents the status codes to validate through Alamofire.
+public enum ValidationType {
+
+    /// No validation.
+    case none
+
+    /// Validate success codes (only 2xx).
+    case successCodes
+
+    /// Validate success codes and redirection codes (only 2xx and 3xx).
+    case successAndRedirectCodes
+
+    /// Validate only the given status codes.
+    case customCodes([Int])
+
+    /// The list of HTTP status codes to validate.
+    var statusCodes: [Int] {
+        switch self {
+        case .successCodes:
+            return Array(200..<300)
+        case .successAndRedirectCodes:
+            return Array(200..<400)
+        case .customCodes(let codes):
+            return codes
+        case .none:
+            return []
+        }
+    }
+}
+
+extension ValidationType: Equatable {
+
+    public static func == (lhs: ValidationType, rhs: ValidationType) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none),
+             (.successCodes, .successCodes),
+             (.successAndRedirectCodes, .successAndRedirectCodes):
+            return true
+        case (.customCodes(let c1), .customCodes(let c2)):
+            return c1 == c2
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Moya/ValidationType.swift
+++ b/Sources/Moya/ValidationType.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 /// Represents the status codes to validate through Alamofire.

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -3,7 +3,7 @@ import Nimble
 @testable
 import Moya
 
-class ErrorTests: QuickSpec {
+final class ErrorTests: QuickSpec {
     override func spec() {
 
         var response: Response!

--- a/Tests/MethodSpec.swift
+++ b/Tests/MethodSpec.swift
@@ -2,7 +2,7 @@ import Quick
 import Moya
 import Nimble
 
-class MethodSpec: QuickSpec {
+final class MethodSpec: QuickSpec {
     override func spec() {
         describe("supportsMultipart") {
             let expectations: [(Moya.Method, Bool)] = [

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -18,7 +18,7 @@ func beIdenticalToResponse(_ expectedValue: Moya.Response) -> Predicate<Moya.Res
     }
 }
 
-class MoyaProviderIntegrationTests: QuickSpec {
+final class MoyaProviderIntegrationTests: QuickSpec {
     override func spec() {
         let userMessage = String(data: GitHub.userProfile("ashfurrow").sampleData, encoding: .utf8)
         let zenMessage = String(data: GitHub.zen.sampleData, encoding: .utf8)
@@ -303,7 +303,7 @@ class MoyaProviderIntegrationTests: QuickSpec {
     }
 }
 
-class StubManager: Manager {
+final class StubManager: Manager {
     var called = false
 
     override func request(_ urlRequest: URLRequestConvertible) -> DataRequest {

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -255,8 +255,9 @@ class MoyaProviderIntegrationTests: QuickSpec {
                         expect(log).to( contain("Request Headers: [:]") )
                         expect(log).to( contain("HTTP Request Method: GET") )
                         expect(log).to( contain("Response:") )
-                        expect(log).to( contain("{ URL: https://api.github.com/zen } { status code: 200, headers") )
-                        expect(log).to( contain("\"Content-Length\" = 43;") )
+                        expect(log).to( contain("{ URL: https://api.github.com/zen } { Status Code: 200, Headers") )
+                        expect(log).to( contain("\"Content-Length\" =") )
+                        expect(log).to( contain("43"))
                     }
                 }
             }

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -255,9 +255,8 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                         expect(log).to( contain("Request Headers: [:]") )
                         expect(log).to( contain("HTTP Request Method: GET") )
                         expect(log).to( contain("Response:") )
-                        expect(log).to( contain("{ URL: https://api.github.com/zen } { Status Code: 200, Headers") )
-                        expect(log).to( contain("\"Content-Length\" =") )
-                        expect(log).to( contain("43"))
+                        expect(log).to( contain("{ URL: https://api.github.com/zen } { status code: 200, headers") )
+                        expect(log).to( contain("\"Content-Length\" = 43;") )
                     }
                 }
             }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -6,7 +6,7 @@ import Foundation
 import OHHTTPStubs
 @testable import Moya
 
-class MoyaProviderSpec: QuickSpec {
+final class MoyaProviderSpec: QuickSpec {
     override func spec() {
         var provider: MoyaProvider<GitHub>!
         beforeEach {

--- a/Tests/MultiTargetSpec.swift
+++ b/Tests/MultiTargetSpec.swift
@@ -11,7 +11,7 @@ class MultiTargetSpec: QuickSpec {
                 let method = Moya.Method.get
                 let task = Task.requestParameters(parameters: ["key": "value"], encoding: JSONEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!
-                let validate = true
+                let validationType: ValidationType = .successCodes
                 let headers: [String: String]? = ["headerKey": "headerValue"]
             }
 
@@ -59,8 +59,8 @@ class MultiTargetSpec: QuickSpec {
                 expect(target.sampleData).to(equal(expectedData))
             }
 
-            it("uses correct validate") {
-                expect(target.validate) == true
+            it("uses correct validation type") {
+                expect(target.validationType).to(equal(ValidationType.successCodes))
             }
 
             it("uses correct headers") {

--- a/Tests/MultiTargetSpec.swift
+++ b/Tests/MultiTargetSpec.swift
@@ -2,7 +2,7 @@ import Quick
 import Nimble
 @testable import Moya
 
-class MultiTargetSpec: QuickSpec {
+final class MultiTargetSpec: QuickSpec {
     override func spec() {
         describe("MultiTarget") {
             struct StructAPI: TargetType {

--- a/Tests/MultipartFormDataSpec.swift
+++ b/Tests/MultipartFormDataSpec.swift
@@ -2,7 +2,7 @@ import Quick
 import Nimble
 @testable import Moya
 
-class MultiPartFormData: QuickSpec {
+final class MultiPartFormData: QuickSpec {
     override func spec() {
         it("initializes correctly") {
             let fileURL = URL(fileURLWithPath: "/tmp.txt")

--- a/Tests/Observable+MoyaSpec.swift
+++ b/Tests/Observable+MoyaSpec.swift
@@ -3,7 +3,7 @@ import Moya
 import RxSwift
 import Nimble
 
-class ObservableMoyaSpec: QuickSpec {
+final class ObservableMoyaSpec: QuickSpec {
     override func spec() {
         describe("status codes filtering") {
             it("filters out unrequested status codes") {

--- a/Tests/SignalProducer+MoyaSpec.swift
+++ b/Tests/SignalProducer+MoyaSpec.swift
@@ -7,7 +7,7 @@ private func signalSendingData(_ data: Data, statusCode: Int = 200) -> SignalPro
     return SignalProducer(value: Response(statusCode: statusCode, data: data as Data, response: nil))
 }
 
-class SignalProducerMoyaSpec: QuickSpec {
+final class SignalProducerMoyaSpec: QuickSpec {
     override func spec() {
         describe("status codes filtering") {
             it("filters out unrequested status codes") {

--- a/Tests/Single+MoyaSpec.swift
+++ b/Tests/Single+MoyaSpec.swift
@@ -3,7 +3,7 @@ import Moya
 import RxSwift
 import Nimble
 
-class SingleMoyaSpec: QuickSpec {
+final class SingleMoyaSpec: QuickSpec {
     override func spec() {
         describe("status codes filtering") {
             it("filters out unrequested status codes") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -41,8 +41,8 @@ extension GitHub: TargetType {
         }
     }
 
-    var validate: Bool {
-        return true
+    var validationType: ValidationType {
+        return .successAndRedirectCodes
     }
 
     var headers: [String: String]? {

--- a/docs/Examples/AlamofireValidation.md
+++ b/docs/Examples/AlamofireValidation.md
@@ -22,18 +22,28 @@ extension MyService: TargetType {
     // Other needed configurations
     // ...
     
-    // Validate setup is not required; defaults to `false`
+    // Validate setup is not required; defaults to `.none`
     // for all requests unless specified otherwise.
-    var validate: Bool {
+    var validationType: ValidationType {
         switch self {
         case .zen, .showUser, .showAccounts:
-            return true
+            return .successCodes
         case .createUser(let firstName, let lastName):
-            return false
+            return .none
         }
     }
 }
 ```
+Moya allows you to configure the Alamofire validation behavior through the `ValidationType` enum.
+ 
+You can choose from four cases:
+- `.none` which does not perform any validation.
+- `.successCodes` which validates requests with status codes 200 - 299.
+- `.successAndRedirectCodes` which validates requests with status codes 200 - 399.
+- `.customCodes([Int])` which only validates the given status codes.
+
+The default validation type for all requests is `ValidationType.none`.
+
 Alamofire automatic validation can be useful, for example if you want to use the [Alamofire's `RequestRetrier` and `RequestAdapter`](https://github.com/Alamofire/Alamofire#requestretrier), for an OAuth 2 ready Moya Client.
 
 Also, if validation fails, you can get the response from the returned `MoyaError`.


### PR DESCRIPTION
This resolves #1447 and completes #1454 which was started by @amaurydavid

It replaces the `Boolean` property of `TargetType` with a `ValidationType` enum allowing the user to customize the status codes used by Alamofire's `validate(statusCodes:)` method.

TODO:
- [x] CHANGELOG
- [x] Update Documentation
- [x] Update Example app