### PR TITLE
Fix create release script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -155,6 +155,8 @@ task :create_release, :version do |task, args|
   puts "Pushing as a GitHub Release."
   require 'octokit'
   version = args[:version]
+  changelog_filename = "CHANGELOG.md"	
+  changelog = File.read(changelog_filename)
   Octokit::Client.new(netrc: true).
     create_release('Moya/Moya',
                    version,


### PR DESCRIPTION
Just found the reason why create release was not working, I've created two test releases on my repo (one with Rocket and one calling `create_release` manually) https://github.com/f-meloni/Moya/releases to check if was working