### PR TITLE
Introducing Path.

### DIFF
--- a/Examples/_shared/GiphyAPI.swift
+++ b/Examples/_shared/GiphyAPI.swift
@@ -9,16 +9,10 @@ public enum Giphy {
 
 extension Giphy: TargetType {
     public var baseURL: URL { URL(string: "https://upload.giphy.com")! } // swiftlint:disable:this force_unwrapping
-    public var path: String {
+    public var path: Path {
         switch self {
         case .upload:
-            return "/v1/gifs"
-        }
-    }
-    public var method: Moya.Method {
-        switch self {
-        case .upload:
-            return .post
+            return .post(endpoint: "/v1/gifs")
         }
     }
     public var task: Task {

--- a/Examples/_shared/GitHubAPI.swift
+++ b/Examples/_shared/GitHubAPI.swift
@@ -34,17 +34,16 @@ public enum GitHub {
 
 extension GitHub: TargetType {
     public var baseURL: URL { URL(string: "https://api.github.com")! }
-    public var path: String {
+    public var path: Path {
         switch self {
         case .zen:
-            return "/zen"
+            return .get(endpoint: "/zen")
         case .userProfile(let name):
-            return "/users/\(name.urlEscaped)"
+            return .get(endpoint: "/users/\(name.urlEscaped)")
         case .userRepositories(let name):
-            return "/users/\(name.urlEscaped)/repos"
+            return .get(endpoint: "/users/\(name.urlEscaped)/repos")
         }
     }
-    public var method: Moya.Method { .get }
 
     public var task: Task {
         switch self {
@@ -77,7 +76,7 @@ extension GitHub: TargetType {
 }
 
 public func url(_ route: TargetType) -> String {
-    route.baseURL.appendingPathComponent(route.path).absoluteString
+    route.baseURL.appendingPathComponent(route.path.endpoint).absoluteString
 }
 
 // MARK: - Response Handlers

--- a/Examples/_shared/GitHubUserContentAPI.swift
+++ b/Examples/_shared/GitHubUserContentAPI.swift
@@ -9,16 +9,10 @@ public enum GitHubUserContent {
 
 extension GitHubUserContent: TargetType {
     public var baseURL: URL { URL(string: "https://raw.githubusercontent.com")! } // swiftlint:disable:this force_unwrapping
-    public var path: String {
+    public var path: Path {
         switch self {
         case .downloadMoyaWebContent(let contentPath):
-            return "/Moya/Moya/master/web/\(contentPath)"
-        }
-    }
-    public var method: Moya.Method {
-        switch self {
-        case .downloadMoyaWebContent:
-            return .get
+            return .get(endpoint: "/Moya/Moya/master/web/\(contentPath)")
         }
     }
     public var task: Task {

--- a/Moya.xcodeproj/project.pbxproj
+++ b/Moya.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		D00AA2514CD6B1276B845BA7 /* ReactiveMoya.h in Headers */ = {isa = PBXBuildFile; fileRef = 019BF5A88BB928EBDFD944FE /* ReactiveMoya.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D6A04B657A83CA2FF80ABCF4 /* Moya.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 559D567FD0DA37D6CC98FF92 /* Moya.framework */; };
 		DA631A5B37F36DA17E135F14 /* SignalProducer+MoyaSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AFAFEA29CDFABC559F0BE2 /* SignalProducer+MoyaSpec.swift */; };
+		DCABD10A240AFDAC000D82FD /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCABD109240AFDAC000D82FD /* Path.swift */; };
 		E9B54EFE4EF4A96444BA76AA /* Observable+MoyaSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461DEED329CE157E412CBCE0 /* Observable+MoyaSpec.swift */; };
 		EDBA10DB0D0E35C1474AAB4D /* Moya+Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D4E607168B403E754F510C /* Moya+Alamofire.swift */; };
 		F88EC83A91FF6DE81246B01C /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4650771638DBA96BDE28F11B /* TestHelpers.swift */; };
@@ -211,6 +212,7 @@
 		CC115388D44D0DB7A753E9BB /* AccessTokenPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessTokenPlugin.swift; sourceTree = "<group>"; };
 		D38525FE207BE148B17084F3 /* Moya.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Moya.h; sourceTree = "<group>"; };
 		D48555FB39336D99F8365F5E /* MoyaProvider+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MoyaProvider+Rx.swift"; sourceTree = "<group>"; };
+		DCABD109240AFDAC000D82FD /* Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
 		DCACC7B19F3FFC2DEE74E07B /* TestPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestPlugin.swift; sourceTree = "<group>"; };
 		E825A32256FC030B8BA2684D /* EndpointSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EndpointSpec.swift; sourceTree = "<group>"; };
 		F1AFAFEA29CDFABC559F0BE2 /* SignalProducer+MoyaSpec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SignalProducer+MoyaSpec.swift"; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				149749421F8923EC00FA4900 /* AnyEncodable.swift */,
 				5C2B20158E599EDBE51D7AB2 /* Cancellable.swift */,
 				3FF1994427C5440527B03B31 /* Endpoint.swift */,
+				DCABD109240AFDAC000D82FD /* Path.swift */,
 				86F3C0EA472C23E786E23CE9 /* Image.swift */,
 				88D4E607168B403E754F510C /* Moya+Alamofire.swift */,
 				2D47F3DC51C28D950491FAAB /* MoyaError.swift */,
@@ -842,6 +845,7 @@
 				59BC4B9B9D0D6F9C060E5620 /* MoyaProvider+Defaults.swift in Sources */,
 				149749431F8923EC00FA4900 /* AnyEncodable.swift in Sources */,
 				9854C1DBF14818CCA76AEC7F /* MoyaProvider+Internal.swift in Sources */,
+				DCABD10A240AFDAC000D82FD /* Path.swift in Sources */,
 				147E26EC1F5B14B300C1F513 /* Task.swift in Sources */,
 				149749451F892E2F00FA4900 /* URLRequest+Encoding.swift in Sources */,
 				5BCAACCA268FEA0DAB07F998 /* MoyaProvider.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let config = PackageConfiguration([
             "scripts/update_podspec.sh"
 	],
 	"after": [
-            "rake create_release\\[\"$VERSION\"\\]"
+            "rake create_release\\[\"$VERSION\"\\]",
+            "scripts/update_docs_website.sh"
 	]
     ]
 ]).write()

--- a/Sources/Moya/MoyaProvider+Defaults.swift
+++ b/Sources/Moya/MoyaProvider+Defaults.swift
@@ -6,7 +6,7 @@ public extension MoyaProvider {
         Endpoint(
             url: URL(target: target).absoluteString,
             sampleResponseClosure: { .networkResponse(200, target.sampleData) },
-            method: target.method,
+            method: target.path.method,
             task: target.task,
             httpHeaderFields: target.headers
         )

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -18,9 +18,6 @@ public enum MultiTarget: TargetType {
     /// The baseURL of the embedded target.
     public var baseURL: URL { target.baseURL }
 
-    /// The HTTP method of the embedded target.
-    public var method: Moya.Method { target.method }
-
     /// The sampleData of the embedded target.
     public var sampleData: Data { target.sampleData }
 

--- a/Sources/Moya/MultiTarget.swift
+++ b/Sources/Moya/MultiTarget.swift
@@ -10,8 +10,10 @@ public enum MultiTarget: TargetType {
         self = MultiTarget.target(target)
     }
 
-    /// The embedded target's base `URL`.
-    public var path: String { target.path }
+    /// The embedded target's base `URL` and the `HTTP` method.
+    public var path: Path {
+        return target.path
+    }
 
     /// The baseURL of the embedded target.
     public var baseURL: URL { target.baseURL }

--- a/Sources/Moya/Path.swift
+++ b/Sources/Moya/Path.swift
@@ -26,7 +26,7 @@ public enum Path {
         }
     }
 
-    public var method: Method {
+    public var method: Moya.Method {
         switch self {
         case .connect:
             return .connect

--- a/Sources/Moya/Path.swift
+++ b/Sources/Moya/Path.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum Path {
+    case connect(endpoint: String)
+    case delete(endpoint: String)
+    case get(endpoint: String)
+    case head(endpoint: String)
+    case options(endpoint: String)
+    case patch(endpoint: String)
+    case post(endpoint: String)
+    case put(endpoint: String)
+    case trace(endpoint: String)
+
+    public var endpoint: String {
+        switch self {
+        case let .connect(endpoint),
+             let .delete(endpoint),
+             let .get(endpoint),
+             let .head(endpoint),
+             let .options(endpoint),
+             let .patch(endpoint),
+             let .post(endpoint),
+             let .put(endpoint),
+             let .trace(endpoint):
+            return endpoint
+        }
+    }
+
+    public var method: Method {
+        switch self {
+        case .connect:
+            return .connect
+        case .delete:
+            return .delete
+        case .get:
+            return .get
+        case .head:
+            return .head
+        case .options:
+            return .options
+        case .patch:
+            return .patch
+        case .post:
+            return .post
+        case .put:
+            return .put
+        case .trace:
+            return .trace
+        }
+    }
+}

--- a/Sources/Moya/Path.swift
+++ b/Sources/Moya/Path.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Path {
+public enum Path: Equatable {
     case connect(endpoint: String)
     case delete(endpoint: String)
     case get(endpoint: String)

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -9,9 +9,6 @@ public protocol TargetType {
     /// The path has `URL` endpoint and `HTTP` method.
     var path: Path { get }
 
-    /// The HTTP method used in the request.
-    var method: Moya.Method { get }
-
     /// Provides stub data for use in testing.
     var sampleData: Data { get }
 

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -6,8 +6,8 @@ public protocol TargetType {
     /// The target's base `URL`.
     var baseURL: URL { get }
 
-    /// The path to be appended to `baseURL` to form the full `URL`.
-    var path: String { get }
+    /// The path has `URL` endpoint and `HTTP` method.
+    var path: Path { get }
 
     /// The HTTP method used in the request.
     var method: Moya.Method { get }

--- a/Sources/Moya/URL+Moya.swift
+++ b/Sources/Moya/URL+Moya.swift
@@ -7,11 +7,11 @@ public extension URL {
         // When a TargetType's path is empty, URL.appendingPathComponent may introduce trailing /, which may not be wanted in some cases
         // See: https://github.com/Moya/Moya/pull/1053
         // And: https://github.com/Moya/Moya/issues/1049
-        let targetPath = target.path
-        if targetPath.isEmpty {
+        let targetEndpoint = target.path.endpoint
+        if targetEndpoint.isEmpty {
             self = target.baseURL
         } else {
-            self = target.baseURL.appendingPathComponent(targetPath)
+            self = target.baseURL.appendingPathComponent(targetEndpoint)
         }
     }
 }

--- a/Tests/MoyaTests/AccessTokenPluginSpec.swift
+++ b/Tests/MoyaTests/AccessTokenPluginSpec.swift
@@ -6,7 +6,7 @@ import Foundation
 final class AccessTokenPluginSpec: QuickSpec {
     struct TestTarget: TargetType, AccessTokenAuthorizable {
         let baseURL = URL(string: "http://www.api.com/")!
-        let path = ""
+        let path = Path.get(endpoint: "")
         let method = Method.get
         let task = Task.requestPlain
         let sampleData = Data()

--- a/Tests/MoyaTests/EndpointSpec.swift
+++ b/Tests/MoyaTests/EndpointSpec.swift
@@ -373,12 +373,12 @@ enum Empty {
 
 extension Empty: TargetType {
     // None of these matter since the Empty has no cases and can't be instantiated.
-    var baseURL: URL { URL(string: "http://example.com")! }
-    var path: String { "" }
-    var method: Moya.Method { .get }
-    var parameters: [String: Any]? { nil }
-    var parameterEncoding: ParameterEncoding { URLEncoding.default }
-    var task: Task { .requestPlain }
-    var sampleData: Data { Data() }
-    var headers: [String: String]? { nil }
+    var baseURL: URL { return URL(string: "http://example.com")! }
+    var path: Path { return Path.get(endpoint: "") }
+    var method: Moya.Method { return .get }
+    var parameters: [String: Any]? { return nil }
+    var parameterEncoding: ParameterEncoding { return URLEncoding.default }
+    var task: Task { return .requestPlain }
+    var sampleData: Data { return Data() }
+    var headers: [String: String]? { return nil }
 }

--- a/Tests/MoyaTests/MoyaProviderSpec.swift
+++ b/Tests/MoyaTests/MoyaProviderSpec.swift
@@ -418,7 +418,7 @@ final class MoyaProviderSpec: QuickSpec {
         describe("a provider with custom sample response closures") {
             it("returns sample data") {
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
-                    let url = target.baseURL.appendingPathComponent(target.path).absoluteString
+                    let url = target.baseURL.appendingPathComponent(target.path.endpoint).absoluteString
                     return Endpoint(url: url, sampleResponseClosure: {.networkResponse(200, target.sampleData)}, method: target.method, task: target.task, httpHeaderFields: target.headers)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
@@ -453,7 +453,7 @@ final class MoyaProviderSpec: QuickSpec {
             it("returns error") {
                 let error = NSError(domain: "Internal iOS Error", code: -1234, userInfo: nil)
                 let endpointResolution: MoyaProvider<GitHub>.EndpointClosure = { target in
-                    let url = target.baseURL.appendingPathComponent(target.path).absoluteString
+                    let url = target.baseURL.appendingPathComponent(target.path.endpoint).absoluteString
                     return Endpoint(url: url, sampleResponseClosure: { .networkError(error) }, method: target.method, task: target.task, httpHeaderFields: target.headers)
                 }
                 let provider = MoyaProvider<GitHub>(endpointClosure: endpointResolution, stubClosure: MoyaProvider.immediatelyStub)
@@ -560,7 +560,7 @@ final class MoyaProviderSpec: QuickSpec {
         describe("struct targets") {
             struct StructAPI: TargetType {
                 let baseURL = URL(string: "http://example.com")!
-                let path = "/endpoint"
+                let path = Path.get(endpoint: "/endpoint")
                 let method = Moya.Method.get
                 let task = Task.requestParameters(parameters: ["key": "value"], encoding: URLEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!
@@ -659,7 +659,7 @@ final class MoyaProviderSpec: QuickSpec {
         describe("a target with empty path") {
             struct PathlessAPI: TargetType {
                 let baseURL = URL(string: "http://example.com/123/somepath?X-ABC-Asd=123")!
-                let path = ""
+                let path = Path.get(endpoint: "")
                 let method = Moya.Method.get
                 let task = Task.requestParameters(parameters: ["key": "value"], encoding: URLEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!

--- a/Tests/MoyaTests/MultiTargetSpec.swift
+++ b/Tests/MoyaTests/MultiTargetSpec.swift
@@ -9,7 +9,7 @@ final class MultiTargetSpec: QuickSpec {
         describe("MultiTarget") {
             struct StructAPI: TargetType, AccessTokenAuthorizable {
                 let baseURL = URL(string: "http://example.com")!
-                let path = "/endpoint"
+                let path = Path.get(endpoint: "/endpoint")
                 let method = Moya.Method.get
                 let task = Task.requestParameters(parameters: ["key": "value"], encoding: JSONEncoding.default)
                 let sampleData = "sample data".data(using: .utf8)!
@@ -28,8 +28,8 @@ final class MultiTargetSpec: QuickSpec {
                 expect(target.baseURL) == URL(string: "http://example.com")!
             }
 
-            it("uses correct path") {
-                expect(target.path) == "/endpoint"
+            it("uses correct Path") {
+                expect(target.path) == Path.get(endpoint: "/endpoint")
             }
 
             it("uses correct parameters") {

--- a/Tests/MoyaTests/MultiTargetSpec.swift
+++ b/Tests/MoyaTests/MultiTargetSpec.swift
@@ -49,10 +49,6 @@ final class MultiTargetSpec: QuickSpec {
                 }
             }
 
-            it("uses correct method") {
-                expect(target.method) == Method.get
-            }
-
             it("uses correct task") {
                 expect(String(describing: target.task)).to(beginWith("requestParameters")) // Hack to avoid implementing Equatable for Task
             }

--- a/Tests/MoyaTests/TestHelpers.swift
+++ b/Tests/MoyaTests/TestHelpers.swift
@@ -14,13 +14,13 @@ enum GitHub {
 }
 
 extension GitHub: TargetType {
-    var baseURL: URL { URL(string: "https://api.github.com")! }
-    var path: String {
+    var baseURL: URL { return URL(string: "https://api.github.com")! }
+    var path: Path {
         switch self {
         case .zen:
-            return "/zen"
+            return .get(endpoint: "/zen")
         case .userProfile(let name):
-            return "/users/\(name.urlEscaped)"
+            return .get(endpoint: "/users/\(name.urlEscaped)")
         }
     }
 
@@ -53,7 +53,7 @@ extension GitHub: Equatable {
 }
 
 func url(_ route: TargetType) -> String {
-    route.baseURL.appendingPathComponent(route.path).absoluteString
+    return route.baseURL.appendingPathComponent(route.path.endpoint).absoluteString
 }
 
 let failureEndpointClosure = { (target: GitHub) -> Endpoint in
@@ -69,15 +69,15 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
     case uploadMultipart([MultipartFormData], [String: Any]?)
     case validatedUploadMultipart([MultipartFormData], [String: Any]?, [Int])
 
-    var baseURL: URL { URL(string: "http://httpbin.org")! }
-    var path: String {
+    var baseURL: URL { return URL(string: "http://httpbin.org")! }
+    var path: Path {
         switch self {
         case .basicAuth:
-            return "/basic-auth/user/passwd"
+            return .get(endpoint: "/basic-auth/user/passwd")
         case .bearer:
-            return "/bearer"
+            return .get(endpoint: "/bearer")
         case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
-            return "/post"
+            return .post(endpoint: "/post")
         }
     }
 
@@ -143,11 +143,11 @@ public enum GitHubUserContent {
 }
 
 extension GitHubUserContent: TargetType {
-    public var baseURL: URL { URL(string: "https://raw.githubusercontent.com")! }
-    public var path: String {
+    public var baseURL: URL { return URL(string: "https://raw.githubusercontent.com")! }
+    public var path: Path {
         switch self {
         case .downloadMoyaWebContent(let contentPath), .requestMoyaWebContent(let contentPath):
-            return "/Moya/Moya/master/web/\(contentPath)"
+            return .get(endpoint: "/Moya/Moya/master/web/\(contentPath)")
         }
     }
     public var method: Moya.Method {

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -25,6 +25,7 @@ If you see an error command that you do not have registered session, run command
 ```ruby
 pod trunk register you@youremailaddress.com
 ```
+1. Install jazzy `[sudo] gem install jazzy`
 
 ## Release
 
@@ -45,6 +46,5 @@ What you might need to do manually afterwards:
 1. Update the instructions for our supported package managers in the Readme to use the release you just made public (e.g. update version numbers if it was a major release).
 1. Update Swift/Moya version table if needed.
 1. Update the release description in [GitHub releases tab](https://github.com/Moya/Moya/releases/tag).
-1. Check if we need to regenerate docs for [moya.github.io](https://github.com/Moya/moya.github.io).
 
 If anything goes wrong, don't panic! Get in touch with someone else who has released, or [Ash](mailto:ash@ashfurrow.com).

--- a/scripts/update_docs_website.sh
+++ b/scripts/update_docs_website.sh
@@ -1,0 +1,15 @@
+git clone git@github.com:Moya/moya.github.io.git _moya.github.io
+
+jazzy -o _moya.github.io
+
+cd _moya.github.io
+
+git add .
+
+git commit -m "Update docs for version $VERSION"
+
+git push origin HEAD
+
+cd ..
+
+rm -rf _moya.github.io

--- a/scripts/update_docs_website.sh
+++ b/scripts/update_docs_website.sh
@@ -1,6 +1,10 @@
 git clone git@github.com:Moya/moya.github.io.git _moya.github.io
 
-jazzy -o _moya.github.io
+# These two lines, instead of pure `jazzy -o ...` make sure we consistently produce docs
+# Otherwise we would sometimes get empty docs due to some cache bug & new Xcode file response
+# Relevant: https://github.com/realm/jazzy/issues/1087
+rm -rf ~/Library/Developer/Xcode/DerivedData/Moya*
+jazzy -x USE_SWIFT_RESPONSE_FILE=NO -o _moya.github.io
 
 cd _moya.github.io
 

--- a/scripts/update_docs_website.sh
+++ b/scripts/update_docs_website.sh
@@ -4,7 +4,7 @@ git clone git@github.com:Moya/moya.github.io.git _moya.github.io
 # Otherwise we would sometimes get empty docs due to some cache bug & new Xcode file response
 # Relevant: https://github.com/realm/jazzy/issues/1087
 rm -rf ~/Library/Developer/Xcode/DerivedData/Moya*
-jazzy -x USE_SWIFT_RESPONSE_FILE=NO -o _moya.github.io
+jazzy --documentation=docs/*.md -x USE_SWIFT_RESPONSE_FILE=NO -o _moya.github.io
 
 cd _moya.github.io
 


### PR DESCRIPTION
When new API endpoints are introduced, the `TargetType` enum can easily grow larger and, in such a case, I find it not easy to check if the endpoints are associated with the right `HTTP` methods. 

For the given reason, I'm introducing `Path` which combines in one place the endpoint and the `HTTP` method.

Example: 

```swift 
extension MyService: TargetType {
    var baseURL: URL { 
        return URL(string: "https://api.myservice.com")! 
     }

    var path: Path {
        switch self {
        case .zen:
            return .get(endpoint: "/zen")
        case .showUser(let id):
            return .get(endpoint: "/users/\(id)")
        case .updateUser(let id, _, _):
            return .post(endpoint: "/users/\(id)")
        case .createUser(_, _):
            return .post(endpoint: "/users")
        case .showAccounts:
            return .get(endpoint: "/accounts")
        }
    }
    ...
}
```

Let me know your thoughts! 
Thanks 😊 

<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
