### PR TITLE
Conform MoyaError to CustomNSError in addition to LocalizedError

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Next
+- `MoyaError` now conforms to `CustomNSError` protocol, makes underlying errors available in its user-info dictionary. [#1783](https://github.com/Moya/Moya/pull/1783) by [@dpoggi](https://github.com/dpoggi).
 - **Breaking Change** `.mapImage()` extension on `Single` and `Observable` now returns non-optional image. [#1789](https://github.com/Moya/Moya/pull/1789), [#1799](https://github.com/Moya/Moya/pull/1799) by [@bjarkehs](https://github.com/bjarkehs) and [@sunshinejr](https://github.com/sunshinejr).
 
 # [12.0.1] - 2018-11-19

--- a/Sources/Moya/MoyaError.swift
+++ b/Sources/Moya/MoyaError.swift
@@ -39,11 +39,26 @@ public extension MoyaError {
         case .jsonMapping(let response): return response
         case .stringMapping(let response): return response
         case .objectMapping(_, let response): return response
+        case .encodableMapping: return nil
         case .statusCode(let response): return response
         case .underlying(_, let response): return response
-        case .encodableMapping: return nil
         case .requestMapping: return nil
         case .parameterEncoding: return nil
+        }
+    }
+
+    /// Depending on error type, returns an underlying `Error`.
+    internal var underlyingError: Swift.Error? {
+        switch self {
+        case .imageMapping: return nil
+        case .jsonMapping: return nil
+        case .stringMapping: return nil
+        case .objectMapping(let error, _): return error
+        case .encodableMapping(let error): return error
+        case .statusCode: return nil
+        case .underlying(let error, _): return error
+        case .requestMapping: return nil
+        case .parameterEncoding(let error): return error
         }
     }
 }
@@ -65,12 +80,23 @@ extension MoyaError: LocalizedError {
             return "Failed to encode Encodable object into data."
         case .statusCode:
             return "Status code didn't fall within the given range."
+        case .underlying(let error, _):
+            return error.localizedDescription
         case .requestMapping:
             return "Failed to map Endpoint to a URLRequest."
         case .parameterEncoding(let error):
             return "Failed to encode parameters for URLRequest. \(error.localizedDescription)"
-        case .underlying(let error, _):
-            return error.localizedDescription
         }
+    }
+}
+
+// MARK: - Error User Info
+
+extension MoyaError: CustomNSError {
+    public var errorUserInfo: [String: Any] {
+        var userInfo: [String: Any] = [:]
+        userInfo[NSLocalizedDescriptionKey] = errorDescription
+        userInfo[NSUnderlyingErrorKey] = underlyingError
+        return userInfo
     }
 }

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -70,6 +70,62 @@ final class ErrorTests: QuickSpec {
             }
         }
 
+        describe("underlyingError computed variable") {
+            it("should not handle ImageMapping error") {
+                let error = MoyaError.imageMapping(response)
+
+                expect(error.underlyingError).to(beNil())
+            }
+
+            it("should not handle JSONMapping error") {
+                let error = MoyaError.jsonMapping(response)
+
+                expect(error.underlyingError).to(beNil())
+            }
+
+            it("should not handle StringMapping error") {
+                let error = MoyaError.stringMapping(response)
+
+                expect(error.underlyingError).to(beNil())
+            }
+
+            it("should handle ObjectMapping error") {
+                let error = MoyaError.objectMapping(underlyingError, response)
+
+                expect(error.underlyingError as NSError?) == underlyingError
+            }
+
+            it("should handle EncodableMapping error") {
+                let error = MoyaError.encodableMapping(underlyingError)
+
+                expect(error.underlyingError as NSError?) == underlyingError
+            }
+
+            it("should not handle StatusCode error") {
+                let error = MoyaError.statusCode(response)
+
+                expect(error.underlyingError).to(beNil())
+            }
+
+            it("should handle Underlying error") {
+                let error = MoyaError.underlying(underlyingError, response)
+
+                expect(error.underlyingError as NSError?) == underlyingError
+            }
+
+            it("should not handle RequestMapping error") {
+                let error = MoyaError.requestMapping("http://www.example.com")
+
+                expect(error.underlyingError as NSError?).to(beNil())
+            }
+
+            it("should handle ParameterEncoding error") {
+                let error = MoyaError.parameterEncoding(underlyingError)
+
+                expect(error.underlyingError as NSError?) == underlyingError
+            }
+        }
+
         describe("bridged userInfo dictionary") {
             it("should have a localized description and no underlying error for ImageMapping error") {
                 let error = MoyaError.imageMapping(response)

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -70,6 +70,80 @@ final class ErrorTests: QuickSpec {
             }
         }
 
+        describe("bridged userInfo dictionary") {
+            it("should have a localized description and no underlying error for ImageMapping error") {
+                let error = MoyaError.imageMapping(response)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError).to(beNil())
+            }
+
+            it("should have a localized description and no underlying error for JSONMapping error") {
+                let error = MoyaError.jsonMapping(response)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError).to(beNil())
+            }
+
+            it("should have a localized description and no underlying error for StringMapping error") {
+                let error = MoyaError.stringMapping(response)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError).to(beNil())
+            }
+
+            it("should have a localized description and underlying error for ObjectMapping error") {
+                let error = MoyaError.objectMapping(underlyingError, response)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError) == underlyingError
+            }
+
+            it("should have a localized description and underlying error for EncodableMapping error") {
+                let error = MoyaError.encodableMapping(underlyingError)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError) == underlyingError
+            }
+
+            it("should have a localized description and no underlying error for StatusCode error") {
+                let error = MoyaError.statusCode(response)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError).to(beNil())
+            }
+
+            it("should have a localized description and underlying error for Underlying error") {
+                let error = MoyaError.underlying(underlyingError, nil)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError) == underlyingError
+            }
+
+            it("should have a localized description and no underlying error for RequestMapping error") {
+                let error = MoyaError.requestMapping("http://www.example.com")
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError).to(beNil())
+            }
+
+            it("should have a localized description and underlying error for ParameterEncoding error") {
+                let error = MoyaError.parameterEncoding(underlyingError)
+                let userInfo = (error as NSError).userInfo
+
+                expect(userInfo[NSLocalizedDescriptionKey] as? String) == error.errorDescription
+                expect(userInfo[NSUnderlyingErrorKey] as? NSError) == underlyingError
+            }
+        }
+
         describe("mapping a result with empty data") {
             let response = Response(statusCode: 200, data: Data())
 

--- a/Tests/ErrorTests.swift
+++ b/Tests/ErrorTests.swift
@@ -7,13 +7,14 @@ final class ErrorTests: QuickSpec {
     override func spec() {
 
         var response: Response!
+        var underlyingError: NSError!
 
         beforeEach {
             response = Response(statusCode: 200, data: Data(), request: nil, response: nil)
+            underlyingError = NSError(domain: "UnderlyingDomain", code: 200, userInfo: ["data": "some data"])
         }
 
         describe("response computed variable") {
-
             it("should handle ImageMapping error") {
                 let error = MoyaError.imageMapping(response)
 
@@ -32,17 +33,40 @@ final class ErrorTests: QuickSpec {
                 expect(error.response) == response
             }
 
+            it("should handle ObjectMapping error") {
+                let error = MoyaError.objectMapping(underlyingError, response)
+
+                expect(error.response) == response
+            }
+
+            it("should not handle EncodableMapping error") {
+                let error = MoyaError.encodableMapping(underlyingError)
+
+                expect(error.response).to(beNil())
+            }
+
             it("should handle StatusCode error") {
                 let error = MoyaError.statusCode(response)
 
                 expect(error.response) == response
             }
 
-            it("should not handle Underlying error ") {
-                let nsError = NSError(domain: "Domain", code: 200, userInfo: ["data": "some data"])
-                let error = MoyaError.underlying(nsError, nil)
+            it("should handle Underlying error") {
+                let error = MoyaError.underlying(underlyingError, response)
 
-                expect(error.response).to( beNil() )
+                expect(error.response) == response
+            }
+
+            it("should not handle RequestMapping error") {
+                let error = MoyaError.requestMapping("http://www.example.com")
+
+                expect(error.response).to(beNil())
+            }
+
+            it("should not handle ParameterEncoding error") {
+                let error = MoyaError.parameterEncoding(underlyingError)
+
+                expect(error.response).to(beNil())
             }
         }
 


### PR DESCRIPTION
Since the existing version of `MoyaError` conforms to `LocalizedError`, its cases with associated (underlying) `Swift.Error` values have no means of returning that information from `userInfo[NSUnderlyingErrorKey]`, where it can be seen by crash reporting tools that speak NSError.

### Motivation

My frustration, looking at a run-of-the-mill "handled" error in Bugsnag, when I realized I couldn't determine the key path at which Codable's object mapping had failed.

In this PR branch, `MoyaError` conforms to `CustomNSError` in addition to `LocalizedError` so it can supply values for both `NSLocalizedDescriptionKey` and `NSUnderlyingErrorKey`.

### Implementation

* The error domain (`String(reflecting: MoyaError.self)`), codes (Swift's internal ordinal value for each enum case), and localized descriptions stay the same.
* Even though it's returned as part of the user info dictionary now, the localized description is still available as `someMoyaError.localizedDescription`.
* Tests have been added for `MoyaError`'s bridged user info dictionary. They ensure that `NSLocalizedDescriptionKey` and the Swift `localizedDescription` property return the same string, and that the appropriate enum cases return an underlying error for `NSUnderlyingErrorKey`.

### P.S.

I recognize that an unsolicited PR is less than ideal, and I do apologize. This is something I thought I ought to do while I had the spare minutes and the inspiration.

If this gets closed, so be it — "the people have spoken." Just thought I'd offer, since it's not a whole ton of code, and I don't think I'm the only person whose time it could save.