### PR TITLE
Remove alamoRequest.cancel() from stubbing closure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,6 @@ jobs:
           name: Set Ruby Version
           command: echo "ruby-2.4" > ~/.ruby-version
       - run:
-          name: Update Homebrew
-          command: brew update    
-      - run:
           name: Carthage checkout
           command: carthage checkout
       - run:
@@ -47,9 +44,6 @@ jobs:
       - run:
           name: Set Ruby Version
           command: echo "ruby-2.4" > ~/.ruby-version
-      - run:
-          name: Update Homebrew
-          command: brew update
       - run:
           name: Install Swiftlint
           command: git clone git@github.com:realm/SwiftLint.git && cd SwiftLint && git submodule update --init --recursive && make install && cd ../

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           command: brew update
       - run:
           name: Install Swiftlint
-          command: brew install swiftlint
+          command: git clone git@github.com:realm/SwiftLint.git && cd SwiftLint && git submodule update --init --recursive && make install && cd ../
       - run:
           name: Add Python directory to PATH
           command: echo 'export PATH=~/Library/Python/2.7/bin:$PATH' >> $BASH_ENV        

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Fixed
+- Fixed a problem where, while using stubbed responses, Moya would generate weird cancellation errors in the console. [#1841](https://github.com/Moya/Moya/pull/1841) by [@sunshinejr](https://github.com/sunshinejr).
+
 # [13.0.0] - 2019-04-10
 
 # [13.0.0-beta.1] - 2019-03-31

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -157,7 +157,6 @@ public extension MoyaProvider {
     final func notifyPluginsOfImpendingStub(for request: URLRequest, target: Target) {
         let alamoRequest = manager.request(request as URLRequestConvertible)
         plugins.forEach { $0.willSend(alamoRequest, target: target) }
-        alamoRequest.cancel()
     }
 }
 


### PR DESCRIPTION
Fixes #1833.

The request was never really resumed and so it most likely doesn't need to be cancelled. This was only making random noise about cancelled request in console.

Targeted master as I'd like to make a 13.0.1 release with this fix.