### PR TITLE
Add Moya 11 to 12 migration guide

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@
 
 - **Breaking Change** Changed `Response`s filter method parameter to use a generic `RangeExpression` that accepts any range type. [#1624](https://github.com/Moya/Moya/pull/1624) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida).
 
-- **Breaking Change** Changed `AuthorizationType`'s initializer to no longer use an `@autoclosure` for the `tokenClosure` parameter. [#1611](https://github.com/Moya/Moya/pull/1611) by [@SeRG1k17](https://github.com/SeRG1k17).
+- **Breaking Change** Changed `AccessTokenPlugin`'s initializer to no longer use an `@autoclosure` for the `tokenClosure` parameter. [#1611](https://github.com/Moya/Moya/pull/1611) by [@SeRG1k17](https://github.com/SeRG1k17).
 
 # [11.0.2] - 2018-04-01
 ### Fixed

--- a/docs/MigrationGuides/migration_11_to_12.md
+++ b/docs/MigrationGuides/migration_11_to_12.md
@@ -9,8 +9,7 @@ This project follows [Semantic Versioning](http://semver.org).
 
 ### Response Migration
 
-- The function signature of `Response`'s filter methods has been changed to use a generic argument constrained to `RangeExpression` where the `RangeExpression.Bound` is
-  equal to `Int`, instead of providing overloads supporting both `Range` and `ClosedRange`. Account for this change if you rely on the signature explicitly.
+- The function signature of `Response`'s filter methods has been changed to use a generic argument constrained to `RangeExpression` where the `RangeExpression.Bound` is equal to `Int`, instead of providing overloads supporting both `Range` and `ClosedRange`. Account for this change if you rely on the signature explicitly.
 
 ### ReactiveSwift Migration
 

--- a/docs/MigrationGuides/migration_11_to_12.md
+++ b/docs/MigrationGuides/migration_11_to_12.md
@@ -1,0 +1,17 @@
+# Migration Guide from 11.x to 12.x
+
+This project follows [Semantic Versioning](http://semver.org).
+
+### ReactiveSwift Migration
+- Check the [ReactiveSwift 4.0.0 release notes](https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/4.0.0) for changes related to ReactiveSwift.
+
+### Result Migration
+- Check the [Result 4.0.0 release notes](https://github.com/antitypical/Result/releases/tag/4.0.0) for changes related to Result.
+
+### AccessTokenPlugin Migration
+- Handle `.custom(String)` case for `AuthorizationType` or add a default case to achive exhaustiveness.
+- The `tokenClosure` parameter of the `AccessTokenPlugin` initializer is no longer an `@autoclosure` so you need to wrap the existing value in a closure.
+
+### Response Migration
+- The function signature of `Response`'s filter methods has been changed to use a generic argument with constrained to `RangeExpression` where the `RangeExpression.Bound` is
+equal to `Int`, instead of providing overloads supporting both `Range` and `ClosedRange`. Account for this change if you rely on the signature explicitly.

--- a/docs/MigrationGuides/migration_11_to_12.md
+++ b/docs/MigrationGuides/migration_11_to_12.md
@@ -2,16 +2,20 @@
 
 This project follows [Semantic Versioning](http://semver.org).
 
+### AccessTokenPlugin Migration
+
+- Handle the `.custom(String)` case for `AuthorizationType` which now allows you add a custom prefix to your authorization token according to the following format: `Authorization: <Custom> <token>`
+- The `tokenClosure` parameter of the `AccessTokenPlugin` initializer is no longer an `@autoclosure`, so you need to wrap the existing value in a closure.
+
+### Response Migration
+
+- The function signature of `Response`'s filter methods has been changed to use a generic argument constrained to `RangeExpression` where the `RangeExpression.Bound` is
+  equal to `Int`, instead of providing overloads supporting both `Range` and `ClosedRange`. Account for this change if you rely on the signature explicitly.
+
 ### ReactiveSwift Migration
+
 - Check the [ReactiveSwift 4.0.0 release notes](https://github.com/ReactiveCocoa/ReactiveSwift/releases/tag/4.0.0) for changes related to ReactiveSwift.
 
 ### Result Migration
+
 - Check the [Result 4.0.0 release notes](https://github.com/antitypical/Result/releases/tag/4.0.0) for changes related to Result.
-
-### AccessTokenPlugin Migration
-- Handle `.custom(String)` case for `AuthorizationType` or add a default case to achive exhaustiveness.
-- The `tokenClosure` parameter of the `AccessTokenPlugin` initializer is no longer an `@autoclosure` so you need to wrap the existing value in a closure.
-
-### Response Migration
-- The function signature of `Response`'s filter methods has been changed to use a generic argument with constrained to `RangeExpression` where the `RangeExpression.Bound` is
-equal to `Int`, instead of providing overloads supporting both `Range` and `ClosedRange`. Account for this change if you rely on the signature explicitly.


### PR DESCRIPTION
### Summary
Adds Moya 11 to 12 migration guide

I think this is all we need and we can do `Moya 12.0.0-beta.1` for a week