### PR TITLE
Jazzy improvements

### DIFF
--- a/scripts/update_docs_website.sh
+++ b/scripts/update_docs_website.sh
@@ -1,6 +1,10 @@
 git clone git@github.com:Moya/moya.github.io.git _moya.github.io
 
-jazzy -o _moya.github.io
+# These two lines, instead of pure `jazzy -o ...` make sure we consistently produce docs
+# Otherwise we would sometimes get empty docs due to some cache bug & new Xcode file response
+# Relevant: https://github.com/realm/jazzy/issues/1087
+rm -rf ~/Library/Developer/Xcode/DerivedData/Moya*
+jazzy -x USE_SWIFT_RESPONSE_FILE=NO -o _moya.github.io
 
 cd _moya.github.io
 

--- a/scripts/update_docs_website.sh
+++ b/scripts/update_docs_website.sh
@@ -4,7 +4,7 @@ git clone git@github.com:Moya/moya.github.io.git _moya.github.io
 # Otherwise we would sometimes get empty docs due to some cache bug & new Xcode file response
 # Relevant: https://github.com/realm/jazzy/issues/1087
 rm -rf ~/Library/Developer/Xcode/DerivedData/Moya*
-jazzy -x USE_SWIFT_RESPONSE_FILE=NO -o _moya.github.io
+jazzy --documentation=docs/*.md -x USE_SWIFT_RESPONSE_FILE=NO -o _moya.github.io
 
 cd _moya.github.io
 


### PR DESCRIPTION
Thanks to #1998, we can now tinker with the build script for Moya documentation website!
In this PR I've added the "docs/" folder so it appears on the sidebar under the "Guides" menu:
![Zrzut ekranu 2020-02-24 o 12 34 33](https://user-images.githubusercontent.com/5232779/75149404-26c1af00-5702-11ea-8c0c-adf7dc3cb422.png)

and also fixed the consistency of the jazzy docs build... At least for me I couldn't get it to work consistently as it was failing silently and couldn't get any of the docs out until I cleaned the derived data and passed a flag.