### PR TITLE
[README] Document support & installation via Accio

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,10 @@ let package = Package(
 
 Note that as of Moya 10, SPM only works with Swift 4 toolchain and greater.
 
+### Accio
+
+Accio is based on Swift Package Manager (with the addition of iOS/macOS/tvOS/watchOS support) and therefore integration of Moya is exactly the same as described above. Once your `Package.swift` file is configured, run `accio update`.
+
 ### CocoaPods
 
 For Moya, use the following entry in your Podfile:
@@ -144,28 +148,6 @@ Then run `carthage update`.
 If this is your first time using Carthage in the project, you'll need to go through some additional steps as explained [over at Carthage](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
 > NOTE: At this time, Carthage does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built with the above command. However, you don't need to copy frameworks you aren't using into your project. For instance, if you aren't using `ReactiveSwift`, feel free to delete that framework along with `ReactiveMoya` from the Carthage Build directory after `carthage update` completes. Or if you are using `ReactiveSwift` but not `RxSwift`, then `RxMoya`, `RxTest`, `RxCocoa`, etc. can safely be deleted.
-
-### Accio
-
-Add the following to your Package.swift:
-
-```swift
-.package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "13.0.0-beta.1")),
-```
-
-Next, choose either `Moya`, `RxMoya` or `ReactiveMoya` and add it to your App targets dependencies, for example:
-
-```swift
-.target(
-    name: "App",
-    dependencies: [
-        "Moya",
-    ]
-),
-```
-
-Then run `accio update`.
-
 
 ### Manually
 

--- a/Readme.md
+++ b/Readme.md
@@ -109,7 +109,7 @@ Note that as of Moya 10, SPM only works with Swift 4 toolchain and greater.
 
 ### Accio
 
-Accio is based on Swift Package Manager (with the addition of iOS/macOS/tvOS/watchOS support) and therefore integration of Moya is exactly the same as described above. Once your `Package.swift` file is configured, run `accio update`.
+[Accio](https://github.com/JamitLabs/Accio) is a dependency manager based on SwiftPM which can build frameworks for iOS/macOS/tvOS/watchOS. Therefore the integration steps of Moya are exactly the same as described above. Once your `Package.swift` file is configured, run `accio update` instead of `swift package update`.
 
 ### CocoaPods
 

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@
 [![CircleCI](https://img.shields.io/circleci/project/github/Moya/Moya/master.svg)](https://circleci.com/gh/Moya/Moya/tree/master)
 [![codecov.io](https://codecov.io/github/Moya/Moya/coverage.svg?branch=master)](https://codecov.io/github/Moya/Moya?branch=master)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Accio supported](https://img.shields.io/badge/Accio-supported-0A7CF5.svg?style=flat)](https://github.com/JamitLabs/Accio)
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/Moya.svg)](https://cocoapods.org/pods/Moya)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager)
 
@@ -143,6 +144,28 @@ Then run `carthage update`.
 If this is your first time using Carthage in the project, you'll need to go through some additional steps as explained [over at Carthage](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application).
 
 > NOTE: At this time, Carthage does not provide a way to build only specific repository submodules. All submodules and their dependencies will be built with the above command. However, you don't need to copy frameworks you aren't using into your project. For instance, if you aren't using `ReactiveSwift`, feel free to delete that framework along with `ReactiveMoya` from the Carthage Build directory after `carthage update` completes. Or if you are using `ReactiveSwift` but not `RxSwift`, then `RxMoya`, `RxTest`, `RxCocoa`, etc. can safely be deleted.
+
+### Accio
+
+Add the following to your Package.swift:
+
+```swift
+.package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "13.0.0-beta.1")),
+```
+
+Next, choose either `Moya`, `RxMoya` or `ReactiveMoya` and add it to your App targets dependencies like so, for example:
+
+```swift
+.target(
+    name: "App",
+    dependencies: [
+        "Moya",
+    ]
+),
+```
+
+Then run `accio update`.
+
 
 ### Manually
 

--- a/Readme.md
+++ b/Readme.md
@@ -153,7 +153,7 @@ Add the following to your Package.swift:
 .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "13.0.0-beta.1")),
 ```
 
-Next, choose either `Moya`, `RxMoya` or `ReactiveMoya` and add it to your App targets dependencies like so, for example:
+Next, choose either `Moya`, `RxMoya` or `ReactiveMoya` and add it to your App targets dependencies, for example:
 
 ```swift
 .target(


### PR DESCRIPTION
This documents support for the new SwiftPM based dependency manager [Accio](https://github.com/JamitLabs/Accio).
Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).

This supersedes my previous approach #1642 and is therefore related to #345.

Checkout [this thread](https://github.com/Carthage/Carthage/pull/1990) and my last [comment](https://github.com/Carthage/Carthage/pull/1990#issuecomment-479442640) if you want to learn more about the history of how I decided to write my own dependency manager to fix #345 properly. Please note that Moya was one of the main motivations for me to write Accio. So I really hope you like it! Any feedback is much appreciated.