### PR TITLE
Adding support for MultiTarget with AccessTokenAuthorizable

### DIFF
--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -91,3 +91,15 @@ public struct AccessTokenPlugin: PluginType {
         return request
     }
 }
+
+extension MultiTarget: AccessTokenAuthorizable {
+    public var authorizationType: AuthorizationType {
+        if target is AccessTokenAuthorizable {
+            guard let authTarget = target as? AccessTokenAuthorizable else {
+                return .none
+            }
+            return authTarget.authorizationType
+        }
+        return .none
+    }
+}


### PR DESCRIPTION
we often use AccessTokenPlugin to 'Signing' the request but when using a MultiTarget  the request didn't get 'Signing' as Multitarget itself is a TargetType wrapper,
adding support for  MultiTarget with AccessTokenAuthorizable will prevent the behavior the user doesn't understand, and make it easy to work with MultiTarget