### PR TITLE
MultiTarget conformance to AccessTokenAuthorizable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+### Changed
+- **Breaking Change**  `MultiTarget` now implements `AccessTokenAuthorizable` so that the inner target's `authorizationType` is correctly returned to the `AccessTokenPlugin` when requested. [#1979](https://github.com/Moya/Moya/pull/1979) by [@amaurydavid](https://github.com/amaurydavid).
+
+
 # [14.0.0-beta.6] - 2019-12-09
 
 ### Changed

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -52,3 +52,10 @@ public enum MultiTarget: TargetType {
         }
     }
 }
+
+extension MultiTarget: AccessTokenAuthorizable {
+    public var authorizationType: AuthorizationType? {
+        guard let authorizableTarget = target as? AccessTokenAuthorizable else { return nil }
+        return authorizableTarget.authorizationType
+    }
+}

--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -32,6 +32,22 @@ public enum AuthorizationType {
     }
 }
 
+extension AuthorizationType: Equatable {
+    public static func == (lhs: AuthorizationType, rhs: AuthorizationType) -> Bool {
+        switch (lhs, rhs) {
+        case (.basic, .basic),
+             (.bearer, .bearer):
+            return true
+
+        case let (.custom(value1), .custom(value2)):
+            return value1 == value2
+
+        default:
+            return false
+        }
+    }
+}
+
 // MARK: - AccessTokenPlugin
 
 /**

--- a/Tests/MoyaTests/MultiTargetSpec.swift
+++ b/Tests/MoyaTests/MultiTargetSpec.swift
@@ -7,7 +7,7 @@ import Foundation
 final class MultiTargetSpec: QuickSpec {
     override func spec() {
         describe("MultiTarget") {
-            struct StructAPI: TargetType {
+            struct StructAPI: TargetType, AccessTokenAuthorizable {
                 let baseURL = URL(string: "http://example.com")!
                 let path = "/endpoint"
                 let method = Moya.Method.get
@@ -15,6 +15,7 @@ final class MultiTargetSpec: QuickSpec {
                 let sampleData = "sample data".data(using: .utf8)!
                 let validationType: ValidationType = .successCodes
                 let headers: [String: String]? = ["headerKey": "headerValue"]
+                let authorizationType: AuthorizationType? = .basic
             }
 
             var target: MultiTarget!
@@ -67,6 +68,10 @@ final class MultiTargetSpec: QuickSpec {
 
             it("uses correct headers") {
                 expect(target.headers) == ["headerKey": "headerValue"]
+            }
+
+            it("uses correct authorizationType") {
+                expect(target.authorizationType).to(equal(AuthorizationType.basic))
             }
         }
     }

--- a/docs/MigrationGuides/migration_13_to_14.md
+++ b/docs/MigrationGuides/migration_13_to_14.md
@@ -11,3 +11,4 @@ This project follows [Semantic Versioning](http://semver.org).
 ### AccessTokenPlugin Migration
 - The token closure now takes an `AuthorizationType` as parameter.
 - `AccessTokenAuthorizable.authorizationType` is now `AuthorizationType?`, instead of `AuthorizationType`. To skip using the plugin for given endpoint, you can still return `.none`, as previously, or `nil`.
+- `MultiTarget` now implements `AccessTokenAuthorizable` and returns the inner target's `authorizationType` if available.


### PR DESCRIPTION
Just a fix for #1969 so that the `AccessTokenPlugin` correctly asks for a token when using `MultiTarget`.