### PR TITLE
Add missing session headers to Request/NetworkLoggerPlugin.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,13 @@
 # Next
 
+## Added
+- `RequestType` now has `sessionHeaders`! These are the headers that are added when the request is added to a session. [#1878](https://github.com/Moya/Moya/pull/1878) by [@sunshinejr](https://github.com/sunshinejr).
+
 ### Changed
 - **Breaking Change** Minimum target version are now in line with Alamofire 5. iOS: 10.0, tvOS: 10.0, macOS: 10.12. [#1810](https://github.com/Moya/Moya/pull/181) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** Minimum version of `Alamofire` is now 5.0.0-beta.6. [#1810](https://github.com/Moya/Moya/pull/181) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** Removed `Result` depndency in favor of `Result` introduced in Swift 5. [#1858](https://github.com/Moya/Moya/pull/1858) by [@larryonoff](https://github.com/larryonoff).
+- `NetworkoLoggerPlugin` uses the newly added `sessionHeaders` and now logs all the headers that the request will produce. [#1878](https://github.com/Moya/Moya/pull/1878) by [@sunshinejr](https://github.com/sunshinejr).
 
 # [14.0.0-alpha.1] - 2019-05-14
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,8 +7,8 @@
 - **Breaking Change** Minimum target version are now in line with Alamofire 5. iOS: 10.0, tvOS: 10.0, macOS: 10.12. [#1810](https://github.com/Moya/Moya/pull/1810) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** Minimum version of `Alamofire` is now 5.0.0-beta.7. [#1810](https://github.com/Moya/Moya/pull/1810) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** Removed `Result` depndency in favor of `Result` introduced in Swift 5. [#1858](https://github.com/Moya/Moya/pull/1858) by [@larryonoff](https://github.com/larryonoff).
-- `NetworkoLoggerPlugin` uses the newly added `sessionHeaders` and now logs all the headers that the request will produce. [#1878](https://github.com/Moya/Moya/pull/1878) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** Added `TargetType` parameter in the output of `NetworkLoggerPlugin`. [#1866](https://github.com/Moya/Moya/pull/1866) by [@hasankose](https://github.com/hasankose).
+- `NetworkoLoggerPlugin` uses the newly added `sessionHeaders` and now logs all the headers that the request will produce. [#1878](https://github.com/Moya/Moya/pull/1878) by [@sunshinejr](https://github.com/sunshinejr).
 
 # [14.0.0-alpha.1] - 2019-05-14
 

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		7B147185DCE78CD98E28D3F2 /* Observable+Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8736BEE85376471D7CB1E0ED /* Observable+Response.swift */; };
 		7C32947EA657E981CB15D58C /* TestPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCACC7B19F3FFC2DEE74E07B /* TestPlugin.swift */; };
 		83B0E400A7562256224CB7FF /* AccessTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC115388D44D0DB7A753E9BB /* AccessTokenPlugin.swift */; };
+		85850A4122CF5AB50089E731 /* NimbleHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85850A4022CF5AB50089E731 /* NimbleHelpers.swift */; };
 		85B2DBBC221C69620098F59A /* PropertyListEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B2DBBB221C69620098F59A /* PropertyListEncoding.swift */; };
 		85F6042E22A018BB00063320 /* RequestTypeWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F6042D22A018BB00063320 /* RequestTypeWrapper.swift */; };
 		8995DF740A59721AA79F5B43 /* MoyaProvider+ReactiveSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C841AA621AEC61FAEA0CA019 /* MoyaProvider+ReactiveSpec.swift */; };
@@ -190,6 +191,7 @@
 		82E52DC541FD052ABA625D2A /* MoyaProviderIntegrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MoyaProviderIntegrationTests.swift; sourceTree = "<group>"; };
 		832781077A551E1F86E5F2D4 /* NetworkLoggerPluginSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkLoggerPluginSpec.swift; sourceTree = "<group>"; };
 		851FFE6DC58E873408D0E8E7 /* MoyaProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MoyaProvider.swift; sourceTree = "<group>"; };
+		85850A4022CF5AB50089E731 /* NimbleHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbleHelpers.swift; sourceTree = "<group>"; };
 		85B2DBBB221C69620098F59A /* PropertyListEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyListEncoding.swift; sourceTree = "<group>"; };
 		85F6042D22A018BB00063320 /* RequestTypeWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTypeWrapper.swift; sourceTree = "<group>"; };
 		86F3C0EA472C23E786E23CE9 /* Image.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				85B2DBBB221C69620098F59A /* PropertyListEncoding.swift */,
 				CA93F1BAD55FF95EDE17EE61 /* testImage.png */,
 				DCACC7B19F3FFC2DEE74E07B /* TestPlugin.swift */,
+				85850A4022CF5AB50089E731 /* NimbleHelpers.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -905,6 +908,7 @@
 				B950CAA84C0656EB11E316FB /* MultiTargetSpec.swift in Sources */,
 				1F24393320125F8200C9D813 /* EndpointClosureSpec.swift in Sources */,
 				4033070748A57EB4A0040DB1 /* NetworkLoggerPluginSpec.swift in Sources */,
+				85850A4122CF5AB50089E731 /* NimbleHelpers.swift in Sources */,
 				E9B54EFE4EF4A96444BA76AA /* Observable+MoyaSpec.swift in Sources */,
 				8995DF740A59721AA79F5B43 /* MoyaProvider+ReactiveSpec.swift in Sources */,
 				58F73370045D6F1FBF73FC82 /* MoyaProvider+RxSpec.swift in Sources */,

--- a/Sources/Moya/Moya+Alamofire.swift
+++ b/Sources/Moya/Moya+Alamofire.swift
@@ -24,7 +24,11 @@ public typealias RequestMultipartFormData = Alamofire.MultipartFormData
 public typealias DownloadDestination = Alamofire.DownloadRequest.Destination
 
 /// Make the Alamofire Request type conform to our type, to prevent leaking Alamofire to plugins.
-extension Request: RequestType { }
+extension Request: RequestType {
+    public var sessionHeaders: [String: String] {
+        return delegate?.sessionConfiguration.httpAdditionalHeaders as? [String: String] ?? [:]
+    }
+}
 
 /// Represents Request interceptor type that can can modify/act on Request
 public typealias RequestInterceptor = Alamofire.RequestInterceptor

--- a/Sources/Moya/Plugin.swift
+++ b/Sources/Moya/Plugin.swift
@@ -38,6 +38,9 @@ public protocol RequestType {
     /// Retrieve an `NSURLRequest` representation.
     var request: URLRequest? { get }
 
+    ///  Additional headers appended to the request when added to the session.
+    var sessionHeaders: [String: String] { get }
+
     /// Authenticates the request with a username and password.
     func authenticate(username: String, password: String, persistence: URLCredential.Persistence) -> Self
 

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -30,7 +30,7 @@ public final class NetworkLoggerPlugin: PluginType {
             output(separator, terminator, request.debugDescription)
             return
         }
-        outputItems(logNetworkRequest(request.request as URLRequest?))
+        outputItems(logNetworkRequest(request))
     }
 
     public func didReceive(_ result: Result<Moya.Response, MoyaError>, target: TargetType) {
@@ -62,25 +62,33 @@ private extension NetworkLoggerPlugin {
         return "\(loggerId): [\(date)] \(identifier): \(message)"
     }
 
-    func logNetworkRequest(_ request: URLRequest?) -> [String] {
+    func logNetworkRequest(_ request: RequestType) -> [String] {
 
         var output = [String]()
 
-        output += [format(loggerId, date: date, identifier: "Request", message: request?.description ?? "(invalid request)")]
+        output += [format(loggerId, date: date, identifier: "Request", message: request.request?.description ?? "(invalid request)")]
 
-        if let headers = request?.allHTTPHeaderFields {
+        var headers = request.sessionHeaders
+        if let requestHeaders = request.request?.allHTTPHeaderFields {
+            headers.merge(requestHeaders) { _, requestHeader in
+                return requestHeader
+            }
+        }
+
+        if !headers.isEmpty {
             output += [format(loggerId, date: date, identifier: "Request Headers", message: headers.description)]
         }
 
-        if let bodyStream = request?.httpBodyStream {
+        if let bodyStream = request.request?.httpBodyStream {
             output += [format(loggerId, date: date, identifier: "Request Body Stream", message: bodyStream.description)]
         }
 
-        if let httpMethod = request?.httpMethod {
+        if let httpMethod = request.request?.httpMethod {
             output += [format(loggerId, date: date, identifier: "HTTP Request Method", message: httpMethod)]
         }
 
-        if let body = request?.httpBody, let stringOutput = requestDataFormatter?(body) ?? String(data: body, encoding: .utf8), isVerbose {
+        if isVerbose, let body = request.request?.httpBody {
+            let stringOutput = requestDataFormatter?(body) ?? String(decoding: body, as: UTF8.self)
             output += [format(loggerId, date: date, identifier: "Request Body", message: stringOutput)]
         }
 

--- a/Sources/Moya/RequestTypeWrapper.swift
+++ b/Sources/Moya/RequestTypeWrapper.swift
@@ -5,6 +5,10 @@ struct RequestTypeWrapper: RequestType {
         return _urlRequest
     }
 
+    var sessionHeaders: [String: String] {
+        return _request.sessionHeaders
+    }
+
     private var _request: Request
     private var _urlRequest: URLRequest?
 

--- a/Tests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaProviderIntegrationTests.swift
@@ -252,7 +252,10 @@ final class MoyaProviderIntegrationTests: QuickSpec {
 
                         expect(log).to(contain("Request:"))
                         expect(log).to(contain("{ URL: https://api.github.com/zen }"))
-                        expect(log).to(contain("Request Headers: [:]"))
+                        expect(log).to(contain("Request Headers: "))
+                        expect(log).to(contain("User-Agent"))
+                        expect(log).to(contain("Accept-Encoding"))
+                        expect(log).to(contain("Accept-Language"))
                         expect(log).to(contain("HTTP Request Method: GET"))
                         expect(log).to(contain("Response:"))
                         expect(log).to(contain("{ URL: https://api.github.com/zen }"))

--- a/Tests/NetworkLoggerPluginSpec.swift
+++ b/Tests/NetworkLoggerPluginSpec.swift
@@ -47,27 +47,31 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
             plugin.willSend(TestBodyRequest(), target: GitHub.zen)
 
-            expect(log).to( contain("Request: https://api.github.com/zen") )
-            expect(log).to( contain("Request Headers: [\"Content-Type\": \"application/json\"]") )
-            expect(log).to( contain("HTTP Request Method: GET") )
-            expect(log).to( contain("Request Body: cool body") )
+            let possibleHeaders = ["Request Headers: [\"Accept-Language\": \"en-US\", \"Content-Type\": \"application/json\"]",
+                                   "Request Headers: [\"Content-Type\": \"application/json\", \"Accept-Language\": \"en-US\"]"]
+            expect(log).to(contain("Request: https://api.github.com/zen"))
+            expect(log).to(containOne(of: possibleHeaders))
+            expect(log).to(contain("HTTP Request Method: GET"))
+            expect(log).to(contain("Request Body: cool body"))
         }
 
         it("outputs all request fields with stream") {
 
             plugin.willSend(TestStreamRequest(), target: GitHub.zen)
 
-            expect(log).to( contain("Request: https://api.github.com/zen") )
-            expect(log).to( contain("Request Headers: [\"Content-Type\": \"application/json\"]") )
-            expect(log).to( contain("HTTP Request Method: GET") )
-            expect(log).to( contain("Request Body Stream:") )
+            let possibleHeaders = ["Request Headers: [\"Accept-Language\": \"en-US\", \"Content-Type\": \"application/json\"]",
+                                   "Request Headers: [\"Content-Type\": \"application/json\", \"Accept-Language\": \"en-US\"]"]
+            expect(log).to(contain("Request: https://api.github.com/zen"))
+            expect(log).to(containOne(of: possibleHeaders))
+            expect(log).to(contain("HTTP Request Method: GET"))
+            expect(log).to(contain("Request Body Stream:"))
         }
 
         it("will output invalid request when reguest is nil") {
 
             plugin.willSend(TestNilRequest(), target: GitHub.zen)
 
-            expect(log).to( contain("Request: (invalid request)") )
+            expect(log).to(contain("Request: (invalid request)"))
         }
 
         it("outputs the response data") {
@@ -76,9 +80,9 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
             plugin.didReceive(result, target: GitHub.zen)
 
-            expect(log).to( contain("Response:") )
-            expect(log).to( contain("{ URL: https://api.github.com/zen }") )
-            expect(log).to( contain("cool body") )
+            expect(log).to(contain("Response:"))
+            expect(log).to(contain("{ URL: https://api.github.com/zen }"))
+            expect(log).to(contain("cool body"))
         }
 
         it("outputs the formatted response data") {
@@ -87,9 +91,9 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
             pluginWithResponseDataFormatter.didReceive(result, target: GitHub.zen)
 
-            expect(log).to( contain("Response:") )
-            expect(log).to( contain("{ URL: https://api.github.com/zen }") )
-            expect(log).to( contain("formatted body") )
+            expect(log).to(contain("Response:"))
+            expect(log).to(contain("{ URL: https://api.github.com/zen }"))
+            expect(log).to(contain("formatted body"))
         }
 
         it("outputs the formatted request data") {
@@ -98,9 +102,9 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 
             pluginWithRequestDataFormatter.didReceive(result, target: GitHub.zen)
 
-            expect(log).to( contain("Response:") )
-            expect(log).to( contain("{ URL: https://api.github.com/zen }") )
-            expect(log).to( contain("formatted request body") )
+            expect(log).to(contain("Response:"))
+            expect(log).to(contain("{ URL: https://api.github.com/zen }"))
+            expect(log).to(contain("formatted request body"))
         }
 
         it("outputs an empty response message") {
@@ -115,10 +119,10 @@ final class NetworkLoggerPluginSpec: QuickSpec {
         it("outputs cURL representation of request") {
             pluginWithCurl.willSend(TestCurlBodyRequest(), target: GitHub.zen)
 
-            expect(log).to( contain("$ curl -i") )
-            expect(log).to( contain("-H \"Content-Type: application/json\"") )
-            expect(log).to( contain("-d \"cool body\"") )
-            expect(log).to( contain("\"https://api.github.com/zen\"") )
+            expect(log).to(contain("$ curl -i"))
+            expect(log).to(contain("-H \"Content-Type: application/json\""))
+            expect(log).to(contain("-d \"cool body\""))
+            expect(log).to(contain("\"https://api.github.com/zen\""))
 
         }
     }
@@ -131,6 +135,10 @@ private class TestStreamRequest: RequestType {
         request.httpBodyStream = InputStream(data: "cool body".data(using: .utf8)!)
 
         return request
+    }
+
+    var sessionHeaders: [String: String] {
+        return ["Content-Type": "application/badJson", "Accept-Language": "en-US"]
     }
 
     func authenticate(username user: String, password: String, persistence: URLCredential.Persistence) -> Self {
@@ -151,6 +159,10 @@ private class TestBodyRequest: RequestType {
         return request
     }
 
+    var sessionHeaders: [String: String] {
+        return ["Content-Type": "application/badJson", "Accept-Language": "en-US"]
+    }
+
     func authenticate(username user: String, password: String, persistence: URLCredential.Persistence) -> Self {
         return self
     }
@@ -169,6 +181,10 @@ private class TestCurlBodyRequest: RequestType, CustomDebugStringConvertible {
         return request
     }
 
+    var sessionHeaders: [String: String] {
+        return ["Content-Type": "application/badJson", "Accept-Language": "en-US"]
+    }
+
     func authenticate(username user: String, password: String, persistence: URLCredential.Persistence) -> Self {
         return self
     }
@@ -185,6 +201,10 @@ private class TestCurlBodyRequest: RequestType, CustomDebugStringConvertible {
 private class TestNilRequest: RequestType {
     var request: URLRequest? {
         return nil
+    }
+
+    var sessionHeaders: [String: String] {
+        return [:]
     }
 
     func authenticate(username user: String, password: String, persistence: URLCredential.Persistence) -> Self {

--- a/Tests/NimbleHelpers.swift
+++ b/Tests/NimbleHelpers.swift
@@ -1,0 +1,18 @@
+import Nimble
+
+/// A Nimble matcher that succeeds when at least one of the substrings
+public func containOne(of substrings: String...) -> Predicate<String> {
+    return containOne(of: substrings)
+}
+
+/// A Nimble matcher that succeeds when at least one of the substrings
+public func containOne(of substrings: [String]) -> Predicate<String> {
+    let containArrayAsString = substrings.map { "<\($0)>" }.joined(separator: " or ")
+    return Predicate.simple("contain \(containArrayAsString)") { actualExpression in
+        if let actual = try actualExpression.evaluate() {
+            let foundSubsring = substrings.first(where: { actual.contains($0) })
+            return PredicateStatus(bool: foundSubsring != nil)
+        }
+        return .fail
+    }
+}


### PR DESCRIPTION
Fixes #1057. Totally forgot about that one and when updating Alamofire I couldn't find the session headers and then I remembered!

This can be reviewed but will be merged only after #1810.

---

Before:
> Moya_Logger: [05/07/2019 12:32:14] Request Headers: [:]

After:

> Moya_Logger: [05/07/2019 12:33:50] Request Headers: ["User-Agent": "Basic/1.0 (Moya.Basic; build:1; iOS 12.2.0) Alamofire/5.0.0", "Accept-Encoding": "br;q=1.0, gzip;q=0.9, deflate;q=0.8", "Accept-Language": "en;q=1.0, pl-PL;q=0.9"]