### PR TITLE
Single mapImage shouldn’t be optional

### DIFF
--- a/Sources/RxMoya/Single+Response.swift
+++ b/Sources/RxMoya/Single+Response.swift
@@ -35,7 +35,7 @@ extension PrimitiveSequence where TraitType == SingleTrait, ElementType == Respo
     }
 
     /// Maps data received from the signal into an Image. If the conversion fails, the signal errors.
-    public func mapImage() -> Single<Image?> {
+    public func mapImage() -> Single<Image> {
         return flatMap { .just(try $0.mapImage()) }
     }
 

--- a/Tests/Single+MoyaSpec.swift
+++ b/Tests/Single+MoyaSpec.swift
@@ -185,7 +185,7 @@ final class SingleMoyaSpec: QuickSpec {
 
                 var size: CGSize?
                 _ = single.mapImage().subscribe(onSuccess: { image in
-                    size = image?.size
+                    size = image.size
                 })
 
                 expect(size).to(equal(image.size))


### PR DESCRIPTION
Unless I misunderstand how RxSwift works then the signature for Single's `mapImage` is incorrect. The comment also states that if conversion fails, then the signal errors. So the value will always be non-optional.

Response's `mapImage` also returns non-optional `UIImage`.