### PR TITLE
Workaround to fix long Carthage build times

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,7 +139,33 @@ Then run `carthage update`.
 
 If this is your first time using Carthage in the project, you'll need to go through some additional steps as explained [over at Carthage](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
-> NOTE: At this time, Carthage does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built with the above command. However, you don't need to copy frameworks you aren't using into your project. For instance, if you aren't using `ReactiveSwift`, feel free to delete that framework along with `ReactiveMoya` from the Carthage Build directory after `carthage update` completes. Or if you are using `ReactiveSwift` but not `RxSwift`, then `RxMoya`, `RxTest`, `RxCocoa`, etc. can safely be deleted.
+> NOTE: At this time, Carthage does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built with the above command. However, you don't need to copy frameworks you aren't using into your project. For instance, if you aren't using `ReactiveSwift`, feel free to delete that framework along with `ReactiveMoya` from the Carthage Build directory after `carthage update` completes. Or if you are using `ReactiveSwift` but not `RxSwift`, then `RxMoya`, `RxTest`, `RxCocoa`, etc. can safely be deleted. Read the next section for a workaround to this.
+
+#### Workaround to enhance build time (Beta)
+
+If you want Carthage to only build a specific variant of Moya with only the dependencies needed for that, we have a workaround for you that's less flexible regarding version specification but still provides you with minor and patch updates to Moya without editing the `Cartfile`.
+
+For plain Moya, use this entry instead:
+
+```
+github "Moya/Moya" "carthage/moya/11.x"
+```
+
+This will checkout the branch `carthage/moya/11.x` which only includes the plain Moya version and its dependencies leaving to a reduced build time. When a new minor or patch version of Moya is released, we will rebase that branch onto the latest release. New major releases will get their own branch.
+
+For RxMoya you would use this:
+
+```
+github "Moya/Moya" "carthage/rxmoya/11.x"
+```
+
+For ReactiveMoya, use this:
+
+```
+github "Moya/Moya" "carthage/reactivemoya/11.x"
+```
+
+NOTE: Please be aware that we don't have long-time experience with this workaround yet and might decide against it and remove it entirely. Once the solution proves to work fine with updates, we will remove the Beta status. We might also remove it once [this issue](https://github.com/Carthage/Carthage/issues/1227) on Carthage is solved.
 
 ### Manually
 


### PR DESCRIPTION
Wow, I can't believe I waited so long for https://github.com/Carthage/Carthage/issues/1227 to be tackled. But I've given up on that long ago after even trying to [fix it myself](https://github.com/Carthage/Carthage/pull/1990) (with no success). Now, I just started [developing a new framework](https://github.com/JamitLabs/LingoHubSync) supporting multiple platforms and plan to use plain Moya (without the reactive extensions). And here's what I saw:

```
*** Building scheme "Alamofire iOS" in Alamofire.xcworkspace
*** Building scheme "Alamofire macOS" in Alamofire.xcworkspace
*** Building scheme "Alamofire watchOS" in Alamofire.xcworkspace
*** Building scheme "Alamofire tvOS" in Alamofire.xcworkspace
*** Building scheme "Result-Mac" in Result.xcodeproj
*** Building scheme "Result-iOS" in Result.xcodeproj
*** Building scheme "Result-watchOS" in Result.xcodeproj
*** Building scheme "Result-tvOS" in Result.xcodeproj
*** Building scheme "ReactiveSwift-macOS" in ReactiveSwift.xcworkspace
*** Building scheme "ReactiveSwift-watchOS" in ReactiveSwift.xcworkspace
*** Building scheme "ReactiveSwift-tvOS" in ReactiveSwift.xcworkspace
*** Building scheme "ReactiveSwift-iOS" in ReactiveSwift.xcworkspace
*** Building scheme "RxBlocking-tvOS" in Rx.xcworkspace
*** Building scheme "RxBlocking-macOS" in Rx.xcworkspace
*** Building scheme "RxBlocking-iOS" in Rx.xcworkspace
*** Building scheme "RxBlocking-watchOS" in Rx.xcworkspace
*** Building scheme "RxCocoa-macOS" in Rx.xcworkspace
*** Building scheme "RxCocoa-watchOS" in Rx.xcworkspace
*** Building scheme "RxCocoa-tvOS" in Rx.xcworkspace
*** Building scheme "RxCocoa-iOS" in Rx.xcworkspace
*** Building scheme "RxSwift-macOS" in Rx.xcworkspace
*** Building scheme "RxSwift-tvOS" in Rx.xcworkspace
*** Building scheme "RxSwift-watchOS" in Rx.xcworkspace
*** Building scheme "RxSwift-iOS" in Rx.xcworkspace
*** Building scheme "RxTests-macOS" in Rx.xcworkspace
*** Building scheme "RxTests-tvOS" in Rx.xcworkspace
*** Building scheme "RxTests-iOS" in Rx.xcworkspace
*** Building scheme "Moya" in Moya.xcodeproj
*** Building scheme "ReactiveMoya" in Moya.xcodeproj
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -project /Users/JamitLabs/Code/Apple/LingoHubSync/Carthage/Checkouts/Moya/Moya.xcodeproj -scheme ReactiveMoya -configuration Release -derivedDataPath /Users/JamitLabs/Library/Caches/org.carthage.CarthageKit/DerivedData/9.3_9E145/Moya/11.0.2 -sdk watchos ONLY_ACTIVE_ARCH=NO BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive -archivePath /var/folders/2l/3tqwt0g91x18hql0jwsz0y280000gn/T/Moya SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in /Users/JamitLabs/Code/Apple/LingoHubSync/Carthage/Checkouts/Moya)

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/2l/3tqwt0g91x18hql0jwsz0y280000gn/T/carthage-xcodebuild.TakmdP.log
Command '/bin/bash -c "carthage update --platform iOS,tvOS,macOS,watchOS --cache-builds"' returned with error code 1.
⚠️  Command '/bin/bash -c /Users/JamitLabs/Documents/beak/builds/_Users_JamitLabs_Code_Apple_LingoHubSync/.build/debug/BeakFile' returned with error code 1.
```

Not only does Moya compile dozens of frameworks I don't need, but it also fails building one of them. This is plain frustrating so even though #345 was closed long time ago, I think we should finally tackle this for those Moya users who don't ever want to run into this issue again.

**And here's my simple yet working solution:**

Let's **introduce support branches** for each Moya variant (plain Moya, RxMoya, ReactiveMoya) and document that people could opt for using those branches instead of the actual git versioning. So long as we clearly state the advantage and disadvantage it's the developers choice to go for one or the other.

I have actually already created these branches based on the latest release (11.0.2), see `carthage/moya/11.x`, `carthage/rxmoya/11.x` and `carthage/reactivemoya/11.x`. I've just also tested how a build with `carthage/moya/11.x` looks like:

```
*** Building scheme "Alamofire iOS" in Alamofire.xcworkspace
*** Building scheme "Alamofire macOS" in Alamofire.xcworkspace
*** Building scheme "Alamofire watchOS" in Alamofire.xcworkspace
*** Building scheme "Alamofire tvOS" in Alamofire.xcworkspace
*** Building scheme "Result-Mac" in Result.xcodeproj
*** Building scheme "Result-iOS" in Result.xcodeproj
*** Building scheme "Result-watchOS" in Result.xcodeproj
*** Building scheme "Result-tvOS" in Result.xcodeproj
*** Building scheme "Moya" in Moya.xcodeproj
```

Wow, it's much faster and it doesn't fail! Yay 🎉 

Please note the following:
* As you can see in the docs, I've marked this workaround as Beta as we don't have much experience with it yet. We can remove that once we have.
* In order for this to work, we would need to rebase all three branches every time we do a release. I'm not sure if we can automate this properly though, so someone might need to do that manually (and I would actually volunteer myself at the beginning).
* The rationale behind the branch naming had three goals:
  1. It should be clear that it's only for Carthage support.
  2. The name of the Moya variant should be clear.
  3. The major version should be clear.

I hope you like the idea. What do you think? Especially @Moya/core-team?

Fixes #345, finally.