### PR TITLE
Align Package manager version requirements

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -24,19 +24,19 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.source_files  = "Sources/Moya/", "Sources/Moya/Plugins/"
-    ss.dependency "Alamofire", "~> 5.0"
+    ss.dependency "Alamofire", "~> 5"
     ss.framework  = "Foundation"
   end
 
   s.subspec "ReactiveSwift" do |ss|
     ss.source_files = "Sources/ReactiveMoya/"
     ss.dependency "Moya/Core"
-    ss.dependency "ReactiveSwift", "~> 6.0"
+    ss.dependency "ReactiveSwift", "~> 6"
   end
 
   s.subspec "RxSwift" do |ss|
     ss.source_files = "Sources/RxMoya/"
     ss.dependency "Moya/Core"
-    ss.dependency "RxSwift", "~> 5.0"
+    ss.dependency "RxSwift", "~> 5"
   end
 end


### PR DESCRIPTION
## PR Description
Fixes the inconsistent behavior between version requirements of 3rd party dependencies, based on which package manager you use.

Using RxSwift as an example:
- `Package.swift` uses `.upToNextMajor(from: "5.0.0")`, which will resolve it to any 5.y.z version
- `Cartfile` uses `~> 5.0` which, surprisingly, will also resolve it to any 5.y.z version
- However, `.podspec` has `~> 5.0`, which will resolve it to any 5.0.z version. 

## Extra context
Initially, I only wanted to raise RxSwift's version requirement from `5.0` to `5.1`, because:
RxSwift 5.1.0 removed the deprecated UIWebView extensions. However, `Moya/RxSwift` insists on using 5.0.
Currently, no new app using `Moya/RxSwift` can be submitted to the app store.