### PR TITLE
Improved access token plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Changed
+- **Breaking Change** In `AccessTokenPlugin`, the token closure now takes a `AuthorizationType` as parameter and `AuthorizationType.none` has been removed in favor of using  `AuthorizationType?`. [#1969](https://github.com/Moya/Moya/pull/1969) by [@amaurydavid](https://github.com/amaurydavid).
+
 # [14.0.0-beta.5] - 2019-10-27
 
 ### Changed

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -46,16 +46,18 @@ public enum AuthorizationType {
  */
 public struct AccessTokenPlugin: PluginType {
 
+    public typealias TokenClosure = (AuthorizationType) -> String
+
     /// A closure returning the access token to be applied in the header.
-    public let tokenClosure: () -> String
+    public let tokenClosure: TokenClosure
 
     /**
      Initialize a new `AccessTokenPlugin`.
 
      - parameters:
-       - tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthorizationType> <token>`
-    */
-    public init(tokenClosure: @escaping () -> String) {
+     - tokenClosure: A closure returning the token to be applied in the pattern `Authorization: <AuthorizationType> <token>`
+     */
+    public init(tokenClosure: @escaping TokenClosure) {
         self.tokenClosure = tokenClosure
     }
 
@@ -75,7 +77,7 @@ public struct AccessTokenPlugin: PluginType {
 
         var request = request
 
-        let authValue = authorizationType.value + " " + tokenClosure()
+        let authValue = authorizationType.value + " " + tokenClosure(authorizationType)
         request.addValue(authValue, forHTTPHeaderField: "Authorization")
 
         return request

--- a/Tests/MoyaTests/AccessTokenPluginSpec.swift
+++ b/Tests/MoyaTests/AccessTokenPluginSpec.swift
@@ -15,7 +15,7 @@ final class AccessTokenPluginSpec: QuickSpec {
     }
 
     let token = "eyeAm.AJsoN.weBTOKen"
-    lazy var plugin = AccessTokenPlugin { self.token }
+    lazy var plugin = AccessTokenPlugin { _ in self.token }
 
     override func spec() {
         it("doesn't add an authorization header to TargetTypes by default") {

--- a/Tests/MoyaTests/AccessTokenPluginSpec.swift
+++ b/Tests/MoyaTests/AccessTokenPluginSpec.swift
@@ -11,7 +11,7 @@ final class AccessTokenPluginSpec: QuickSpec {
         let task = Task.requestPlain
         let sampleData = Data()
         let headers: [String: String]? = nil
-        let authorizationType: AuthorizationType
+        let authorizationType: AuthorizationType?
     }
 
     let token = "eyeAm.AJsoN.weBTOKen"
@@ -25,11 +25,9 @@ final class AccessTokenPluginSpec: QuickSpec {
             expect(preparedRequest.allHTTPHeaderFields).to(beNil())
         }
 
-        it("doesn't add an authorization header to AccessTokenAuthorizables when AuthorizationType is .none") {
-            let authorizationType: AuthorizationType = .none
-            let preparedRequest = self.createPreparedRequest(for: authorizationType)
+        it("doesn't add an authorization header to AccessTokenAuthorizables when AuthorizationType is nil") {
+            let preparedRequest = self.createPreparedRequest(for: nil)
 
-            expect(authorizationType.value).to(beNil())
             expect(preparedRequest.allHTTPHeaderFields).to(beNil())
         }
 
@@ -37,7 +35,7 @@ final class AccessTokenPluginSpec: QuickSpec {
             let authorizationType: AuthorizationType = .basic
             let preparedRequest = self.createPreparedRequest(for: authorizationType)
 
-            let authValue = authorizationType.value!
+            let authValue = authorizationType.value
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "\(authValue) \(self.token)"]
         }
 
@@ -45,7 +43,7 @@ final class AccessTokenPluginSpec: QuickSpec {
             let authorizationType: AuthorizationType = .bearer
             let preparedRequest = self.createPreparedRequest(for: authorizationType)
 
-            let authValue = authorizationType.value!
+            let authValue = authorizationType.value
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "\(authValue) \(self.token)"]
         }
 
@@ -53,12 +51,12 @@ final class AccessTokenPluginSpec: QuickSpec {
             let authorizationType: AuthorizationType = .custom("CustomAuthorizationHeader")
             let preparedRequest = self.createPreparedRequest(for: authorizationType)
 
-            let authValue = authorizationType.value!
+            let authValue = authorizationType.value
             expect(preparedRequest.allHTTPHeaderFields) == ["Authorization": "\(authValue) \(self.token)"]
         }
     }
 
-    private func createPreparedRequest(for type: AuthorizationType) -> URLRequest {
+    private func createPreparedRequest(for type: AuthorizationType?) -> URLRequest {
         let target = TestTarget(authorizationType: type)
         let request = URLRequest(url: target.baseURL)
 

--- a/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
@@ -294,7 +294,7 @@ final class MoyaProviderIntegrationTests: QuickSpec {
 
                     beforeEach {
                         token = UUID().uuidString
-                        plugin = AccessTokenPlugin { token }
+                        plugin = AccessTokenPlugin { _ in token }
                         provider = MoyaProvider<HTTPBin>(stubClosure: MoyaProvider.immediatelyStub,
                                                          plugins: [plugin])
                     }

--- a/Tests/MoyaTests/TestHelpers.swift
+++ b/Tests/MoyaTests/TestHelpers.swift
@@ -137,12 +137,12 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
         }
     }
 
-    var authorizationType: AuthorizationType {
+    var authorizationType: AuthorizationType? {
         switch self {
         case .bearer:
             return  .bearer
         default:
-            return .none
+            return nil
         }
     }
 }

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -42,7 +42,7 @@ There are two steps required to start using an `AccessTokenPlugin`.
 1. You need to add an `AccessTokenPlugin` to your `MoyaProvider` like this:
 ```Swift
 let token = "eyeAm.AJsoN.weBTOKen"
-let authPlugin = AccessTokenPlugin { token }
+let authPlugin = AccessTokenPlugin { _ in token }
 let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
 ```
 The `AccessTokenPlugin` initializer accepts a `tokenClosure` that is responsible
@@ -57,7 +57,7 @@ extension YourAPI: TargetType, AccessTokenAuthorizable {
     case targetThatNeedsCustomAuth
     case targetDoesNotNeedAuth
 
-    var authorizationType: AuthorizationType {
+    var authorizationType: AuthorizationType? {
         switch self {
             case .targetThatNeedsBearerAuth:
                 return .bearer
@@ -66,7 +66,7 @@ extension YourAPI: TargetType, AccessTokenAuthorizable {
             case .targetThatNeedsCustomAuth:
                 return .custom("CustomAuthorizationType")
             case .targetDoesNotNeedAuth:
-                return .none
+                return nil
             }
         }
 }

--- a/docs/MigrationGuides/migration_13_to_14.md
+++ b/docs/MigrationGuides/migration_13_to_14.md
@@ -7,3 +7,7 @@ This project follows [Semantic Versioning](http://semver.org).
 - The `verbose` and `cURL` flag are replaced by the `NetworkLoggerPlugin.Configuration.LogOptions` option set that allows finer tuning of logged elements. Use `.verbose` value to display every possible element and `formatRequestAscURL` to format request's logs as cURL.
 - The `output` closure no longer provides a `separator` and `terminator`, and items are now of type `String` instead of `Any`. To provide extra context, the target is also now provided in parameters.
 - `requestDataFormatter` and `responseDataFormatter` moved into a new `Configuration.Formatter` object and are now called `requestData` and `responseData`. Their return type have also changed from `Data` to `String`.
+
+### AccessTokenPlugin Migration
+- The token closure now takes an `AuthorizationType` as parameter.
+- The `AuthorizationType.none` value has been removed. Consequently in `AccessTokenAuthorizable` the property `AuthorizationType` is now optional. 

--- a/docs/MigrationGuides/migration_13_to_14.md
+++ b/docs/MigrationGuides/migration_13_to_14.md
@@ -10,4 +10,4 @@ This project follows [Semantic Versioning](http://semver.org).
 
 ### AccessTokenPlugin Migration
 - The token closure now takes an `AuthorizationType` as parameter.
-- The `AuthorizationType.none` value has been removed. Consequently in `AccessTokenAuthorizable` the property `AuthorizationType` is now optional. 
+- `AccessTokenAuthorizable.authorizationType` is now `AuthorizationType?`, instead of `AuthorizationType`. To skip using the plugin for given endpoint, you can still return `.none`, as previously, or `nil`.

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -21,9 +21,17 @@ let provider = MoyaProvider<GitHub>(plugins: [NetworkLoggerPlugin()])
 ```
 
 ### Authentication
+
+#### URLCredential
 The authentication plugin allows a user to assign an optional `URLCredential` per request. There is no action when a request is received.
 
 The plugin can be found at [`Sources/Moya/Plugins/CredentialsPlugin.swift`](../Sources/Moya/Plugins/CredentialsPlugin.swift)
+
+#### Access token
+The AccessTokenPlugin adds the `Authorization` field in the request's header if the target requires it.
+Before sending the request, the plugin will ask for a token of a specified type using its `tokenClosure`, and add the appropriate value to headers.
+
+The plugin can be found at [`Sources/Moya/Plugins/AccessTokenPlugin.swift`](../Sources/Moya/Plugins/AccessTokenPlugin.swift)
 
 ### Network Activity Indicator
 One very common task with iOS networking is to show a network activity indicator during network requests, and remove it when all requests have finished. The provided plugin adds callbacks which are called when a requests starts and finishes, which can be used to keep track of the number of requests in progress, and show / hide the network activity indicator accordingly.
@@ -36,6 +44,9 @@ During development it can be very useful to log network activity to the console.
 The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initializing the plugin, you can choose options for verbosity, whether to log curl commands, and provide functions for outputting data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `String.Encoding.utf8` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in [`Examples/_shared/GitHubAPI.swift`](../Examples/_shared/GitHubAPI.swift) for an example that does exactly that)
 
 The plugin can be found at [`Sources/Moya/Plugins/NetworkLoggerPlugin.swift`](../Sources/Moya/Plugins/NetworkLoggerPlugin.swift)
+
+### AccessTokenPlugin
+
 
 ## Custom plugins
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -27,8 +27,8 @@ The authentication plugin allows a user to assign an optional `URLCredential` pe
 
 The plugin can be found at [`Sources/Moya/Plugins/CredentialsPlugin.swift`](../Sources/Moya/Plugins/CredentialsPlugin.swift)
 
-#### Access token
-The AccessTokenPlugin adds the `Authorization` field in the request's header if the target requires it.
+### Access Token
+The `AccessTokenPlugin` adds the `Authorization` field in the request's header if the target requires it.
 Before sending the request, the plugin will ask for a token of a specified type using its `tokenClosure`, and add the appropriate value to headers.
 
 The plugin can be found at [`Sources/Moya/Plugins/AccessTokenPlugin.swift`](../Sources/Moya/Plugins/AccessTokenPlugin.swift)
@@ -44,8 +44,6 @@ During development it can be very useful to log network activity to the console.
 The provided plugin for logging is the most complex of the provided plugins, and can be configured to suit the amount of logging your app (and build type) require. When initializing the plugin, you can choose options for verbosity, whether to log curl commands, and provide functions for outputting data (useful if you are using your own log framework instead of `print`) and formatting data before printing (by default the response will be converted to a String using `String.Encoding.utf8` but if you'd like to convert to pretty-printed JSON for your responses you can pass in a formatter function, see the function `JSONResponseDataFormatter` in [`Examples/_shared/GitHubAPI.swift`](../Examples/_shared/GitHubAPI.swift) for an example that does exactly that)
 
 The plugin can be found at [`Sources/Moya/Plugins/NetworkLoggerPlugin.swift`](../Sources/Moya/Plugins/NetworkLoggerPlugin.swift)
-
-### AccessTokenPlugin
 
 
 ## Custom plugins

--- a/docs_CN/Authentication.md
+++ b/docs_CN/Authentication.md
@@ -40,7 +40,7 @@ Moya提供一个 `AccessTokenPlugin` 来完成
 
 ```Swift
 let token = "eyeAm.AJsoN.weBTOKen"
-let authPlugin = AccessTokenPlugin { token }
+let authPlugin = AccessTokenPlugin { _ in token }
 let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
 ```
 
@@ -52,17 +52,19 @@ let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
 extension YourAPI: TargetType, AccessTokenAuthorizable {
     case targetThatNeedsBearerAuth
     case targetThatNeedsBasicAuth
+    case targetThatNeedsCustomAuth
     case targetDoesNotNeedAuth
 
-    var authorizationType: AuthorizationType {
+    var authorizationType: AuthorizationType? {
         switch self {
             case .targetThatNeedsBearerAuth:
                 return .bearer
             case .targetThatNeedsBasicAuth:
                 return .basic
+            case .targetThatNeedsCustomAuth:
+                return .custom("CustomAuthorizationType")
             case .targetDoesNotNeedAuth:
-                return .none
-            }
+                return nil
         }
 }
 ```


### PR DESCRIPTION
Some APIs require clients to use multiple access token types. For example, when using the Reddit API we need to use a basic token to get a bearer token, and then use the bearer token in every request.

With the current state of the AccessTokenPlugin, it's impossible to know in the token closure which token we are supposed to return. With that in mind, I added the AuthorizationType as parameter of the token closure so that we can now return the correct token.

Additionally, I've removed the `AuthorizationType.none` value because when implementing the token closure with the `AuthorizationType` as parameter there could have a possibility for it to be `AuthorizationType.none`, which doesn't make sense.
Also, it simplifies a bit the code when using an optional `AuthorizationType` instead of `AuthorizationType.none`.