### PR TITLE
Fixing Data race conditions caught by TSAN

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "Alamofire/Alamofire" "5.0.0-rc.3"
 github "AliSoftware/OHHTTPStubs" "8.0.0"
-github "Quick/Nimble" "v8.0.2"
-github "Quick/Quick" "v2.1.0"
+github "Quick/Nimble" "v8.0.4"
+github "Quick/Quick" "v2.2.0"
 github "ReactiveCocoa/ReactiveSwift" "6.1.0"
 github "ReactiveX/RxSwift" "5.0.1"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Fixed
+- Fixed a data race condition issue and enable TSAN on the test action and CI. [#1952](https://github.com/Moya/Moya/pull/1952) by [@LucianoPAlmeida](https://github.com/LucianoPAlmeida).
+
 # [14.0.0-beta.5] - 2019-10-27
 
 ### Changed

--- a/Moya.xcodeproj/xcshareddata/xcschemes/Moya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/Moya.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,8 +40,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +60,6 @@
             ReferencedContainer = "container:Moya.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Moya.xcodeproj/xcshareddata/xcschemes/MoyaTests.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/MoyaTests.xcscheme
@@ -26,8 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,8 +41,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -62,8 +61,6 @@
             ReferencedContainer = "container:Moya.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Moya.xcodeproj/xcshareddata/xcschemes/ReactiveMoya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/ReactiveMoya.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,8 +40,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +60,6 @@
             ReferencedContainer = "container:Moya.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Moya.xcodeproj/xcshareddata/xcschemes/RxMoya.xcscheme
+++ b/Moya.xcodeproj/xcshareddata/xcschemes/RxMoya.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,8 +40,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +60,6 @@
             ReferencedContainer = "container:Moya.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Moya/Moya+Alamofire.swift
+++ b/Sources/Moya/Moya+Alamofire.swift
@@ -106,7 +106,7 @@ extension DownloadRequest: Requestable {
     }
 }
 
-final class MoyaRequestInterceptor: RequestInterceptor {
+final class MoyaRequestInterceptor: NSRecursiveLock, RequestInterceptor {
 
     var prepare: ((URLRequest) -> URLRequest)?
     var willSend: ((URLRequest) -> Void)?
@@ -117,8 +117,10 @@ final class MoyaRequestInterceptor: RequestInterceptor {
     }
 
     func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        let request = prepare?(urlRequest) ?? urlRequest
-        willSend?(request)
+        lock(); defer { unlock() }
+
+        let request = self.prepare?(urlRequest) ?? urlRequest
+        self.willSend?(request)
         completion(.success(request))
     }
 }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -31,18 +31,18 @@ public extension MoyaProvider {
         }
 
         if trackInflights {
-            objc_sync_enter(self)
+            lock.lock()
             var inflightCompletionBlocks = self.inflightRequests[endpoint]
             inflightCompletionBlocks?.append(pluginsWithCompletion)
             self.inflightRequests[endpoint] = inflightCompletionBlocks
-            objc_sync_exit(self)
+            lock.unlock()
 
             if inflightCompletionBlocks != nil {
                 return cancellableToken
             } else {
-                objc_sync_enter(self)
+                lock.lock()
                 self.inflightRequests[endpoint] = [pluginsWithCompletion]
-                objc_sync_exit(self)
+                lock.unlock()
             }
         }
 
@@ -66,9 +66,9 @@ public extension MoyaProvider {
               if self.trackInflights {
                 self.inflightRequests[endpoint]?.forEach { $0(result) }
 
-                objc_sync_enter(self)
+                self.lock.lock()
                 self.inflightRequests.removeValue(forKey: endpoint)
-                objc_sync_exit(self)
+                self.lock.unlock()
               } else {
                 pluginsWithCompletion(result)
               }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -171,6 +171,7 @@ private extension MoyaProvider {
     }
 
     private func setup(interceptor: MoyaRequestInterceptor, with target: Target, and request: Request) {
+        interceptor.lock(); defer { interceptor.unlock() }
         interceptor.willSend = { [weak self, weak request] urlRequest in
             guard let self = self, let request = request else { return }
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -171,7 +171,6 @@ private extension MoyaProvider {
     }
 
     private func setup(interceptor: MoyaRequestInterceptor, with target: Target, and request: Request) {
-        interceptor.lock(); defer { interceptor.unlock() }
         interceptor.willSend = { [weak self, weak request] urlRequest in
             guard let self = self, let request = request else { return }
 

--- a/Sources/Moya/MoyaProvider.swift
+++ b/Sources/Moya/MoyaProvider.swift
@@ -88,6 +88,8 @@ open class MoyaProvider<Target: TargetType>: MoyaProviderType {
     /// Propagated to Alamofire as callback queue. If nil - the Alamofire default (as of their API in 2017 - the main queue) will be used.
     let callbackQueue: DispatchQueue?
 
+    let lock: NSRecursiveLock = NSRecursiveLock()
+
     /// Initializes a provider.
     public init(endpointClosure: @escaping EndpointClosure = MoyaProvider.defaultEndpointMapping,
                 requestClosure: @escaping RequestClosure = MoyaProvider.defaultRequestMapping,
@@ -156,7 +158,7 @@ open class MoyaProvider<Target: TargetType>: MoyaProviderType {
     // swiftlint:enable function_parameter_count
 }
 
-/// Mark: Stubbing
+// MARK: Stubbing
 
 /// Controls how stub responses are returned.
 public enum StubBehavior {

--- a/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
@@ -365,7 +365,7 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                 var receievedResponse: Response?
                 var receivedError: Error?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     provider.request(target) { result in
                         switch result {
                         case .success(let response):
@@ -387,7 +387,7 @@ final class MoyaProviderIntegrationTests: QuickSpec {
                 var receievedResponse: Response?
                 var receivedError: Error?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     provider.request(target) { result in
                         switch result {
                         case .success(let response):

--- a/Tests/MoyaTests/MoyaProviderSpec.swift
+++ b/Tests/MoyaTests/MoyaProviderSpec.swift
@@ -769,7 +769,7 @@ final class MoyaProviderSpec: QuickSpec {
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     let progressClosure: ProgressBlock = { progress in
                         progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
@@ -801,7 +801,7 @@ final class MoyaProviderSpec: QuickSpec {
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     let progressClosure: ProgressBlock = { progress in
                         progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
@@ -849,7 +849,7 @@ final class MoyaProviderSpec: QuickSpec {
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     let progressClosure: ProgressBlock = { progress in
                         progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
@@ -880,7 +880,7 @@ final class MoyaProviderSpec: QuickSpec {
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     let progressClosure: ProgressBlock = { progress in
                         progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
@@ -919,7 +919,7 @@ final class MoyaProviderSpec: QuickSpec {
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     let progressClosure: ProgressBlock = { progress in
                         progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)
@@ -954,7 +954,7 @@ final class MoyaProviderSpec: QuickSpec {
                 var completedValues: [Bool] = []
                 var error: MoyaError?
 
-                waitUntil(timeout: 5.0) { done in
+                waitUntil(timeout: 10.0) { done in
                     let progressClosure: ProgressBlock = { progress in
                         progressObjects.append(progress.progressObject)
                         progressValues.append(progress.progress)


### PR DESCRIPTION
* Enable TSAN on MoyaTests Target, so when we run the tests TSAN is always enabled.

* Fixing issue caught by TSAN on interceptor when running tests with it 
<img width="891" alt="Screen Shot 2019-11-10 at 18 03 46" src="https://user-images.githubusercontent.com/8292651/68551626-b65e7e80-03ed-11ea-8984-6abbe6271614.png">
It was just a concurrent read/write access to the willSend `MoyaInterceptor` property. 

cc @sunshinejr 