### PR TITLE
Add custom header / query parameter auth to AccessTokenPlugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 - **Breaking Change** Updated minimum version of `ReactiveSwift` to 3.0.
 [#1470](https://github.com/Moya/Moya/pull/1470) by [@larryonoff](https://github.com/larryonoff).
 - **Breaking Change** Changed the `validate` property of `TargetType` to use new `ValidationType` enum representing valid status codes. [#1505](https://github.com/Moya/Moya/pull/1505) by [@SD10](https://github.com/sd10), [@amaurydavid](https://github.com/amaurydavid). 
+- **Breaking Change** Changed `AccessTokenPlugin` to support custom header / query parameter authentication in addition to the current `Basic` and `Bearer` auth [#1521](https://github.com/Moya/Moya/pull/1521) by [@ffittschen](https://github.com/ffittschen).
 
 # [10.0.1] - 2017-11-23
 ### Fixed

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -1,73 +1,95 @@
 import Foundation
 import Result
 
-// MARK: - AccessTokenAuthorizable
+/// HTTP authentication scheme
+///
+/// As declared in the [HTTP Authentication Scheme Registry](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml)
+public enum AuthenticationScheme {
+    case basic
+    case bearer
 
-/// A protocol for controlling the behavior of `AccessTokenPlugin`.
-public protocol AccessTokenAuthorizable {
+    var headerField: String {
+        return "Authorization"
+    }
 
-    /// Represents the authorization header to use for requests.
-    var authorizationType: AuthorizationType { get }
+    var tokenPrefix: String {
+        switch self {
+        case .basic:
+            return "Basic"
+        case .bearer:
+            return "Bearer"
+        }
+    }
 }
 
-// MARK: - AuthorizationType
+public enum TokenPlacement {
+    case header
+    case queryParameter
+}
 
-/// An enum representing the header to use with an `AccessTokenPlugin`
-public enum AuthorizationType: String {
+public enum AccessControlType {
     case none
-    case basic = "Basic"
-    case bearer = "Bearer"
+    case http(scheme: AuthenticationScheme)
+    case apiKey(name: String, placement: TokenPlacement)
 }
 
-// MARK: - AccessTokenPlugin
+public protocol AccessControllable {
+    var accessControlType: AccessControlType { get }
+}
 
-/**
- A plugin for adding basic or bearer-type authorization headers to requests. Example:
-
- ```
- Authorization: Bearer <token>
- Authorization: Basic <token>
- ```
-
-*/
 public struct AccessTokenPlugin: PluginType {
 
-    /// A closure returning the access token to be applied in the header.
+    /// A closure returning the access token to be applied in the header or query parameter.
     public let tokenClosure: () -> String
 
-    /**
-     Initialize a new `AccessTokenPlugin`.
-
-     - parameters:
-       - tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthorizationType> <token>`
-    */
-    public init(tokenClosure: @escaping @autoclosure () -> String) {
+    /// Initialize a new `AccessTokenPlugin`.
+    ///
+    /// - Parameter tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthenticationScheme> <token>`
+    public init(tokenClosure: @escaping () -> String) {
         self.tokenClosure = tokenClosure
     }
 
-    /**
-     Prepare a request by adding an authorization header if necessary.
-
-     - parameters:
-       - request: The request to modify.
-       - target: The target of the request.
-     - returns: The modified `URLRequest`.
-    */
+    /// Prepare a request by adding an authorization header or query parameter if necessary.
+    ///
+    /// - Parameters:
+    ///   - request: The request to modify.
+    ///   - target: The target of the request.
+    /// - Returns: The modified `URLRequest`.
     public func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
-        guard let authorizable = target as? AccessTokenAuthorizable else { return request }
-
-        let authorizationType = authorizable.authorizationType
+        guard let accessControllable = target as? AccessControllable else { return request }
 
         var request = request
 
-        switch authorizationType {
-        case .basic, .bearer:
-            let authValue = authorizationType.rawValue + " " + tokenClosure()
-            request.addValue(authValue, forHTTPHeaderField: "Authorization")
-        case .none:
+        switch accessControllable.accessControlType {
+        case .http(let scheme):
+            let authValue = scheme.tokenPrefix + " " + tokenClosure()
+            request.addValue(authValue, forHTTPHeaderField: scheme.headerField)
+        case .apiKey(let name, let placement) where placement == .header:
+            request.addValue(tokenClosure(), forHTTPHeaderField: name)
+        case .apiKey(let name, let placement) where placement == .queryParameter:
+            guard let url = request.url else { return request }
+            request.url = addOrAppendQueryParameterToURL(url, toParameter: name)
+        default:
             break
         }
 
         return request
+    }
+
+    private func addOrAppendQueryParameterToURL(_ url: URL, toParameter name: String) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+
+        if components.queryItems != nil {
+            // swiftlint:disable:next force_unwrapping
+            components.queryItems!.append(URLQueryItem(name: name, value: tokenClosure()))
+        } else {
+            components.queryItems = [URLQueryItem(name: name, value: tokenClosure())]
+        }
+
+        do {
+            return try components.asURL()
+        } catch {
+            return url
+        }
     }
 }

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -4,20 +4,35 @@ import Moya
 import Result
 
 final class AccessTokenPluginSpec: QuickSpec {
-    struct TestTarget: TargetType, AccessTokenAuthorizable {
-        let baseURL = URL(string: "http://www.api.com/")!
-        let path = ""
-        let method = Method.get
-        let task = Task.requestPlain
-        let sampleData = Data()
-        let headers: [String: String]? = nil
+    struct TestTarget: TargetType, AccessControllable {
+        let baseURL: URL
+        let path: String
+        let method: Moya.Method
+        let task: Task
+        let sampleData: Data
+        let headers: [String: String]?
+        let accessControlType: AccessControlType
 
-        let authorizationType: AuthorizationType
+        init(baseURL: URL = URL(string: "http://www.api.com/")!,
+             path: String = "",
+             method: Moya.Method = .get,
+             task: Task = .requestPlain,
+             sampleData: Data = Data(),
+             headers: [String: String]? = nil,
+             accessControlType: AccessControlType) {
+            self.baseURL = baseURL
+            self.path = path
+            self.method = method
+            self.task = task
+            self.sampleData = sampleData
+            self.headers = headers
+            self.accessControlType = accessControlType
+        }
     }
 
     override func spec() {
-        let token = "eyeAm.AJsoN.weBTOKen"
-        let plugin = AccessTokenPlugin(tokenClosure: token)
+        let tokenClosure = { return "eyeAm.AJsoN.weBTOKen" }
+        let plugin = AccessTokenPlugin(tokenClosure: tokenClosure)
 
         it("doesn't add an authorization header to TargetTypes by default") {
             let target = GitHub.zen
@@ -26,26 +41,68 @@ final class AccessTokenPluginSpec: QuickSpec {
             expect(preparedRequest.allHTTPHeaderFields).to(beNil())
         }
 
-        it("doesn't add an authorization header to AccessTokenAuthorizables when AuthorizationType is .none") {
-            let target = TestTarget(authorizationType: .none)
+        it("doesn't add query parameter authentication to TargetTypes by default") {
+            let target = GitHub.zen
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            let components = URLComponents(url: preparedRequest.url!, resolvingAgainstBaseURL: false)!
+            expect(components.queryItems).to(beNil())
+        }
+
+        it("doesn't add an authorization header to AccessControllables when AccessControlType is .none") {
+            let target = TestTarget(accessControlType: .none)
             let request = URLRequest(url: target.baseURL)
             let preparedRequest = plugin.prepare(request, target: target)
             expect(preparedRequest.allHTTPHeaderFields).to(beNil())
         }
 
-        it("adds a bearer authorization header to AccessTokenAuthorizables when AuthorizationType is .bearer") {
-            let target = TestTarget(authorizationType: .bearer)
+        it("doesn't add query parameter authentication to AccessControllables when AccessControlType is .none") {
+            let target = TestTarget(accessControlType: .none)
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            let components = URLComponents(url: preparedRequest.url!, resolvingAgainstBaseURL: false)!
+            expect(components.queryItems).to(beNil())
+        }
+
+        it("adds a bearer authorization header to AccessControllables when AccessControlType is .http and the scheme is .bearer") {
+            let target = TestTarget(accessControlType: .http(scheme: .bearer))
             let request = URLRequest(url: target.baseURL)
             let preparedRequest = plugin.prepare(request, target: target)
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Bearer eyeAm.AJsoN.weBTOKen"]
         }
 
-        it("adds a basic authorization header to AccessTokenAuthorizables when AuthorizationType is .basic") {
-            let target = TestTarget(authorizationType: .basic)
+        it("adds a basic authorization header to AccessControllables when AccessControlType is .http and the scheme is .basic") {
+            let target = TestTarget(accessControlType: .http(scheme: .basic))
             let request = URLRequest(url: target.baseURL)
             let preparedRequest = plugin.prepare(request, target: target)
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "Basic eyeAm.AJsoN.weBTOKen"]
         }
 
+        it("adds a custom authorization header to AccessControllables when AccessControlType is .apiKey and the placement is .header") {
+            let target = TestTarget(accessControlType: .apiKey(name: "X-Access-Token", placement: .header))
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            expect(preparedRequest.allHTTPHeaderFields) == ["X-Access-Token": "eyeAm.AJsoN.weBTOKen"]
+        }
+
+        it("adds a query parameter to AccessControllables when AccessControlType is .apiKey and the placement is .queryParameter") {
+            let target = TestTarget(accessControlType: .apiKey(name: "accessToken", placement: .queryParameter))
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            let components = URLComponents(url: preparedRequest.url!, resolvingAgainstBaseURL: false)!
+            expect(components.queryItems) == [URLQueryItem(name: "accessToken", value: "eyeAm.AJsoN.weBTOKen")]
+        }
+
+        it("appends a query parameter to AccessControllables when AccessControlType is .apiKey and the placement is .queryParameter") {
+            let target = TestTarget(baseURL: URL(string: "http://www.api.com/?key=value")!,
+                                    accessControlType: .apiKey(name: "accessToken", placement: .queryParameter))
+            let request = URLRequest(url: target.baseURL)
+            let preparedRequest = plugin.prepare(request, target: target)
+            let components = URLComponents(url: preparedRequest.url!, resolvingAgainstBaseURL: false)!
+            expect(components.queryItems) == [
+                URLQueryItem(name: "key", value: "value"),
+                URLQueryItem(name: "accessToken", value: "eyeAm.AJsoN.weBTOKen")
+            ]
+        }
     }
 }

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -21,9 +21,13 @@ let provider = MoyaProvider<GitHub>(plugins: [NetworkLoggerPlugin(verbose: true)
 ```
 
 ### Authentication
-The authentication plugin allows a user to assign an optional `URLCredential` per request. There is no action when a request is received.
+The `CredentialsPlugin` allows a user to assign an optional `URLCredential` per request. There is no action when a request is received.
 
 The plugin can be found at [`Sources/Moya/Plugins/CredentialsPlugin.swift`](../Sources/Moya/Plugins/CredentialsPlugin.swift)
+
+The `AccessTokenPlugin` allows a user to a type of access control per request, either `Bearer` or `Basic` HTTP authentication schemes, or a custom header / query parameter.
+
+The plugin can be found at [`Sources/Moya/Plugins/AccessTokenPlugin.swift`](../Sources/Moya/Plugins/AccessTokenPlugin.swift)
 
 ### Network Activity Indicator
 One very common task with iOS networking is to show a network activity indicator during network requests, and remove it when all requests have finished. The provided plugin adds callbacks which are called when a requests starts and finishes, which can be used to keep track of the number of requests in progress, and show / hide the network activity indicator accordingly.

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -142,7 +142,7 @@ let provider = MoyaProvider<MyTarget>(manager: manager)
 Finally, you may also provide an array of `plugins` to the provider. These receive callbacks
 before a request is sent and after a response is received. There are a few plugins
 included already: one for network activity (`NetworkActivityPlugin`), one for logging
-all network activity (`NetworkLoggerPlugin`), and another for [HTTP Authentication](Authentication.md).
+all network activity (`NetworkLoggerPlugin`), and another for [Authentication](Authentication.md).
 
 For example you can enable the logger plugin by simply passing `[NetworkLoggerPlugin()]` alongside the `plugins` parameter of your `Endpoint`. Note that a plugin can also be configurable, for example the already included `NetworkActivityPlugin` requires a `networkActivityClosure` parameter. The configurable plugin implementation looks like this:
 


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->

This is a result of the discussions in https://github.com/Moya/Moya/issues/1283, but does not add the ability to reuse parameters/headers. It is only an improvement to the `AccessTokenPlugin`.

Based on the discussion, I changed the `AccessTokenPlugin` to support custom header / query parameter authentication in addition to the existing Basic and Bearer authentication schemes. Doing so, I also cleaned up the naming:

| Old | New | Reason |
|-----|-----|--------|
|`AccessTokenAuthorizable`|`AccessControllable`| The plugin does not add the capability of targets to be authorized. It merely adds the ability to comply to access control rules of endpoints |
|`AuthorizationType`|`AccessControlType`| Same as above, these are types of access control and not authorization |

The behavior mention in https://github.com/Moya/Moya/issues/1492#issuecomment-350091896 remains unchanged: 
> `AccessTokenPlugin` does nothing by default. You must conform to `AccessControllable` for the plugin to take effect.

### Breaking Changes

* Renamed `AccessTokenAuthorizable` to `AccessControllable`
* Renamed `AuthorizationType` to `AccessControlType`
  * And therefore renamed `authorizationType` to `accessControlType`
* Added another "enum layer" to `accessControlType`, therefore removed the `.basic` and `.bearer` cases. Their new equivalent is `.http(scheme: .basic)` and `.http(scheme: .bearer)`, and added a new case: `.apiKey(name: String, placement: TokenPlacement)` to support custom header / query parameter access control
* Removed `@autoclosure` from `tokenClosure`