### PR TITLE
Perform validation on stubbed responses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ### Fixed
 - Fixed Alamofire validation not being performed on `.uploadMultipart` requests.
 [#1591](https://github.com/Moya/Moya/pull/1591) by [@SD10](https://github.com/SD10).
-- Fixed `Response` validation not being performed on stubbed requests.
+- Fixed Alamofire validation not being performed on stubbed requests.
 [#1593](https://github.com/Moya/Moya/pull/1593) by [@SD10](https://github.com/sd10).
 
 # [11.0.0] - 2018-02-07

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+### Fixed
+- Fixes `Response` validation not being performed on stubbed requests.
+[#1593](https://github.com/Moya/Moya/pull/1593) by [@SD10](https://github.com/sd10).
+
 # [11.0.0] - 2018-02-07
 
 # [11.0.0-beta.2] - 2018-01-27

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -122,15 +122,29 @@ public extension MoyaProvider {
                 return
             }
 
+            let validate = { (response: Moya.Response) -> Result<Moya.Response, MoyaError> in
+                let validCodes = target.validationType.statusCodes
+                guard !validCodes.isEmpty else { return .success(response) }
+                if validCodes.contains(response.statusCode) {
+                    return .success(response)
+                } else {
+                    let statusError = MoyaError.statusCode(response)
+                    let error = MoyaError.underlying(statusError, response)
+                    return .failure(error)
+                }
+            }
+
             switch endpoint.sampleResponseClosure() {
             case .networkResponse(let statusCode, let data):
                 let response = Moya.Response(statusCode: statusCode, data: data, request: request, response: nil)
-                plugins.forEach { $0.didReceive(.success(response), target: target) }
-                completion(.success(response))
+                let result = validate(response)
+                plugins.forEach { $0.didReceive(result, target: target) }
+                completion(result)
             case .response(let customResponse, let data):
                 let response = Moya.Response(statusCode: customResponse.statusCode, data: data, request: request, response: customResponse)
-                plugins.forEach { $0.didReceive(.success(response), target: target) }
-                completion(.success(response))
+                let result = validate(response)
+                plugins.forEach { $0.didReceive(result, target: target) }
+                completion(result)
             case .networkError(let error):
                 let error = MoyaError.underlying(error, nil)
                 plugins.forEach { $0.didReceive(.failure(error), target: target) }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -409,8 +409,7 @@ final class MoyaProviderSpec: QuickSpec {
             }
 
             it("returns identical sample response") {
-                // TODO: Fix this failing test
-                let response = HTTPURLResponse(url: URL(string: "http://example.com")!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+                let response = HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
                     return Endpoint(url: URL(target: target).absoluteString, sampleResponseClosure: { .response(response, target.sampleData) }, method: target.method, task: target.task, httpHeaderFields: target.headers)
                 }

--- a/Tests/MoyaProviderSpec.swift
+++ b/Tests/MoyaProviderSpec.swift
@@ -973,6 +973,7 @@ final class MoyaProviderSpec: QuickSpec {
             }
         }
 
+        // Resolves #1592 where validation is not performed on a stubbed request
         describe("a provider for stubbed requests with validation") {
             var stubbedProvider: MoyaProvider<GitHub>!
 


### PR DESCRIPTION
Resolves #1592 

This adds the ability to validate a stubbed response.

#### Something to consider:
The `EndpointSampleResponse` has a case `.response(HTTPURLResponse, Data)`. 

We have a unit test for this where we use the `URLResponse` initializer to create the `HTTPURLResponse`.

You can see the two initializers below:
```Swift
// HTTPURLResponse initializer
public init?(url: URL, statusCode: Int, httpVersion HTTPVersion: String?, headerFields: [String: String]?)

// URLResponse initializer
public init(url: URL, mimeType MIMEType: String?, expectedContentLength length: Int, textEncodingName name: String?)
```
 
This change would require that you use the `HTTPURLResponse` initializer because that is the only way to set the `statusCode` property (it is `get-only`). The drawback, however, is arguments like `mimeType` are also `get-only`. 

However, both `HTTPURLResponse` and `URLResponse` are open, so you could get around this by subclassing to make a mock response. 

Looking for thoughts from @Moya/contributors 