### PR TITLE
Fix Alamofire validation not being performed on uploadMultipart

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 # Next
 
+## Fixed
+- Fixes Alamofire validation not being performed on `.uploadMultipart` requests.
+[#1591](https://github.com/Moya/Moya/pull/1591) by [@SD10](https://github.com/SD10).
+
 # [11.0.0] - 2018-02-07
+- No changes
 
 # [11.0.0-beta.2] - 2018-01-27
 ## Changed

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -162,7 +162,9 @@ private extension MoyaProvider {
                     self.cancelCompletion(completion, target: target)
                     return
                 }
-                cancellable.innerCancellable = self.sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
+                let validationCodes = target.validationType.statusCodes
+                let validated = validationCodes.isEmpty ? alamoRequest : alamoRequest.validate(statusCode: validationCodes)
+                cancellable.innerCancellable = self.sendAlamofireRequest(validated, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
             case .failure(let error):
                 completion(.failure(MoyaError.underlying(error as NSError, nil)))
             }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -163,8 +163,8 @@ private extension MoyaProvider {
                     return
                 }
                 let validationCodes = target.validationType.statusCodes
-                let validated = validationCodes.isEmpty ? alamoRequest : alamoRequest.validate(statusCode: validationCodes)
-                cancellable.innerCancellable = self.sendAlamofireRequest(validated, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
+                let validatedRequest = validationCodes.isEmpty ? alamoRequest : alamoRequest.validate(statusCode: validationCodes)
+                cancellable.innerCancellable = self.sendAlamofireRequest(validatedRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
             case .failure(let error):
                 completion(.failure(MoyaError.underlying(error as NSError, nil)))
             }

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -306,21 +306,21 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                 let formData = HTTPBin.createMultipartFormData()
                 let target = HTTPBin.validatedUploadMultipart(formData, nil)
                 let provider = MoyaProvider<HTTPBin>()
-                provider.request(target) { result in
-                    switch result {
-                    case .success(let response):
-                        let validCodes = target.validationType.statusCodes
-                        expect(validCodes).to(contain(response.statusCode))
-                    case .failure(let error):
-                        switch error {
-                        case .underlying(_, let response):
-                            let validCodes = target.validationType.statusCodes
-                            expect(validCodes).toNot(contain(response!.statusCode))
-                        default:
-                            fatalError("Received unexpected error")
+                var receievedResponse: Response?
+                var receivedError: Error?
+                waitUntil(timeout: 5.0) { done in
+                    provider.request(target) { result in
+                        switch result {
+                        case .success(let response):
+                            receievedResponse = response
+                        case .failure(let error):
+                            receivedError = error
                         }
+                        done()
                     }
                 }
+                expect(receievedResponse).to(beNil())
+                expect(receivedError).toNot(beNil())
             }
         }
     }

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -304,10 +304,12 @@ final class MoyaProviderIntegrationTests: QuickSpec {
         describe("a provider performing a multipart upload with Alamofire validation") {
             let provider = MoyaProvider<HTTPBin>()
             let formData = HTTPBin.createTestMultipartFormData()
+
             it("returns an error for status code different than 287") {
                 let target = HTTPBin.validatedUploadMultipart(formData, nil, [287])
                 var receievedResponse: Response?
                 var receivedError: Error?
+
                 waitUntil(timeout: 5.0) { done in
                     provider.request(target) { result in
                         switch result {
@@ -319,14 +321,17 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                         done()
                     }
                 }
+
                 expect(receievedResponse).to(beNil())
                 expect(receivedError).toNot(beNil())
             }
+
             it("returns a valid response for .succesCodes") {
                 let successCodes = ValidationType.successCodes.statusCodes
                 let target = HTTPBin.validatedUploadMultipart(formData, nil, successCodes)
                 var receievedResponse: Response?
                 var receivedError: Error?
+
                 waitUntil(timeout: 5.0) { done in
                     provider.request(target) { result in
                         switch result {
@@ -338,6 +343,7 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                         done()
                     }
                 }
+
                 expect(receievedResponse).toNot(beNil())
                 expect(receivedError).to(beNil())
             }

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -299,6 +299,29 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                 }
             }
         }
+
+        describe("a provider performing a multipart upload with Alamofire validation") {
+            it("only allows status code 287") {
+                let formData = HTTPBin.createMultipartFormData()
+                let target = HTTPBin.validatedUploadMultipart(formData, nil)
+                let provider = MoyaProvider<HTTPBin>()
+                provider.request(target) { result in
+                    switch result {
+                    case .success(let response):
+                        let validCodes = target.validationType.statusCodes
+                        expect(validCodes).to(contain(response.statusCode))
+                    case .failure(let error):
+                        switch error {
+                        case .underlying(_, let response):
+                            let validCodes = target.validationType.statusCodes
+                            expect(validCodes).toNot(contain(response!.statusCode))
+                        default:
+                            fatalError("Received unexpected error")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -300,6 +300,7 @@ final class MoyaProviderIntegrationTests: QuickSpec {
             }
         }
 
+        // Resolves ValidationType not working with multipart upload #1590
         describe("a provider performing a multipart upload with Alamofire validation") {
             it("only allows status code 287") {
                 let formData = HTTPBin.createMultipartFormData()

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -302,10 +302,10 @@ final class MoyaProviderIntegrationTests: QuickSpec {
 
         // Resolves ValidationType not working with multipart upload #1590
         describe("a provider performing a multipart upload with Alamofire validation") {
-            it("only allows status code 287") {
-                let formData = HTTPBin.createMultipartFormData()
-                let target = HTTPBin.validatedUploadMultipart(formData, nil)
-                let provider = MoyaProvider<HTTPBin>()
+            let provider = MoyaProvider<HTTPBin>()
+            let formData = HTTPBin.createTestMultipartFormData()
+            it("returns an error for status code different than 287") {
+                let target = HTTPBin.validatedUploadMultipart(formData, nil, [287])
                 var receievedResponse: Response?
                 var receivedError: Error?
                 waitUntil(timeout: 5.0) { done in
@@ -321,6 +321,25 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                 }
                 expect(receievedResponse).to(beNil())
                 expect(receivedError).toNot(beNil())
+            }
+            it("returns a valid response for .succesCodes") {
+                let successCodes = ValidationType.successCodes.statusCodes
+                let target = HTTPBin.validatedUploadMultipart(formData, nil, successCodes)
+                var receievedResponse: Response?
+                var receivedError: Error?
+                waitUntil(timeout: 5.0) { done in
+                    provider.request(target) { result in
+                        switch result {
+                        case .success(let response):
+                            receievedResponse = response
+                        case .failure(let error):
+                            receivedError = error
+                        }
+                        done()
+                    }
+                }
+                expect(receievedResponse).toNot(beNil())
+                expect(receivedError).to(beNil())
             }
         }
     }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -841,13 +841,8 @@ final class MoyaProviderSpec: QuickSpec {
 
             it("tracks progress of multipart request") {
 
-                let url = Bundle(for: MoyaProviderSpec.self).url(forResource: "testImage", withExtension: "png")!
-                let string = "some data"
-                guard let data = string.data(using: .utf8) else { fatalError("Failed creating Data from String \(string)") }
-                let target: HTTPBin = .uploadMultipart([
-                    MultipartFormData(provider: .file(url), name: "file", fileName: "testImage"),
-                    MultipartFormData(provider: .data(data), name: "data")
-                    ], nil)
+                let formData = HTTPBin.createMultipartFormData()
+                let target = HTTPBin.uploadMultipart(formData, nil)
 
                 var progressObjects: [Progress?] = []
                 var progressValues: [Double] = []

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -841,7 +841,7 @@ final class MoyaProviderSpec: QuickSpec {
 
             it("tracks progress of multipart request") {
 
-                let formData = HTTPBin.createMultipartFormData()
+                let formData = HTTPBin.createTestMultipartFormData()
                 let target = HTTPBin.uploadMultipart(formData, nil)
 
                 var progressObjects: [Progress?] = []

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -74,13 +74,14 @@ enum HTTPBin: TargetType {
     case post
     case upload(file: URL)
     case uploadMultipart([MultipartFormData], [String: Any]?)
+    case validatedUploadMultipart([MultipartFormData], [String: Any]?)
 
     var baseURL: URL { return URL(string: "http://httpbin.org")! }
     var path: String {
         switch self {
         case .basicAuth:
             return "/basic-auth/user/passwd"
-        case .post, .upload, .uploadMultipart:
+        case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
             return "/post"
         }
     }
@@ -89,7 +90,7 @@ enum HTTPBin: TargetType {
         switch self {
         case .basicAuth:
             return .get
-        case .post, .upload, .uploadMultipart:
+        case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
             return .post
         }
     }
@@ -100,7 +101,7 @@ enum HTTPBin: TargetType {
         return .requestParameters(parameters: [:], encoding: URLEncoding.default)
         case .upload(let fileURL):
             return .uploadFile(fileURL)
-        case .uploadMultipart(let data, let urlParameters):
+        case .uploadMultipart(let data, let urlParameters), .validatedUploadMultipart(let data, let urlParameters):
             if let urlParameters = urlParameters {
                 return .uploadCompositeMultipart(data, urlParameters: urlParameters)
             } else {
@@ -113,13 +114,22 @@ enum HTTPBin: TargetType {
         switch self {
         case .basicAuth:
             return "{\"authenticated\": true, \"user\": \"user\"}".data(using: String.Encoding.utf8)!
-        case .post, .upload, .uploadMultipart:
+        case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
             return "{\"args\": {}, \"data\": \"\", \"files\": {}, \"form\": {}, \"headers\": { \"Connection\": \"close\", \"Content-Length\": \"0\", \"Host\": \"httpbin.org\" },  \"json\": null, \"origin\": \"198.168.1.1\", \"url\": \"https://httpbin.org/post\"}".data(using: String.Encoding.utf8)!
         }
     }
 
     var headers: [String: String]? {
         return nil
+    }
+
+    var validationType: ValidationType {
+        switch self {
+        case .validatedUploadMultipart:
+            return .customCodes([287])
+        default:
+            return .none
+        }
     }
 }
 
@@ -168,6 +178,20 @@ extension GitHubUserContent: TargetType {
 
     public var headers: [String: String]? {
         return nil
+    }
+}
+
+// MARK: - Upload Multipart Helpers
+
+extension HTTPBin {
+    static func createMultipartFormData() -> [MultipartFormData] {
+        let url = Bundle(for: MoyaProviderSpec.self).url(forResource: "testImage", withExtension: "png")!
+        let string = "some data"
+        guard let data = string.data(using: .utf8) else { fatalError("Failed creating Data from String \(string)") }
+        return [
+            MultipartFormData(provider: .file(url), name: "file", fileName: "testImage"),
+            MultipartFormData(provider: .data(data), name: "data")
+        ]
     }
 }
 

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -74,7 +74,7 @@ enum HTTPBin: TargetType {
     case post
     case upload(file: URL)
     case uploadMultipart([MultipartFormData], [String: Any]?)
-    case validatedUploadMultipart([MultipartFormData], [String: Any]?)
+    case validatedUploadMultipart([MultipartFormData], [String: Any]?, [Int])
 
     var baseURL: URL { return URL(string: "http://httpbin.org")! }
     var path: String {
@@ -101,7 +101,7 @@ enum HTTPBin: TargetType {
         return .requestParameters(parameters: [:], encoding: URLEncoding.default)
         case .upload(let fileURL):
             return .uploadFile(fileURL)
-        case .uploadMultipart(let data, let urlParameters), .validatedUploadMultipart(let data, let urlParameters):
+        case .uploadMultipart(let data, let urlParameters), .validatedUploadMultipart(let data, let urlParameters, _):
             if let urlParameters = urlParameters {
                 return .uploadCompositeMultipart(data, urlParameters: urlParameters)
             } else {
@@ -125,8 +125,8 @@ enum HTTPBin: TargetType {
 
     var validationType: ValidationType {
         switch self {
-        case .validatedUploadMultipart:
-            return .customCodes([287])
+        case .validatedUploadMultipart(_, _, let codes):
+            return .customCodes(codes)
         default:
             return .none
         }
@@ -184,7 +184,7 @@ extension GitHubUserContent: TargetType {
 // MARK: - Upload Multipart Helpers
 
 extension HTTPBin {
-    static func createMultipartFormData() -> [MultipartFormData] {
+    static func createTestMultipartFormData() -> [MultipartFormData] {
         guard let url = Bundle(for: MoyaProviderSpec.self).url(forResource: "testImage", withExtension: "png") else {
             fatalError("Resource testImage.png could not be found in bundle")
         }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -185,9 +185,13 @@ extension GitHubUserContent: TargetType {
 
 extension HTTPBin {
     static func createMultipartFormData() -> [MultipartFormData] {
-        let url = Bundle(for: MoyaProviderSpec.self).url(forResource: "testImage", withExtension: "png")!
+        guard let url = Bundle(for: MoyaProviderSpec.self).url(forResource: "testImage", withExtension: "png") else {
+            fatalError("Resource testImage.png could not be found in bundle")
+        }
         let string = "some data"
-        guard let data = string.data(using: .utf8) else { fatalError("Failed creating Data from String \(string)") }
+        guard let data = string.data(using: .utf8) else {
+            fatalError("Failed creating Data from String \(string)")
+        }
         return [
             MultipartFormData(provider: .file(url), name: "file", fileName: "testImage"),
             MultipartFormData(provider: .data(data), name: "data")


### PR DESCRIPTION
Resolves #1590 

Alamofire validation was not being performed on `.uploadMultipart` requests. I've added a backing unit test for this. 