### PR TITLE
Update Package.Resolved for ReactiveSwift 3.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
         "state": {
           "branch": null,
-          "revision": "b9d5b350a446b85704396ce332a1f9e4960cfc6b",
-          "version": "2.0.1"
+          "revision": "2ec944c43ef9cf6b1380629e3ea483f62a7afaef",
+          "version": "3.0.0"
         }
       },
       {


### PR DESCRIPTION
Link to issue #1470
We updated Package.Swift to ReactiveSwift 3.0.0 but not the Package.Resolved.