### PR TITLE
Support resume download with data

### DIFF
--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -85,7 +85,7 @@ public extension Endpoint {
         request.allHTTPHeaderFields = httpHeaderFields
 
         switch task {
-        case .requestPlain, .uploadFile, .uploadMultipart, .downloadDestination:
+        case .requestPlain, .uploadFile, .uploadMultipart, .downloadDestination, .downloadResume:
             return request
         case .requestData(let data):
             request.httpBody = data

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -99,6 +99,9 @@ public extension MoyaProvider {
             case .downloadDestination(let destination), .downloadParameters(_, _, let destination):
                 return self.sendDownloadRequest(target, request: request, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
             }
+            case .downloadResume(let resumeData, let destination):
+                return self.sendDownloadRequest(target, request: request, resumeData: resumeData, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
+            }
         default:
             return self.stubRequest(target, request: request, callbackQueue: callbackQueue, completion: completion, endpoint: endpoint, stubBehavior: stubBehavior)
         }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -205,9 +205,14 @@ private extension MoyaProvider {
         return sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
     }
 
-    func sendDownloadRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
+    func sendDownloadRequest(_ target: Target, request: URLRequest, resumeData: Data? = nil, callbackQueue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let downloadRequest = session.download(request, interceptor: interceptor, to: destination)
+        let downloadRequest: DownloadRequest
+        if let resumeData = resumeData {
+            downloadRequest = session.download(resumingWith: resumeData, interceptor: interceptor, to: destination)
+        } else {
+            downloadRequest = session.download(request, interceptor: interceptor, to: destination)
+        }
         setup(interceptor: interceptor, with: target, and: downloadRequest)
 
         let validationCodes = target.validationType.statusCodes

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -98,7 +98,6 @@ public extension MoyaProvider {
                 return self.sendUploadMultipart(target, request: request, callbackQueue: callbackQueue, multipartBody: multipartBody, progress: progress, completion: completion)
             case .downloadDestination(let destination), .downloadParameters(_, _, let destination):
                 return self.sendDownloadRequest(target, request: request, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
-            }
             case .downloadResume(let resumeData, let destination):
                 return self.sendDownloadRequest(target, request: request, resumeData: resumeData, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
             }

--- a/Sources/Moya/Task.swift
+++ b/Sources/Moya/Task.swift
@@ -35,6 +35,9 @@ public enum Task {
 
     /// A file download task to a destination.
     case downloadDestination(DownloadDestination)
+    
+    /// A file download task with resume data, to a destination
+    case downloadResume(data: Data, destination: DownloadDestination)
 
     /// A file download task to a destination with extra parameters using the given encoding.
     case downloadParameters(parameters: [String: Any], encoding: ParameterEncoding, destination: DownloadDestination)


### PR DESCRIPTION
Added a resume download case.
This is used when canceling a download and resuming at a later time.

Usually, when using background download, all requests are terminated when a user kills the App. It is possible however, to resume download. When a request is canceled, a task resume data is returned in the error's user info for NSURLSessionDownloadTaskResumeData. Using this data, we can resume the download when the App restarts.

<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
