### PR TITLE
Add Moya 10 to 11 migration guide

### DIFF
--- a/docs/MigrationGuides/migration_10_to_11.md
+++ b/docs/MigrationGuides/migration_10_to_11.md
@@ -1,0 +1,10 @@
+# Migration Guide from 10.x to 11.x
+
+This project follows [Semantic Versioning](http://semver.org).
+
+### Task Migration
+- Add `.requestCustomJSONEncodable` case to `Task` or default case to achieve exhaustiveness.
+
+### TargetType Migration
+- Replace the `validate` property of `TargetType` with the new property `validationType`.
+If `validate` was previously `false`, use `ValidationType.none`. If `true`, use `ValidationType.successCodes`. The default is `ValidationType.none`.

--- a/docs/MigrationGuides/migration_10_to_11.md
+++ b/docs/MigrationGuides/migration_10_to_11.md
@@ -2,6 +2,9 @@
 
 This project follows [Semantic Versioning](http://semver.org).
 
+### ReactiveSwift Migration
+- Check the [ReactiveSwift 3.0.0 release notes](https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/3.0.0) for changes related to ReactiveSwift.
+
 ### Task Migration
 - Add `.requestCustomJSONEncodable` case to `Task` or default case to achieve exhaustiveness.
 


### PR DESCRIPTION
This resolves #1520. 

I think we should release a `11.0.0-beta.1` for a week and then do a hard `11.0.0` if all goes well.