### PR TITLE
Add "bug?" to the list of exemptLabels for Stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,6 +9,7 @@ daysUntilClose: 7
 # Issues or Pull Requests with these labels will never be considered stale
 exemptLabels:
   - "enhancement"
+  - "bug?"
   - "confirmed bug"
   - "chore"
   - "discussion"


### PR DESCRIPTION
I don't really want to lose issues that might or might not be a problem with Moya.