### PR TITLE
Add Danger rule to help track English and Chinese docs

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -6,9 +6,11 @@ has_app_changes = !git.modified_files.grep(/Sources/).empty?
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
 warn("PR is classed as Work in Progress") if github.pr_title.include? "WIP"
 
-# Warn, asking to update Chinese translation of docs if file(s) in `docs` is/are modified
-if !git.modified_files.grep(/docs/).empty?
-  warn("Consider **also** updating the Chinese version of the docs, if possible. Otherwise, request the modified file(s) to be added to the list [here](https://github.com/Moya/Moya/issues/1357) for someone else to translate.")
+# Warn, asking to update Chinese docs if only English docs are updated and vice-versa
+en_docs_modified = git.modified_files.grep(%r{docs/}).empty? # Necessary to exclude `docs_CN` from the grep.
+cn_docs_modified = git.modified_files.grep(%r{docs_CN}).empty?
+if en_docs_modified ^ cn_docs_modified
+  warn("Consider **also** updating the #{ en_docs_modified ? "English" : "Chinese" } docs. For Chinese translations, request the modified file(s) to be added to the list [here](https://github.com/Moya/Moya/issues/1357) for someone else to translate, if you can't do so yourself.")
 end
 
 # Warn when there is a big PR

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,6 +6,11 @@ has_app_changes = !git.modified_files.grep(/Sources/).empty?
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
 warn("PR is classed as Work in Progress") if github.pr_title.include? "WIP"
 
+# Warn, asking to update Chinese translation of docs if file(s) in `docs` is/are modified
+if !git.modified_files.grep(/docs/).empty?
+  warn("Consider **also** updating the Chinese version of the docs, if possible. Otherwise, request the modified file(s) to be added to the list [here](https://github.com/Moya/Moya/issues/1357) for someone else to translate.")
+end
+
 # Warn when there is a big PR
 warn("Big PR, try to keep changes smaller if you can") if git.lines_of_code > 500
 


### PR DESCRIPTION
This change makes it so that Danger warns the user to try and update the corresponding Chinese docs, if possible. Otherwise, it asks the user to have the modified file(s) to be added to the list of Chinese docs to be translated being tracked in #1357.

I'm not an expert Ruby developer, so if I can trim some lines of code, LMK, I'll update this PR. 😅

💖

<hr />
Closes #1548

<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
