### PR TITLE
Make a restriction for CocoaPods version ~> 1.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           command: bundle exec danger
       - run:
           name: CocoaPods Spec linting
-          command: pod lib lint
+          command: bundle exec pod lib lint
       - run:
           name: Send Code Coverage to Codecov.io
           command: bash <(curl -s https://codecov.io/bash) -J Moya

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'xcpretty'
 
-gem 'cocoapods'
+gem 'cocoapods', '~> 1.6'
 gem 'rake'
 gem 'octokit', '~> 4.3'
 


### PR DESCRIPTION
Related: https://github.com/CocoaPods/CocoaPods/issues/8089

Our CI is struggling to make a green light on builds that succeed. The problem seems to be our `pod lint` step and I had the same problem locally. For me, the fix was to restrict CocoaPods version to ~> 16.0.

Let's see if it fixes the issue on Circle as well 🐼 