### PR TITLE
Added discardable result attribute to status code filters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Added
+- Added `@discardableResult` attribute to status code filtering methods in `Response`. [#1790](https://github.com/Moya/Moya/pull/1790) by [@alexandergmacleod](https://github.com/alexandergmacleod).
+
 # [12.0.1] - 2018-11-19
 
 # [12.0.0] - 2018-11-18

--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -48,6 +48,7 @@ public extension Response {
         - statusCodes: The range of acceptable status codes.
      - throws: `MoyaError.statusCode` when others are encountered.
     */
+    @discardableResult
     public func filter<R: RangeExpression>(statusCodes: R) throws -> Response where R.Bound == Int {
         guard statusCodes.contains(statusCode) else {
             throw MoyaError.statusCode(self)
@@ -62,6 +63,7 @@ public extension Response {
         - statusCode: The acceptable status code.
      - throws: `MoyaError.statusCode` when others are encountered.
     */
+    @discardableResult
     public func filter(statusCode: Int) throws -> Response {
         return try filter(statusCodes: statusCode...statusCode)
     }
@@ -71,6 +73,7 @@ public extension Response {
 
      - throws: `MoyaError.statusCode` when others are encountered.
     */
+    @discardableResult
     public func filterSuccessfulStatusCodes() throws -> Response {
         return try filter(statusCodes: 200...299)
     }
@@ -80,6 +83,7 @@ public extension Response {
 
      - throws: `MoyaError.statusCode` when others are encountered.
     */
+    @discardableResult
     public func filterSuccessfulStatusAndRedirectCodes() throws -> Response {
         return try filter(statusCodes: 200...399)
     }


### PR DESCRIPTION
I often use the function `Response.filterSuccessfulStatusCodes` to catch status code errors. However, rarely do I need the result of these filter functions and thus resort to using the following code in order to hide the complier warning.

```
do {
    _ = try response.filterSuccessfulStatusCodes()
   ...
} catch {
   ...
}
```

I have added `@discardableResult` attribute to the status code filter functions. I believe that this improves the quality of my code.