### PR TITLE
NetworkLoggerPlugin curl fixes.

### DIFF
--- a/Sources/Moya/Plugin.swift
+++ b/Sources/Moya/Plugin.swift
@@ -46,4 +46,9 @@ public protocol RequestType {
 
     /// Authenticates the request with an `NSURLCredential` instance.
     func authenticate(with credential: URLCredential) -> Self
+
+    /// cURL representation of the instance.
+    ///
+    /// - Returns: The cURL equivalent of the instance.
+    func cURLDescription(calling handler: @escaping (String) -> Void) -> Self
 }

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -82,16 +82,15 @@ private extension NetworkLoggerPlugin {
     }
 
     func logNetworkResponse(_ response: Response, target: TargetType, isFromError: Bool) -> [String] {
-
-        //Response presence check
-        guard let httpResponse = response.response else {
-            return [configuration.formatter.entry("Response", "Received empty network response for \(target).", target)]
-        }
-
         // Adding log entries for each given log option
         var output = [String]()
 
-        output.append(configuration.formatter.entry("Response", httpResponse.description, target))
+        //Response presence check
+        if let httpResponse = response.response {
+            output.append(configuration.formatter.entry("Response", httpResponse.description, target))
+        } else {
+            output.append(configuration.formatter.entry("Response", "Received empty network response for \(target).", target))
+        }
 
         if (isFromError && configuration.logOptions.contains(.errorResponseBody))
             || configuration.logOptions.contains(.successResponseBody) {

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -14,7 +14,9 @@ public final class NetworkLoggerPlugin {
 // MARK: - PluginType
 extension NetworkLoggerPlugin: PluginType {
     public func willSend(_ request: RequestType, target: TargetType) {
-        configuration.output(target, logNetworkRequest(request, target: target))
+        logNetworkRequest(request, target: target) { [weak self] output in
+            self?.configuration.output(target, output)
+        }
     }
 
     public func didReceive(_ result: Result<Moya.Response, MoyaError>, target: TargetType) {
@@ -30,17 +32,21 @@ extension NetworkLoggerPlugin: PluginType {
 // MARK: - Logging
 private extension NetworkLoggerPlugin {
 
-    func logNetworkRequest(_ request: RequestType, target: TargetType) -> [String] {
-
+    func logNetworkRequest(_ request: RequestType, target: TargetType, completion: @escaping ([String]) -> Void) {
         //cURL formatting
-        if configuration.logOptions.contains(.formatRequestAscURL),
-            let request = request as? CustomDebugStringConvertible {
-            return [configuration.formatter.entry("Request", request.debugDescription, target)]
+        if configuration.logOptions.contains(.formatRequestAscURL) {
+            _ = request.cURLDescription { [weak self] output in
+                guard let self = self else { return }
+
+                completion([self.configuration.formatter.entry("Request", output, target)])
+            }
+            return
         }
 
         //Request presence check
         guard let httpRequest = request.request else {
-            return [configuration.formatter.entry("Request", "(invalid request)", target)]
+            completion([configuration.formatter.entry("Request", "(invalid request)", target)])
+            return
         }
 
         // Adding log entries for each given log option
@@ -72,7 +78,7 @@ private extension NetworkLoggerPlugin {
             output.append(configuration.formatter.entry("HTTP Request Method", httpMethod, target))
         }
 
-        return output
+        completion(output)
     }
 
     func logNetworkResponse(_ response: Response, target: TargetType, isFromError: Bool) -> [String] {

--- a/Sources/Moya/RequestTypeWrapper.swift
+++ b/Sources/Moya/RequestTypeWrapper.swift
@@ -28,4 +28,9 @@ struct RequestTypeWrapper: RequestType {
         let newRequest = _request.authenticate(with: credential)
         return RequestTypeWrapper(request: newRequest, urlRequest: _urlRequest)
     }
+
+    func cURLDescription(calling handler: @escaping (String) -> Void) -> RequestTypeWrapper {
+        _request.cURLDescription(calling: handler)
+        return self
+    }
 }

--- a/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
@@ -265,6 +265,25 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                         expect(log.lowercased()).to(contain("{ status code: 200, headers"))
                         expect(log.lowercased()).to(contain("\"content-length\""))
                     }
+
+                    it("logs the request using curlDescription") {
+                        plugin.configuration.logOptions.insert(.formatRequestAscURL)
+
+                        let provider = MoyaProvider<GitHub>(plugins: [plugin])
+                        waitUntil { done in
+                            provider.request(.zen) { _ in done() }
+                        }
+
+                        expect(log).to(contain("$ curl -v"))
+                        expect(log).to(contain("-X GET"))
+                        expect(log).to(contain("-H \"Accept-Language:"))
+                        expect(log).to(contain("-H \"Accept-Encoding:"))
+                        expect(log).to(contain("-H \"User-Agent:"))
+                        expect(log).to(contain("\"https://api.github.com/zen\""))
+
+                        expect(log).to(contain("Response:"))
+                        expect(log).to(contain("{ URL: https://api.github.com/zen }"))
+                    }
                 }
             }
 

--- a/Tests/MoyaTests/MoyaProviderSpec.swift
+++ b/Tests/MoyaTests/MoyaProviderSpec.swift
@@ -157,6 +157,26 @@ final class MoyaProviderSpec: QuickSpec {
             expect(calledTarget) == target
         }
 
+        it("logs the request using with stubbing") {
+            var log = ""
+            let plugin = NetworkLoggerPlugin(configuration: .init(output: { log += $1.joined() },
+                                                                  logOptions: .verbose))
+            let provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.immediatelyStub, plugins: [plugin])
+
+            waitUntil { done in
+                provider.request(.zen) { _ in done() }
+            }
+
+            expect(log).to(contain("Request: https://api.github.com/zen"))
+            expect(log).to(contain("Request Headers: "))
+            expect(log).to(contain("User-Agent"))
+            expect(log).to(contain("Accept-Encoding"))
+            expect(log).to(contain("Accept-Language"))
+            expect(log).to(contain("HTTP Request Method: GET"))
+            expect(log).to(contain("Response: Received empty network response for zen."))
+            expect(log).to(contain("Response Body: Half measures are as bad as nothing at all."))
+        }
+
         describe("a provider with delayed stubs") {
             var provider: MoyaProvider<GitHub>!
             var plugin: TestingPlugin!

--- a/Tests/MoyaTests/NetworkLoggerPluginSpec.swift
+++ b/Tests/MoyaTests/NetworkLoggerPluginSpec.swift
@@ -151,6 +151,7 @@ final class NetworkLoggerPluginSpec: QuickSpec {
 }
 
 private class TestStreamRequest: RequestType {
+
     var request: URLRequest? {
         var request = URLRequest(url: URL(string: url(GitHub.zen))!)
         request.allHTTPHeaderFields = ["Content-Type": "application/json"]
@@ -168,6 +169,11 @@ private class TestStreamRequest: RequestType {
     }
 
     func authenticate(with credential: URLCredential) -> Self {
+        return self
+    }
+
+    func cURLDescription(calling handler: @escaping (String) -> Void) -> Self {
+        handler("")
         return self
     }
 }
@@ -192,9 +198,14 @@ private class TestBodyRequest: RequestType {
     func authenticate(with credential: URLCredential) -> Self {
         return self
     }
+
+    func cURLDescription(calling handler: @escaping (String) -> Void) -> Self {
+        handler("")
+        return self
+    }
 }
 
-private class TestCurlBodyRequest: RequestType, CustomDebugStringConvertible {
+private class TestCurlBodyRequest: RequestType {
     var request: URLRequest? {
         var request = URLRequest(url: URL(string: url(GitHub.zen))!)
         request.allHTTPHeaderFields = ["Content-Type": "application/json"]
@@ -215,8 +226,9 @@ private class TestCurlBodyRequest: RequestType, CustomDebugStringConvertible {
         return self
     }
 
-    var debugDescription: String {
-        return ["$ curl -i", "-H \"Content-Type: application/json\"", "-d \"cool body\"", "\"https://api.github.com/zen\""].joined(separator: " \\\n\t")
+    func cURLDescription(calling handler: @escaping (String) -> Void) -> Self {
+        handler(["$ curl -i", "-H \"Content-Type: application/json\"", "-d \"cool body\"", "\"https://api.github.com/zen\""].joined(separator: " \\\n\t"))
+        return self
     }
 }
 
@@ -234,6 +246,11 @@ private class TestNilRequest: RequestType {
     }
 
     func authenticate(with credential: URLCredential) -> Self {
+        return self
+    }
+
+    func cURLDescription(calling handler: @escaping (String) -> Void) -> Self {
+        handler("")
         return self
     }
 }


### PR DESCRIPTION
Alamofire changed how they print `curlDescription` so we have to adapt as well!