### PR TITLE
Fix wrong reference to target instead of endpoint #1546

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # Next
+### Fixed
+- Fixed a bug where modifying `.uploadMultipart`, `.uploadCompositeMultipart`, `.uploadFile`, `.downloadDestination`, and `.downloadParameters` tasks through an `endpointClosure` has no effect on the final request.
+[#1550](https://github.com/Moya/Moya/pull/1550) by [@SD10](https://github.com/sd10), [@sunshinejr](https://github.com/sunshinejr).
 
 # [10.0.1] - 2017-11-23
 ### Fixed

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 			isa = PBXGroup;
 			children = (
 				31BAAD7EC02607A52AD3EF1E /* AccessTokenPluginSpec.swift */,
+				1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */,
 				E825A32256FC030B8BA2684D /* EndpointSpec.swift */,
 				C79C5F376B4A2C3F70051980 /* Error+MoyaSpec.swift */,
 				7F112022D8F42844A7D5CB5C /* ErrorTests.swift */,
@@ -301,7 +302,6 @@
 				4650771638DBA96BDE28F11B /* TestHelpers.swift */,
 				CA93F1BAD55FF95EDE17EE61 /* testImage.png */,
 				DCACC7B19F3FFC2DEE74E07B /* TestPlugin.swift */,
-				1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		149749431F8923EC00FA4900 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749421F8923EC00FA4900 /* AnyEncodable.swift */; };
 		149749451F892E2F00FA4900 /* URLRequest+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */; };
 		15D3A2BD1223B59E2BBE09F0 /* MoyaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D47F3DC51C28D950491FAAB /* MoyaError.swift */; };
+		1F24393320125F8200C9D813 /* EndpointClosureSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */; };
 		1FD44D9E21CEA6B6221807EF /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4553E5591EE96535C5310C02 /* NetworkLoggerPlugin.swift */; };
 		2ADDFC96D7F7912333534C46 /* SignalProducer+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */; };
 		2C7132B56A7B129E12BAACAC /* EndpointSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E825A32256FC030B8BA2684D /* EndpointSpec.swift */; };
@@ -148,6 +149,7 @@
 		149749421F8923EC00FA4900 /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Encoding.swift"; sourceTree = "<group>"; };
 		14FB7A3E1F3E089900308949 /* Single+Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Single+Response.swift"; sourceTree = "<group>"; };
+		1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointClosureSpec.swift; sourceTree = "<group>"; };
 		225C397C03E17F7DFBCA2848 /* MoyaProvider+Internal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Internal.swift"; sourceTree = "<group>"; };
 		269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SignalProducer+Response.swift"; sourceTree = "<group>"; };
 		2AD20F6A819D899E3278E903 /* NetworkActivityPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkActivityPlugin.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				4650771638DBA96BDE28F11B /* TestHelpers.swift */,
 				CA93F1BAD55FF95EDE17EE61 /* testImage.png */,
 				DCACC7B19F3FFC2DEE74E07B /* TestPlugin.swift */,
+				1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -897,6 +900,7 @@
 				9A58B120B1293AFE556915AE /* MoyaProviderSpec.swift in Sources */,
 				FA9EE63E068C40C97D7B0156 /* MultipartFormDataSpec.swift in Sources */,
 				B950CAA84C0656EB11E316FB /* MultiTargetSpec.swift in Sources */,
+				1F24393320125F8200C9D813 /* EndpointClosureSpec.swift in Sources */,
 				4033070748A57EB4A0040DB1 /* NetworkLoggerPluginSpec.swift in Sources */,
 				E9B54EFE4EF4A96444BA76AA /* Observable+MoyaSpec.swift in Sources */,
 				8995DF740A59721AA79F5B43 /* MoyaProvider+ReactiveSpec.swift in Sources */,

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -90,13 +90,13 @@ public extension MoyaProvider {
     private func performRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion, endpoint: Endpoint<Target>, stubBehavior: Moya.StubBehavior) -> Cancellable {
         switch stubBehavior {
         case .never:
-            switch target.task {
+            switch endpoint.task {
             case .requestPlain, .requestData, .requestJSONEncodable, .requestParameters, .requestCompositeData, .requestCompositeParameters:
                 return self.sendRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion)
             case .uploadFile(let file):
                 return self.sendUploadFile(target, request: request, callbackQueue: callbackQueue, file: file, progress: progress, completion: completion)
             case .uploadMultipart(let multipartBody), .uploadCompositeMultipart(let multipartBody, _):
-                guard !multipartBody.isEmpty && target.method.supportsMultipart else {
+                guard !multipartBody.isEmpty && endpoint.method.supportsMultipart else {
                     fatalError("\(target) is not a multipart upload target.")
                 }
                 return self.sendUploadMultipart(target, request: request, callbackQueue: callbackQueue, multipartBody: multipartBody, progress: progress, completion: completion)

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -152,16 +152,7 @@ private extension MoyaProvider {
         let cancellable = CancellableWrapper()
 
         let multipartFormData: (RequestMultipartFormData) -> Void = { form in
-            for bodyPart in multipartBody {
-                switch bodyPart.provider {
-                case .data(let data):
-                    form.append(data: data, bodyPart: bodyPart)
-                case .file(let url):
-                    form.append(fileURL: url, bodyPart: bodyPart)
-                case .stream(let stream, let length):
-                    form.append(stream: stream, length: length, bodyPart: bodyPart)
-                }
-            }
+            form.applyMoyaMultipartFormData(multipartBody)
         }
 
         manager.upload(multipartFormData: multipartFormData, with: request) { result in

--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Alamofire
 
 /// Represents "multipart/form-data" for an upload.
 public struct MultipartFormData {
@@ -28,6 +29,7 @@ public struct MultipartFormData {
 
     /// The MIME type
     public let mimeType: String?
+
 }
 
 // MARK: RequestMultipartFormData appending
@@ -54,5 +56,18 @@ internal extension RequestMultipartFormData {
 
     func append(stream: InputStream, length: UInt64, bodyPart: MultipartFormData) {
         append(stream, withLength: length, name: bodyPart.name, fileName: bodyPart.fileName ?? "", mimeType: bodyPart.mimeType ?? "")
+    }
+
+    func applyMoyaMultipartFormData(_ multipartBody: [Moya.MultipartFormData]) {
+        for bodyPart in multipartBody {
+            switch bodyPart.provider {
+            case .data(let data):
+                append(data: data, bodyPart: bodyPart)
+            case .file(let url):
+                append(fileURL: url, bodyPart: bodyPart)
+            case .stream(let stream, let length):
+                append(stream: stream, length: length, bodyPart: bodyPart)
+            }
+        }
     }
 }

--- a/Tests/AccessTokenPluginSpec.swift
+++ b/Tests/AccessTokenPluginSpec.swift
@@ -11,7 +11,6 @@ final class AccessTokenPluginSpec: QuickSpec {
         let task = Task.requestPlain
         let sampleData = Data()
         let headers: [String: String]? = nil
-
         let authorizationType: AuthorizationType
     }
 

--- a/Tests/EndpointClosureSpec.swift
+++ b/Tests/EndpointClosureSpec.swift
@@ -29,7 +29,7 @@ final class EndpointClosureSpec: QuickSpec {
             provider = MoyaProvider<HTTPBin>(endpointClosure: endpointClosure, manager: sessionManager)
         }
 
-        it("returns a new endpoint for adding(newHTTPHeaderFields:)") {
+        it("appends additional multipart body in endpointClosure") {
             let multipartData1 = Moya.MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test1")
             let multipartData2 = Moya.MultipartFormData(provider: .data("test2".data(using: .utf8)!), name: "test2")
 

--- a/Tests/EndpointClosureSpec.swift
+++ b/Tests/EndpointClosureSpec.swift
@@ -38,7 +38,10 @@ final class EndpointClosureSpec: QuickSpec {
 
             _ = provider.request(.uploadMultipart(providedMultipartData, nil)) { _ in }
             let stringData1 = String(data: try! sessionManager.uploadMultipartFormData!.encode(), encoding: .utf8)
-            let stringData2 = String(data: try! sessionManager.convertMoyaMultipartFormDataToAlamofire(sentMultipartData).encode(), encoding: .utf8)
+
+            let requestMultipartFormData = RequestMultipartFormData()
+            requestMultipartFormData.applyMoyaMultipartFormData(sentMultipartData)
+            let stringData2 = String(data: try! requestMultipartFormData.encode(), encoding: .utf8)
 
             let formData1 = "data; name=\"test1\"\r\n\r\ntest1\r\n"
             let formData2 = "data; name=\"test2\"\r\n\r\ntest2\r\n"
@@ -63,21 +66,5 @@ final class SessionManagerMock: SessionManager {
         let uploadMultipartFormData = Alamofire.MultipartFormData()
         multipartFormData(uploadMultipartFormData)
         self.uploadMultipartFormData = uploadMultipartFormData
-    }
-
-    func convertMoyaMultipartFormDataToAlamofire(_ multipartBody: [Moya.MultipartFormData]) -> Alamofire.MultipartFormData {
-        let form = RequestMultipartFormData()
-        for bodyPart in multipartBody {
-            switch bodyPart.provider {
-            case .data(let data):
-                form.append(data: data, bodyPart: bodyPart)
-            case .file(let url):
-                form.append(fileURL: url, bodyPart: bodyPart)
-            case .stream(let stream, let length):
-                form.append(stream: stream, length: length, bodyPart: bodyPart)
-            }
-        }
-
-        return form
     }
 }

--- a/Tests/EndpointClosureSpec.swift
+++ b/Tests/EndpointClosureSpec.swift
@@ -1,0 +1,83 @@
+import Nimble
+import Quick
+import Alamofire
+@testable import Moya
+
+final class EndpointClosureSpec: QuickSpec {
+
+    override func spec() {
+        var provider: MoyaProvider<HTTPBin>!
+        var sessionManager: SessionManagerMock!
+
+        beforeEach {
+            sessionManager = SessionManagerMock()
+            let endpointClosure: MoyaProvider<HTTPBin>.EndpointClosure = { target in
+                let task: Task
+
+                switch target.task {
+                case let .uploadMultipart(multipartFormData):
+                    let additional = Moya.MultipartFormData(provider: .data("test2".data(using: .utf8)!), name: "test2")
+                    var newMultipartFormData = multipartFormData
+                    newMultipartFormData.append(additional)
+                    task = .uploadMultipart(newMultipartFormData)
+                default:
+                    task = target.task
+                }
+
+                return Endpoint<HTTPBin>(url: URL(target: target).absoluteString, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, task: task, httpHeaderFields: target.headers)
+            }
+            provider = MoyaProvider<HTTPBin>(endpointClosure: endpointClosure, manager: sessionManager)
+        }
+
+        it("returns a new endpoint for adding(newHTTPHeaderFields:)") {
+            let multipartData1 = Moya.MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test1")
+            let multipartData2 = Moya.MultipartFormData(provider: .data("test2".data(using: .utf8)!), name: "test2")
+
+            let providedMultipartData = [multipartData1]
+            let sentMultipartData = [multipartData1, multipartData2]
+
+            _ = provider.request(.uploadMultipart(providedMultipartData, nil)) { _ in }
+            let stringData1 = String(data: try! sessionManager.uploadMultipartFormData!.encode(), encoding: .utf8)
+            let stringData2 = String(data: try! sessionManager.convertMoyaMultipartFormDataToAlamofire(sentMultipartData).encode(), encoding: .utf8)
+
+            let formData1 = "data; name=\"test1\"\r\n\r\ntest1\r\n"
+            let formData2 = "data; name=\"test2\"\r\n\r\ntest2\r\n"
+
+            let splitString1 = stringData1?.split(separator: "-").map { String($0) }
+            let splitString2 = stringData2?.split(separator: "-").map { String($0) }
+
+            expect(splitString1).to(contain(formData1))
+            expect(splitString1).to(contain(formData2))
+            expect(splitString2).to(contain(formData1))
+            expect(splitString2).to(contain(formData2))
+
+        }
+    }
+}
+
+final class SessionManagerMock: SessionManager {
+
+    var uploadMultipartFormData: Alamofire.MultipartFormData?
+
+    override func upload(multipartFormData: @escaping (Alamofire.MultipartFormData) -> Void, usingThreshold encodingMemoryThreshold: UInt64, with urlRequest: URLRequestConvertible, encodingCompletion: ((SessionManager.MultipartFormDataEncodingResult) -> Void)?) {
+        let uploadMultipartFormData = Alamofire.MultipartFormData()
+        multipartFormData(uploadMultipartFormData)
+        self.uploadMultipartFormData = uploadMultipartFormData
+    }
+
+    func convertMoyaMultipartFormDataToAlamofire(_ multipartBody: [Moya.MultipartFormData]) -> Alamofire.MultipartFormData {
+        let form = RequestMultipartFormData()
+        for bodyPart in multipartBody {
+            switch bodyPart.provider {
+            case .data(let data):
+                form.append(data: data, bodyPart: bodyPart)
+            case .file(let url):
+                form.append(fileURL: url, bodyPart: bodyPart)
+            case .stream(let stream, let length):
+                form.append(stream: stream, length: length, bodyPart: bodyPart)
+            }
+        }
+
+        return form
+    }
+}


### PR DESCRIPTION
This resolves #1546 by switching on `endpoint.task` instead of the original `target.task`. 

This way when a request is performed it will have any changes made to the: `.uploadMultipart`, `.uploadCompositeMultipart`, `.uploadFile`, `.downloadDestination`, and `.downloadParameters` tasks through an `endpointClosure`.

Thanks to @sunshinejr for setting up the test