### PR TITLE
Use new Alamofire append(_ fileURL, …) function with optional parameters

### DIFF
--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -47,11 +47,7 @@ internal extension RequestMultipartFormData {
     }
 
     func append(fileURL url: URL, bodyPart: MultipartFormData) {
-        if let fileName = bodyPart.fileName, let mimeType = bodyPart.mimeType {
-            append(url, withName: bodyPart.name, fileName: fileName, mimeType: mimeType)
-        } else {
-            append(url, withName: bodyPart.name)
-        }
+        append(url, withName: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
     }
 
     func append(stream: InputStream, length: UInt64, bodyPart: MultipartFormData) {

--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -35,19 +35,15 @@ public struct MultipartFormData {
 // MARK: RequestMultipartFormData appending
 internal extension RequestMultipartFormData {
     func append(data: Data, bodyPart: MultipartFormData) {
-        if let mimeType = bodyPart.mimeType {
-            if let fileName = bodyPart.fileName {
-                append(data, withName: bodyPart.name, fileName: fileName, mimeType: mimeType)
-            } else {
-                append(data, withName: bodyPart.name, mimeType: mimeType)
-            }
-        } else {
-            append(data, withName: bodyPart.name)
-        }
+        append(data, withName: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
     }
 
     func append(fileURL url: URL, bodyPart: MultipartFormData) {
-        append(url, withName: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
+        if let fileName = bodyPart.fileName, let mimeType = bodyPart.mimeType {
+            append(url, withName: bodyPart.name, fileName: fileName, mimeType: mimeType)
+        } else {
+            append(url, withName: bodyPart.name)
+        }
     }
 
     func append(stream: InputStream, length: UInt64, bodyPart: MultipartFormData) {


### PR DESCRIPTION
This PR relies in https://github.com/Alamofire/Alamofire/pull/2718 getting merged first. Until then PR validation checks will also fail.

Before we had to specify both a `fileName` and a `mimeType`. If one of them was missing the other would be discarded resulting in potential bugs.

 In our case we were removing invalid characters to create a valid server fileName, which in turn was getting discarded by this method resulting on failing uploads.