### PR TITLE
Making range filter generic to any range type.

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "4.7.0"
+github "Alamofire/Alamofire" "4.7.1"
 github "AliSoftware/OHHTTPStubs" "f90c2bb0fb882e43761ab963ca8869d349d2c6e3"
 github "Quick/Nimble" "v7.0.3"
 github "Quick/Quick" "v1.2.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Next
 
-### Added
+### Changed
 
-- **API Change** Response filter by range now receives a generic `RangeExpression` parameter that accepts any range type.  [#1624](https://github.com/Moya/Moya/pull/1624) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+- **Breaking Change** Changed `Response`s filter method parameter to use a generic `RangeExpression` that accepts any range type. [#1624](https://github.com/Moya/Moya/pull/1624) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 
 # [11.0.1] - 2018-02-26
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Convenience filter by `Range<Int>` on reponses.  [#1605](https://github.com/Moya/Moya/pull/1605) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+- **API Change** Response filter by range now receives a generic `RangeExpression` parameter that accepts any range type.  [#1624](https://github.com/Moya/Moya/pull/1624) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 
 # [11.0.1] - 2018-02-26
 

--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -42,7 +42,7 @@ public final class Response: CustomDebugStringConvertible, Equatable {
 public extension Response {
 
     /**
-     Returns the `Response` if the `statusCode` falls within the specified closed range.
+     Returns the `Response` if the `statusCode` falls within the specified range.
 
      - parameters:
         - statusCodes: The range of acceptable status codes.

--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -48,22 +48,11 @@ public extension Response {
         - statusCodes: The range of acceptable status codes.
      - throws: `MoyaError.statusCode` when others are encountered.
     */
-    public func filter(statusCodes: ClosedRange<Int>) throws -> Response {
+    public func filter<R: RangeExpression>(statusCodes: R) throws -> Response where R.Bound == Int {
         guard statusCodes.contains(statusCode) else {
             throw MoyaError.statusCode(self)
         }
         return self
-    }
-
-    /**
-     Returns the `Response` if the `statusCode` falls within the specified range.
-     
-     - parameters:
-     - statusCodes: The range of acceptable status codes.
-     - throws: `MoyaError.statusCode` when others are encountered.
-     */
-    public func filter(statusCodes: Range<Int>) throws -> Response {
-        return try filter(statusCodes: statusCodes.lowerBound...statusCodes.upperBound-1)
     }
 
     /**

--- a/Sources/ReactiveMoya/SignalProducer+Response.swift
+++ b/Sources/ReactiveMoya/SignalProducer+Response.swift
@@ -8,14 +8,7 @@ import Moya
 extension SignalProducerProtocol where Value == Response, Error == MoyaError {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filter(statusCodes: ClosedRange<Int>) -> SignalProducer<Value, MoyaError> {
-        return producer.flatMap(.latest) { response -> SignalProducer<Value, Error> in
-            return unwrapThrowable { try response.filter(statusCodes: statusCodes) }
-        }
-    }
-
-    /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filter(statusCodes: Range<Int>) -> SignalProducer<Value, MoyaError> {
+    public func filter<R: RangeExpression>(statusCodes: R) -> SignalProducer<Value, MoyaError> where R.Bound == Int {
         return producer.flatMap(.latest) { response -> SignalProducer<Value, Error> in
             return unwrapThrowable { try response.filter(statusCodes: statusCodes) }
         }

--- a/Sources/RxMoya/Observable+Response.swift
+++ b/Sources/RxMoya/Observable+Response.swift
@@ -8,14 +8,7 @@ import Moya
 extension ObservableType where E == Response {
 
     /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filter(statusCodes: ClosedRange<Int>) -> Observable<E> {
-        return flatMap { response -> Observable<E> in
-            return Observable.just(try response.filter(statusCodes: statusCodes))
-        }
-    }
-
-    /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filter(statusCodes: Range<Int>) -> Observable<E> {
+    public func filter<R: RangeExpression>(statusCodes: R) -> Observable<E> where R.Bound == Int {
         return flatMap { response -> Observable<E> in
             return Observable.just(try response.filter(statusCodes: statusCodes))
         }

--- a/Sources/RxMoya/Single+Response.swift
+++ b/Sources/RxMoya/Single+Response.swift
@@ -8,14 +8,7 @@ import RxSwift
 extension PrimitiveSequence where TraitType == SingleTrait, ElementType == Response {
 
     /// Filters out responses that don't fall within the given closed range, generating errors when others are encountered.
-    public func filter(statusCodes: ClosedRange<Int>) -> Single<ElementType> {
-        return flatMap { response -> Single<ElementType> in
-            return Single.just(try response.filter(statusCodes: statusCodes))
-        }
-    }
-
-    /// Filters out responses that don't fall within the given range, generating errors when others are encountered.
-    public func filter(statusCodes: Range<Int>) -> Single<ElementType> {
+    public func filter<R: RangeExpression>(statusCodes: R) -> Single<ElementType> where R.Bound == Int {
         return flatMap { response -> Single<ElementType> in
             return Single.just(try response.filter(statusCodes: statusCodes))
         }


### PR DESCRIPTION
Hey guys :)) 
Proposal 
I did a PR adding a convenience filter for Range #1605 
But now I think is a better idea make instead of adding a convenience function for any Range type, just make the existing function generic and maintain only on function implementation that can handle any range type for a filter.  
