### PR TITLE
mapOptional<D: Decodable>( ... ) for Observable and Signal

### DIFF
--- a/Sources/RxMoya/Observable+Response.swift
+++ b/Sources/RxMoya/Observable+Response.swift
@@ -10,53 +10,66 @@ extension ObservableType where E == Response {
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
     public func filter(statusCodes: ClosedRange<Int>) -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filter(statusCodes: statusCodes))
+            return .just(try response.filter(statusCodes: statusCodes))
         }
     }
 
     public func filter(statusCode: Int) -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filter(statusCode: statusCode))
+            return .just(try response.filter(statusCode: statusCode))
         }
     }
 
     public func filterSuccessfulStatusCodes() -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filterSuccessfulStatusCodes())
+            return .just(try response.filterSuccessfulStatusCodes())
         }
     }
 
     public func filterSuccessfulStatusAndRedirectCodes() -> Observable<E> {
         return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filterSuccessfulStatusAndRedirectCodes())
+            return .just(try response.filterSuccessfulStatusAndRedirectCodes())
         }
     }
 
     /// Maps data received from the signal into an Image. If the conversion fails, the signal errors.
     public func mapImage() -> Observable<Image?> {
         return flatMap { response -> Observable<Image?> in
-            return Observable.just(try response.mapImage())
+            return .just(try response.mapImage())
         }
     }
 
     /// Maps data received from the signal into a JSON object. If the conversion fails, the signal errors.
     public func mapJSON(failsOnEmptyData: Bool = true) -> Observable<Any> {
         return flatMap { response -> Observable<Any> in
-            return Observable.just(try response.mapJSON(failsOnEmptyData: failsOnEmptyData))
+            return .just(try response.mapJSON(failsOnEmptyData: failsOnEmptyData))
         }
     }
 
     /// Maps received data at key path into a String. If the conversion fails, the signal errors.
     public func mapString(atKeyPath keyPath: String? = nil) -> Observable<String> {
         return flatMap { response -> Observable<String> in
-            return Observable.just(try response.mapString(atKeyPath: keyPath))
+            return .just(try response.mapString(atKeyPath: keyPath))
         }
     }
 
     /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
     public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> Observable<D> {
         return flatMap { response -> Observable<D> in
-            return Observable.just(try response.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData))
+            return .just(try response.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData))
+        }
+    }
+    
+    /// Maps received data at key path into a Decodable object.
+    /// If the conversion fails, the nil is returned instead of error signal.
+    public func mapOptional<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder()) -> Observable<D?> {
+        return flatMap { response -> Observable<D?> in
+            do {
+                let object = try response.map(type, atKeyPath: keyPath, using: decoder)
+                return .just(object)
+            } catch {
+                return .just(nil)
+            }   
         }
     }
 }

--- a/Sources/RxMoya/Single+Response.swift
+++ b/Sources/RxMoya/Single+Response.swift
@@ -10,53 +10,67 @@ extension PrimitiveSequence where TraitType == SingleTrait, ElementType == Respo
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
     public func filter(statusCodes: ClosedRange<Int>) -> Single<ElementType> {
         return flatMap { response -> Single<ElementType> in
-            return Single.just(try response.filter(statusCodes: statusCodes))
+            return .just(try response.filter(statusCodes: statusCodes))
         }
     }
 
     public func filter(statusCode: Int) -> Single<ElementType> {
         return flatMap { response -> Single<ElementType> in
-            return Single.just(try response.filter(statusCode: statusCode))
+            return .just(try response.filter(statusCode: statusCode))
         }
     }
 
     public func filterSuccessfulStatusCodes() -> Single<ElementType> {
         return flatMap { response -> Single<ElementType> in
-            return Single.just(try response.filterSuccessfulStatusCodes())
+            return .just(try response.filterSuccessfulStatusCodes())
         }
     }
 
     public func filterSuccessfulStatusAndRedirectCodes() -> Single<ElementType> {
         return flatMap { response -> Single<ElementType> in
-            return Single.just(try response.filterSuccessfulStatusAndRedirectCodes())
+            return .just(try response.filterSuccessfulStatusAndRedirectCodes())
         }
     }
 
     /// Maps data received from the signal into an Image. If the conversion fails, the signal errors.
     public func mapImage() -> Single<Image?> {
         return flatMap { response -> Single<Image?> in
-            return Single.just(try response.mapImage())
+            return .just(try response.mapImage())
         }
     }
 
     /// Maps data received from the signal into a JSON object. If the conversion fails, the signal errors.
     public func mapJSON(failsOnEmptyData: Bool = true) -> Single<Any> {
         return flatMap { response -> Single<Any> in
-            return Single.just(try response.mapJSON(failsOnEmptyData: failsOnEmptyData))
+            return .just(try response.mapJSON(failsOnEmptyData: failsOnEmptyData))
         }
     }
 
     /// Maps received data at key path into a String. If the conversion fails, the signal errors.
     public func mapString(atKeyPath keyPath: String? = nil) -> Single<String> {
         return flatMap { response -> Single<String> in
-            return Single.just(try response.mapString(atKeyPath: keyPath))
+            return .just(try response.mapString(atKeyPath: keyPath))
         }
     }
 
     /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
     public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> Single<D> {
         return flatMap { response -> Single<D> in
-            return Single.just(try response.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData))
+            return .just(try response.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData))
         }
     }
+    
+    /// Maps received data at key path into a Decodable object.
+    /// If the conversion fails, the nil is returned instead of error signal.
+    public func mapOptional<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder()) -> Single<D?> {
+        return flatMap { response -> Single<D?> in
+            do {
+                let object = try response.map(type, atKeyPath: keyPath, using: decoder)
+                return .just(object)
+            } catch {
+                return .just(nil)
+            }   
+        }
+    }
+
 }


### PR DESCRIPTION
This pull request covers the case when `nil` is returned by `Observable/Signal` instead of error.