### PR TITLE
Fix a header doc to remove the image type specification

### DIFF
--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -84,7 +84,7 @@ public extension Response {
         return try filter(statusCodes: 200...399)
     }
 
-    /// Maps data received from the signal into a UIImage.
+    /// Maps data received from the signal into an Image.
     func mapImage() throws -> Image {
         guard let image = Image(data: data) else {
             throw MoyaError.imageMapping(self)


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
Removes an image type specification in a header doc, as the function might not always return a `UIImage`.