### PR TITLE
Add `mapString`, `mapDecodable` funtion take multiple key paths parameter

### DIFF
--- a/Sources/ReactiveMoya/SignalProducer+Response.swift
+++ b/Sources/ReactiveMoya/SignalProducer+Response.swift
@@ -62,10 +62,24 @@ extension SignalProducerProtocol where Value == Response, Error == MoyaError {
         }
     }
 
+    /// Maps received data at multiple key paths into a String. If the conversion fails, the signal errors.
+    public func mapString(atKeyPaths keyPaths: [String]) -> SignalProducer<String, MoyaError> {
+        return producer.flatMap(.latest) { response in
+            unwrapThrowable { try response.mapString(atKeyPaths: keyPaths) }
+        }
+    }
+
     /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
     public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> SignalProducer<D, MoyaError> {
         return producer.flatMap(.latest) { response in
             unwrapThrowable { try response.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData) }
+        }
+    }
+
+    /// Maps received data at multiple key paths into a Decodable object. If the conversion fails, the signal errors.
+    public func map<D: Decodable>(_ type: D.Type, atKeyPaths keyPaths: [String], using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> SignalProducer<D, MoyaError> {
+        return producer.flatMap(.latest) { response in
+            unwrapThrowable { try response.map(type, atKeyPaths: keyPaths, using: decoder, failsOnEmptyData: failsOnEmptyData) }
         }
     }
 }

--- a/Sources/RxMoya/Observable+Response.swift
+++ b/Sources/RxMoya/Observable+Response.swift
@@ -48,9 +48,19 @@ extension ObservableType where E == Response {
         return flatMap { Observable.just(try $0.mapString(atKeyPath: keyPath)) }
     }
 
+    /// Maps received data at multiple key paths into a String. If the conversion fails, the signal errors.
+    public func mapString(atKeyPaths keyPaths: [String]) -> Observable<String> {
+        return flatMap { Observable.just(try $0.mapString(atKeyPaths: keyPaths)) }
+    }
+
     /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
     public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> Observable<D> {
         return flatMap { Observable.just(try $0.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData)) }
+    }
+
+    /// Maps received data at multiple key paths into a Decodable object. If the conversion fails, the signal errors.
+    public func map<D: Decodable>(_ type: D.Type, atKeyPaths keyPaths: [String], using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> Observable<D> {
+        return flatMap { Observable.just(try $0.map(type, atKeyPaths: keyPaths, using: decoder, failsOnEmptyData: failsOnEmptyData)) }
     }
 }
 

--- a/Sources/RxMoya/Single+Response.swift
+++ b/Sources/RxMoya/Single+Response.swift
@@ -48,8 +48,18 @@ extension PrimitiveSequence where TraitType == SingleTrait, ElementType == Respo
         return flatMap { .just(try $0.mapString(atKeyPath: keyPath)) }
     }
 
+    /// Maps received data at multiple key paths into a String. If the conversion fails, the signal errors.
+    public func mapString(atKeyPaths keyPaths: [String]) -> Single<String> {
+        return flatMap { .just(try $0.mapString(atKeyPaths: keyPaths)) }
+    }
+
     /// Maps received data at key path into a Decodable object. If the conversion fails, the signal errors.
     public func map<D: Decodable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> Single<D> {
         return flatMap { .just(try $0.map(type, atKeyPath: keyPath, using: decoder, failsOnEmptyData: failsOnEmptyData)) }
+    }
+
+    /// Maps received data at multiple key paths into a Decodable object. If the conversion fails, the signal errors.
+    public func map<D: Decodable>(_ type: D.Type, atKeyPaths keyPaths: [String], using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> Single<D> {
+        return flatMap { .just(try $0.map(type, atKeyPaths: keyPaths, using: decoder, failsOnEmptyData: failsOnEmptyData)) }
     }
 }

--- a/Tests/Single+MoyaSpec.swift
+++ b/Tests/Single+MoyaSpec.swift
@@ -293,6 +293,23 @@ final class SingleMoyaSpec: QuickSpec {
                 expect(receivedString).to(equal(string))
             }
 
+            it("maps data representing a string at multiple key paths to a string") {
+                let string = "이병찬"
+                let json: [String: [String: String]] = ["name": ["korean": string]]
+                guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                    fatalError("Failed creating Data from JSON dictionary")
+                }
+
+                let single = Response(statusCode: 200, data: data).asSingle()
+
+                var receivedString: String?
+                _ = single.mapString(atKeyPaths: ["name", "korean"]).subscribe(onSuccess: { string in
+                    receivedString = string
+                })
+
+                expect(receivedString).to(equal(string))
+            }
+
             it("ignores invalid data") {
                 let data = Data(bytes: [0x11FFFF] as [UInt32], count: 1) //Byte exceeding UTF8
                 let single = Response(statusCode: 200, data: data).asSingle()
@@ -500,6 +517,38 @@ final class SingleMoyaSpec: QuickSpec {
                     expect(url) == URL(string: "http://www.example.com/test")
                 }
 
+                it("maps data representing a json array to a decodable object (#1311) with multiple key paths") {
+                    let json: [String: [String: Any]] = ["data": ["issues": [json]]] // nested json array
+                    guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                        preconditionFailure("Failed creating Data from JSON dictionary")
+                    }
+                    let single = Response(statusCode: 200, data: data).asSingle()
+
+                    var receivedObjects: [Issue]?
+                    _ = single.map([Issue].self, atKeyPaths: ["data", "issues"], using: decoder).subscribe(onSuccess: { object in
+                        receivedObjects = object
+                    })
+                    expect(receivedObjects).notTo(beNil())
+                    expect(receivedObjects?.count) == 1
+                    expect(receivedObjects?.first?.title) == "Hello, Moya!"
+                    expect(receivedObjects?.first?.createdAt) == formatter.date(from: "1995-01-14T12:34:56")!
+                }
+
+                it("map String data to a String value with multiple key paths") {
+                    let json: [String: [String: Any]] = ["name": ["korean": "이병찬"]]
+                    guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                        preconditionFailure("Failed creating Data from JSON dictionary")
+                    }
+                    let single = Response(statusCode: 200, data: data).asSingle()
+
+                    var description: String?
+                    _ = single.map(String.self, atKeyPaths: ["name", "korean"], using: decoder).subscribe(onSuccess: { value in
+                        description = value
+                    })
+                    expect(description).notTo(beNil())
+                    expect(description) == "이병찬"
+                }
+
                 it("shouldn't map Int data to a Bool value") {
                     let json: [String: Any] = ["isNew": 1]
                     guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
@@ -551,6 +600,20 @@ final class SingleMoyaSpec: QuickSpec {
 
                     var test: [String]?
                     _ = observable.map([String].self, atKeyPath: "test", using: decoder).subscribe(onSuccess: { value in
+                        test = value
+                    })
+                    expect(test).to(beNil())
+                }
+
+                it("shouldn't map Any data to Any value with missing key path") {
+                    let json: [String: Any] = ["data": ["test": "123"]]
+                    guard let data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted) else {
+                        preconditionFailure("Failed creating Data from JSON dictionary")
+                    }
+                    let single = Response(statusCode: 200, data: data).asSingle()
+
+                    var test: String?
+                    _ = single.map(String.self, atKeyPaths: ["data", "testing"], using: decoder).subscribe(onSuccess: { value in
                         test = value
                     })
                     expect(test).to(beNil())


### PR DESCRIPTION
Hello all! I wanted to add new `mapString`, `mapDecodable` function

Much JSON Response, usually wrapped in many key path.
How could we get a `name` in below JSON Response?
It was not possible in the current `Moya` (We just made `XXX_ResponseData`)

```swift
let json = """
{
  result: {
    data: {
        name: "lee"
        korean_name: "이병찬"
    },
    response_code: 200
  }
}
"""
```

However, the new 'mapString' and 'mapDecodable' function take multiple key paths
Therefore, even the above complex JSON Response we can easily bring a `name`.

```swift
let name = try response.mapString(atKeypaths: ["result", "data", "name"])
print(name)
// "lee"

provider.rx.response(.getName)
    .map(String.self, atKeypaths: ["result", "data", "name"])
    // Type is now Observable<String>
    .subscribe { print($0) }
    // "lee"
```

