### PR TITLE
Remove OHHTTPStubs to fix SPM support for Xcode

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,15 +20,6 @@
         }
       },
       {
-        "package": "OHHTTPStubs",
-        "repositoryURL": "https://github.com/AliSoftware/OHHTTPStubs.git",
-        "state": {
-          "branch": "feature/spm-support",
-          "revision": "fda9902f8c5c4170c6914d7dc845174e8c75bf92",
-          "version": null
-        }
-      },
-      {
         "package": "Quick",
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")),
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .branch("feature/spm-support")),
+//        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .branch("feature/spm-support")),
     ],
     targets: [
          .target(
@@ -51,7 +51,7 @@ let package = Package(
                 "ReactiveMoya",
                 "Quick",
                 "Nimble",
-                "OHHTTPStubsSwift"
+//                "OHHTTPStubsSwift"
             ]
         )
     ]


### PR DESCRIPTION
Currently when we fetch the beta.1 it doesn't work because `OHHTTPStubs` seems to be "incompatible".