### PR TITLE
Add discussion label to exemptLabels for StaleBot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   - "enhancement"
   - "confirmed bug"
   - "chore"
+  - "discussion"
 
 # Label to use when marking as stale
 staleLabel: stale


### PR DESCRIPTION
I've added "discussion" label to the `exemptLabels`, which just prevents StaleBot from closing/making it stale. Discussions tend to be long and most of the time we reopen them by ourselves whenever StaleBot is taking action. Thus, I figured we could automate it 😄 