### PR TITLE
Remove SwiftLint build phases

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # Next
-
+### Fixed
+- Fixed Carthage compatibility by removing a SwiftLint build phase for now. [#1615](https://github.com/Moya/Moya/pull/1615) by [@sunshinejr](https://github.com/sunshinejr).
 # [11.0.1] - 2018-02-26
 
 ### Fixed

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -29,8 +29,8 @@
 		149749431F8923EC00FA4900 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749421F8923EC00FA4900 /* AnyEncodable.swift */; };
 		149749451F892E2F00FA4900 /* URLRequest+Encoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */; };
 		15D3A2BD1223B59E2BBE09F0 /* MoyaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D47F3DC51C28D950491FAAB /* MoyaError.swift */; };
-		1F8AA0BC1FE0630300C9D7B6 /* ValidationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */; };
 		1F24393320125F8200C9D813 /* EndpointClosureSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */; };
+		1F8AA0BC1FE0630300C9D7B6 /* ValidationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */; };
 		1FD44D9E21CEA6B6221807EF /* NetworkLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4553E5591EE96535C5310C02 /* NetworkLoggerPlugin.swift */; };
 		2ADDFC96D7F7912333534C46 /* SignalProducer+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */; };
 		2C7132B56A7B129E12BAACAC /* EndpointSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E825A32256FC030B8BA2684D /* EndpointSpec.swift */; };
@@ -150,8 +150,8 @@
 		149749421F8923EC00FA4900 /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		149749441F892E2F00FA4900 /* URLRequest+Encoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Encoding.swift"; sourceTree = "<group>"; };
 		14FB7A3E1F3E089900308949 /* Single+Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Single+Response.swift"; sourceTree = "<group>"; };
-		1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationType.swift; sourceTree = "<group>"; };
 		1F24393220125F8200C9D813 /* EndpointClosureSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointClosureSpec.swift; sourceTree = "<group>"; };
+		1F8AA0BB1FE0630300C9D7B6 /* ValidationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationType.swift; sourceTree = "<group>"; };
 		225C397C03E17F7DFBCA2848 /* MoyaProvider+Internal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Internal.swift"; sourceTree = "<group>"; };
 		269C64D1ABED61A91DD873D3 /* SignalProducer+Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SignalProducer+Response.swift"; sourceTree = "<group>"; };
 		2AD20F6A819D899E3278E903 /* NetworkActivityPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkActivityPlugin.swift; sourceTree = "<group>"; };
@@ -489,7 +489,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 469A06821F705C3E001153A0 /* Build configuration list for PBXNativeTarget "Basic" */;
 			buildPhases = (
-				46AE31F61F86DEEF004E4236 /* Swiftlint */,
 				469A066F1F705C3E001153A0 /* Sources */,
 				469A06701F705C3E001153A0 /* Frameworks */,
 				469A06711F705C3E001153A0 /* Resources */,
@@ -512,7 +511,6 @@
 				469A06861F705C4E001153A0 /* Frameworks */,
 				469A06871F705C4E001153A0 /* Resources */,
 				1463B87F1F8A8A79002D9C4F /* Embed Frameworks */,
-				46AE31F71F86DEFE004E4236 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -563,7 +561,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2066E11FF26ED668745C75F0 /* Build configuration list for PBXNativeTarget "MoyaTests" */;
 			buildPhases = (
-				46AE31F51F86DEE2004E4236 /* Swiftlint */,
 				8434BE38D4F49CF6A376FEAC /* Sources */,
 				79EE6DEC46EED0B6DF2F3604 /* Resources */,
 				893A08BEE844EE1A074B526F /* Frameworks */,
@@ -706,48 +703,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		46AE31F51F86DEE2004E4236 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint to lint!\"\nfi";
-		};
-		46AE31F61F86DEEF004E4236 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint to lint!\"\nfi";
-		};
-		46AE31F71F86DEFE004E4236 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint to lint!\"\nfi";
-		};
 		B33B10BA6802FCF699147E8B /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -527,7 +527,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 730B3998272DA2F2A3DA3BC3 /* Build configuration list for PBXNativeTarget "RxMoya" */;
 			buildPhases = (
-				46AE31F41F86DED0004E4236 /* Swiftlint */,
 				32F3AD3786CDD74D9581BAD8 /* Headers */,
 				27825A1A1770E680684F9B64 /* Sources */,
 				6C19AE05179816E0E74776FD /* Resources */,
@@ -546,7 +545,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7F311DEFBAD859E3836BF38C /* Build configuration list for PBXNativeTarget "ReactiveMoya" */;
 			buildPhases = (
-				46AE31F31F86DDFC004E4236 /* Swiftlint */,
 				685A8F97EA2FF47C7F6FF84E /* Headers */,
 				2D769A89D905FD6D03ECF24C /* Sources */,
 				8A60BE8FF1AF8DE50D5C3B8F /* Resources */,
@@ -587,7 +585,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3190CB92EA23E8BF6F8407F2 /* Build configuration list for PBXNativeTarget "Moya" */;
 			buildPhases = (
-				46AE31F21F86DDC6004E4236 /* Swiftlint */,
 				B89AF3F53E069FA188A11C14 /* Headers */,
 				054614992B184CBD90E510ED /* Sources */,
 				E83509792249AE1FFE8EA7B7 /* Resources */,
@@ -709,48 +706,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		46AE31F21F86DDC6004E4236 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint to lint!\"\nfi";
-		};
-		46AE31F31F86DDFC004E4236 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint to lint!\"\nfi";
-		};
-		46AE31F41F86DED0004E4236 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint to lint!\"\nfi";
-		};
 		46AE31F51F86DEE2004E4236 /* Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -48,7 +48,7 @@ public enum MultiTarget: TargetType {
     /// The embedded `TargetType`.
     public var target: TargetType {
         switch self {
-        case .target(let t): return t
+        case .target(let target): return target
         }
     }
 }

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -82,8 +82,8 @@ final class ErrorTests: QuickSpec {
                 switch result {
                 case let .failure(error):
                     switch error {
-                    case let .underlying(e, _):
-                        expect(e as NSError) == underlyingError
+                    case let .underlying(error, _):
+                        expect(error as NSError) == underlyingError
                     default:
                         XCTFail("expected to get underlying error")
                     }

--- a/Tests/NetworkLoggerPluginSpec.swift
+++ b/Tests/NetworkLoggerPluginSpec.swift
@@ -127,11 +127,11 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
 private class TestStreamRequest: RequestType {
     var request: URLRequest? {
-        var r = URLRequest(url: URL(string: url(GitHub.zen))!)
-        r.allHTTPHeaderFields = ["Content-Type": "application/json"]
-        r.httpBodyStream = InputStream(data: "cool body".data(using: .utf8)!)
+        var request = URLRequest(url: URL(string: url(GitHub.zen))!)
+        request.allHTTPHeaderFields = ["Content-Type": "application/json"]
+        request.httpBodyStream = InputStream(data: "cool body".data(using: .utf8)!)
 
-        return r
+        return request
     }
 
     func authenticate(user: String, password: String, persistence: URLCredential.Persistence) -> Self {
@@ -145,11 +145,11 @@ private class TestStreamRequest: RequestType {
 
 private class TestBodyRequest: RequestType {
     var request: URLRequest? {
-        var r = URLRequest(url: URL(string: url(GitHub.zen))!)
-        r.allHTTPHeaderFields = ["Content-Type": "application/json"]
-        r.httpBody = "cool body".data(using: .utf8)
+        var request = URLRequest(url: URL(string: url(GitHub.zen))!)
+        request.allHTTPHeaderFields = ["Content-Type": "application/json"]
+        request.httpBody = "cool body".data(using: .utf8)
 
-        return r
+        return request
     }
 
     func authenticate(user: String, password: String, persistence: URLCredential.Persistence) -> Self {
@@ -163,11 +163,11 @@ private class TestBodyRequest: RequestType {
 
 private class TestCurlBodyRequest: RequestType, CustomDebugStringConvertible {
     var request: URLRequest? {
-        var r = URLRequest(url: URL(string: url(GitHub.zen))!)
-        r.allHTTPHeaderFields = ["Content-Type": "application/json"]
-        r.httpBody = "cool body".data(using: .utf8)
+        var request = URLRequest(url: URL(string: url(GitHub.zen))!)
+        request.allHTTPHeaderFields = ["Content-Type": "application/json"]
+        request.httpBody = "cool body".data(using: .utf8)
 
-        return r
+        return request
     }
 
     func authenticate(user: String, password: String, persistence: URLCredential.Persistence) -> Self {

--- a/Tests/SignalProducer+MoyaSpec.swift
+++ b/Tests/SignalProducer+MoyaSpec.swift
@@ -169,8 +169,8 @@ final class SignalProducerMoyaSpec: QuickSpec {
 
                 var receivedJSON: [String: String]?
                 signal.mapJSON().startWithResult { result in
-                    if case .success(let _json) = result,
-                        let json = _json as? [String: String] {
+                    if case .success(let response) = result,
+                        let json = response as? [String: String] {
                         receivedJSON = json
                     }
                 }


### PR DESCRIPTION
Fixes #1458 and #1542.

I removed the build phases because it does more harm than it helps right now. Not only there is a problem for people that do not have SwiftLint installed, but also there is a problem with new versions of Swift and new versions of SwiftLint, whenever there is a linter error the build just doesn't pass.

Right now we have a linter on every PR, so that's a good start. We could try a fix that Quick did for the same problem. I'm gonna create an issue for the improvement with link to their fix.

Also, I'm targeting master so we can release the next patch version after the merge, for Carthage users.

Oh, and while I was at it, fixed some of the SwiftLint errors.