### PR TITLE
Observable.mapImage() returns non-optional image

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Next
+- **Breaking Change** `.mapImage()` extension on `Single` and `Observable` now returns non-optional image. [#1789](https://github.com/Moya/Moya/pull/1789), [#1799](https://github.com/Moya/Moya/pull/1799) by [@bjarkehs](https://github.com/bjarkehs) and [@sunshinejr](https://github.com/sunshinejr).
 
 # [12.0.1] - 2018-11-19
 

--- a/Sources/RxMoya/Observable+Response.swift
+++ b/Sources/RxMoya/Observable+Response.swift
@@ -35,7 +35,7 @@ extension ObservableType where E == Response {
     }
 
     /// Maps data received from the signal into an Image. If the conversion fails, the signal errors.
-    public func mapImage() -> Observable<Image?> {
+    public func mapImage() -> Observable<Image> {
         return flatMap { Observable.just(try $0.mapImage()) }
     }
 

--- a/Tests/Observable+MoyaSpec.swift
+++ b/Tests/Observable+MoyaSpec.swift
@@ -197,7 +197,7 @@ final class ObservableMoyaSpec: QuickSpec {
 
                 var size: CGSize?
                 _ = observable.mapImage().subscribe(onNext: { image in
-                    size = image?.size
+                    size = image.size
                 })
 
                 expect(size).to(equal(image.size))


### PR DESCRIPTION
This is a continuation of #1789. @bjarkehs forgot to update `Observable` extension and because it was a long time ago I created a complimentary PR. 