### PR TITLE
Adds note to Vision.md

### DIFF
--- a/Vision.md
+++ b/Vision.md
@@ -3,6 +3,7 @@
 - leverage the Swift compiler to prevent runtime errors associated with configuring network requests.
 - provide a Swift-first API/abstraction for making network requests.
 - provide an API that makes it easy to stub network requests.
+- provide an API where common things are easy, and uncommon things are possible.
 - provide basics of response decoding while exposing customization points for other libraries to help.
 - provide (optional) RxSwift / ReactiveSwift extensions to the API.
 - avoid leaky abstractions by providing thoughtful and easy-to-use extension points for customizing behaviour.


### PR DESCRIPTION
This came up in #1647 and I think it makes sense to add to the vision document. Open to discussion of course. I can't claim credit for this idea, it's been around in the Cocoa/Touch communities so long that I can't even find an original source. But it's a good idea. 

If accepted, this PR will need to be reflected in the `Vision_CN.md` file as well.