### PR TITLE
✨Danger package manifest warning (#1672)

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -50,7 +50,7 @@ end
 # Warn when either the podspec or Cartfile + Cartfile.resolved has been updated,
 # but not both.
 podspec_updated = !git.modified_files.grep(/Moya.podspec/).empty?
-cartfile_updated = !git.modified_files.grep(/Cartfile/).empty?
+cartfile_updated = !git.modified_files.grep(/Cartfile$/).empty?
 cartfile_resolved_updated = !git.modified_files.grep(/Cartfile.resolved/).empty?
 package_updated = !git.modified_files.grep(/Package.swift/).empty?
 package_resolved_updated = !git.modified_files.grep(/Package.resolved/).empty?

--- a/Dangerfile
+++ b/Dangerfile
@@ -47,28 +47,55 @@ if has_app_changes && missing_doc_changes && doc_changes_recommended && not_decl
   warn("Consider adding supporting documentation to this change. Documentation can be found in the `docs` directory.")
 end
 
-# Warn when either the podspec or Cartfile + Cartfile.resolved has been updated,
-# but not both.
-podspec_updated = !git.modified_files.grep(/Moya.podspec/).empty?
-cartfile_updated = !git.modified_files.grep(/Cartfile$/).empty?
-cartfile_resolved_updated = !git.modified_files.grep(/Cartfile.resolved/).empty?
-package_updated = !git.modified_files.grep(/Package.swift/).empty?
-package_resolved_updated = !git.modified_files.grep(/Package.resolved/).empty?
+# Wrapper for package manifest file name and update status
+PackageManifest = Struct.new(:fileName, :updated)
 
-if podspec_updated && (!cartfile_updated || !cartfile_resolved_updated)
-  warn("The `podspec` was updated, but there were no changes in either the `Cartfile` nor `Cartfile.resolved`. Did you forget updating `Cartfile` or `Cartfile.resolved`?")
+# Well formatted, comma separated list of package manifest(s)
+def format_manifests(manifests)
+    return "" if manifests.empty?
+    formatted = manifests.map { |e| "`#{e.fileName}`" }
+    return formatted.first if formatted.size == 1
+    output = formatted.join(', ')
+    output[output.rindex(',')] = ' and'
+    return output
 end
 
-if (cartfile_updated || cartfile_resolved_updated) && !podspec_updated
-  warn("The `Cartfile` or `Cartfile.resolved` was updated, but there were no changes in the `podspec`. Did you forget updating the `podspec`?")
+# Warning message for not updated package manifest(s)
+def manifests_warning_message(updated:, not_updated:)
+    return "Unable to construct warning message." if updated.empty? || not_updated.empty?
+    updated_manifests_names = format_manifests(updated)
+    not_updated_manifests_names = format_manifests(not_updated)
+    updated_article = updated.size == 1 ? "The " : ""
+    updated_verb = updated.size == 1 ? "was" : "were"
+    not_updated_article = not_updated.size == 1 ? "the " : ""
+    output = "#{updated_article}#{updated_manifests_names} #{updated_verb} updated, " \
+             "but there were no changes in #{not_updated_article}#{not_updated_manifests_names}.\n"\
+             "Did you forget to update #{not_updated_manifests_names}?"
+    return output
 end
 
-if (cartfile_updated && !cartfile_resolved_updated)
-  warn("The `Cartfile` was updated, but `Cartfile.resolved` was not. Did you forget to update `Cartfile.resolved`?" )
+# Warn when any of the package manifest(s) updated but not others
+podspec_updated = PackageManifest.new("Moya.podspec", !git.modified_files.grep(/Moya.podspec/).empty?)
+cartfile_updated = PackageManifest.new("Cartfile", !git.modified_files.grep(/Cartfile$/).empty?)
+cartfile_resolved_updated = PackageManifest.new("Cartfile.resolved", !git.modified_files.grep(/Cartfile.resolved/).empty?)
+package_updated = PackageManifest.new("Package.swift", !git.modified_files.grep(/Package.swift/).empty?)
+package_resolved_updated = PackageManifest.new("Package.resolved", !git.modified_files.grep(/Package.resolved/).empty?)
+
+manifests = [
+    podspec_updated, 
+    cartfile_updated, 
+    cartfile_resolved_updated,
+    package_updated,
+    package_resolved_updated
+]
+
+updated_manifests = manifests.select { |e| e.updated }
+not_updated_manifests = manifests.select { |e| !e.updated }
+
+if !updated_manifests.empty? && !not_updated_manifests.empty?
+    warn(manifests_warning_message(updated: updated_manifests, not_updated: not_updated_manifests))
 end
-if (package_updated && !package_resolved_updated)
-  warn("The `Package.swift` was updated, but `Package.resolved` was not. Did you forget to update `Package.resolved`?" )
-end 
+
 # Warn when library files has been updated but not tests.
 tests_updated = !git.modified_files.grep(/Tests/).empty?
 if has_app_changes && !tests_updated


### PR DESCRIPTION
Fixes #1672.

Danger warns if any of manifest files for CocoaPods, Carthage, or SPM updated but not the other two.

This check also may be easily extended for other package managers as well when they will be supported by Moya.