### PR TITLE
Link Combine weakly

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Fixed
+- Fixes an issue that caused apps to crash on startup when using the latest, Combine-enabled Moya version on non-iOS 13 devices. [#1915](https://github.com/Moya/Moya/pull/1915) by [@fredpi](https://github.com/fredpi).
+
 # [14.0.0-beta.2] - 2019-09-09
 
 ### Changed

--- a/Config/Moya.xcconfig
+++ b/Config/Moya.xcconfig
@@ -1,0 +1,2 @@
+
+OTHER_LDFLAGS[sdk=iphoneos13.0] = -weak_framework Combine

--- a/Config/Moya.xcconfig
+++ b/Config/Moya.xcconfig
@@ -1,2 +1,12 @@
 
 OTHER_LDFLAGS[sdk=iphoneos13.0] = -weak_framework Combine
+OTHER_LDFLAGS[sdk=iphonesimulator13.0] = -weak_framework Combine
+
+OTHER_LDFLAGS[sdk=watchos6.0] = -weak_framework Combine
+OTHER_LDFLAGS[sdk=watchsimulator6.0] = -weak_framework Combine
+
+OTHER_LDFLAGS[sdk=appletvos13.0] = -weak_framework Combine
+OTHER_LDFLAGS[sdk=appletvsimulator13.0] = -weak_framework Combine
+
+OTHER_LDFLAGS[sdk=macosx10.15] = -weak_framework Combine
+OTHER_LDFLAGS[sdk=macosx10.15] = -weak_framework Combine

--- a/Config/Moya.xcconfig
+++ b/Config/Moya.xcconfig
@@ -9,4 +9,3 @@ OTHER_LDFLAGS[sdk=appletvos13.0] = -weak_framework Combine
 OTHER_LDFLAGS[sdk=appletvsimulator13.0] = -weak_framework Combine
 
 OTHER_LDFLAGS[sdk=macosx10.15] = -weak_framework Combine
-OTHER_LDFLAGS[sdk=macosx10.15] = -weak_framework Combine

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -1010,6 +1010,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.Moya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1059,6 +1063,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.RxMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1207,6 +1215,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.RxMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1414,6 +1426,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.ReactiveMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1527,6 +1543,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.Moya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1616,6 +1636,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					Combine,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.ReactiveMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		C79C5F376B4A2C3F70051980 /* Error+MoyaSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Error+MoyaSpec.swift"; sourceTree = "<group>"; };
 		C841AA621AEC61FAEA0CA019 /* MoyaProvider+ReactiveSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+ReactiveSpec.swift"; sourceTree = "<group>"; };
 		CC115388D44D0DB7A753E9BB /* AccessTokenPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessTokenPlugin.swift; sourceTree = "<group>"; };
+		CC9FE2C72328F106005310CA /* Moya.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Moya.xcconfig; sourceTree = "<group>"; };
 		D38525FE207BE148B17084F3 /* Moya.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Moya.h; sourceTree = "<group>"; };
 		D48555FB39336D99F8365F5E /* MoyaProvider+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Rx.swift"; sourceTree = "<group>"; };
 		DCACC7B19F3FFC2DEE74E07B /* TestPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestPlugin.swift; sourceTree = "<group>"; };
@@ -389,6 +390,7 @@
 			children = (
 				FC95CA86272B4EE5DBDDAD55 /* Products */,
 				0E7C5E12BDDF8CD3A778D84C /* Frameworks */,
+				CC9FE2C62328F0BF005310CA /* Config */,
 				9A58CD622B8FBB54907843BE /* Sources */,
 				469A069C1F705C62001153A0 /* Examples */,
 				1952C4A00E2EF89FFE965603 /* Tests */,
@@ -467,6 +469,14 @@
 				94621FEF4A2A1BFCE4BA36D0 /* RxMoya */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		CC9FE2C62328F0BF005310CA /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				CC9FE2C72328F106005310CA /* Moya.xcconfig */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		FC95CA86272B4EE5DBDDAD55 /* Products */ = {
@@ -1010,10 +1020,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.Moya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1063,10 +1069,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.RxMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1125,6 +1127,7 @@
 		};
 		1F6BA0C94269FECB59EB249A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC9FE2C72328F106005310CA /* Moya.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -1215,10 +1218,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.RxMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1426,10 +1425,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.ReactiveMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1446,6 +1441,7 @@
 		};
 		863C614A62CAB15119F5FB74 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC9FE2C72328F106005310CA /* Moya.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
@@ -1543,10 +1539,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.Moya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1636,10 +1628,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					Combine,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cocoapods.ReactiveMoya;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
Fixes #1914.

I linked Combine weakly as proposed here: https://stackoverflow.com/questions/57168931/optional-linking-for-swift-combine-framework-in-xcode-11

After installing Moya via my branch, the issue went away so I could run my app on iOS 12 devices again.

As proposed in the SO answer, maybe the weak linking configuration should be done via a XCConfig file to maintain compatibility with Xcode 10:

> or if you still want to support building with older Xcode versions:
> 
> `OTHER_LDFLAGS[sdk=iphoneos13.0] = -weak_framework Combine`

As there are no XCConfig files currently and I needed a quick fix, I didn't opt for this approach for now.