### PR TITLE
Changed the parameter type AuthorizationType to TargetType in the tok…

### DIFF
--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -62,7 +62,7 @@ extension AuthorizationType: Equatable {
  */
 public struct AccessTokenPlugin: PluginType {
 
-    public typealias TokenClosure = (AuthorizationType) -> String
+    public typealias TokenClosure = (TargetType) -> String
 
     /// A closure returning the access token to be applied in the header.
     public let tokenClosure: TokenClosure
@@ -93,7 +93,7 @@ public struct AccessTokenPlugin: PluginType {
 
         var request = request
 
-        let authValue = authorizationType.value + " " + tokenClosure(authorizationType)
+        let authValue = authorizationType.value + " " + tokenClosure(target)
         request.addValue(authValue, forHTTPHeaderField: "Authorization")
 
         return request

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -45,6 +45,22 @@ let token = "eyeAm.AJsoN.weBTOKen"
 let authPlugin = AccessTokenPlugin { _ in token }
 let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
 ```
+If you use `MultiTarget` with different token, you can do like this:
+
+```swift
+let fooToken = "eyeAm.AJsoN.weBTOKen.foo"
+let barToken = "eyeAm.AJsoN.weBTOKen.bar"
+let authPlugin = AccessTokenPlugin { target in 
+    if target is FooService {
+        return fooToken    
+    } else if target is BarService {
+        return barToken
+    }
+    return ""
+}
+let provider = MoyaProvider<MultiTarget>(plugins: [authPlugin])
+```
+
 The `AccessTokenPlugin` initializer accepts a `tokenClosure` that is responsible
 for returning the token to be applied to the header of the request.
 

--- a/docs_CN/Authentication.md
+++ b/docs_CN/Authentication.md
@@ -44,6 +44,22 @@ let authPlugin = AccessTokenPlugin { _ in token }
 let provider = MoyaProvider<YourAPI>(plugins: [authPlugin])
 ```
 
+如果你使用 `MultiTarget` 且返回不同的令牌，你可以像下面这样:
+
+```swift
+let fooToken = "eyeAm.AJsoN.weBTOKen.foo"
+let barToken = "eyeAm.AJsoN.weBTOKen.bar"
+let authPlugin = AccessTokenPlugin { target in 
+    if target is FooService {
+        return fooToken    
+    } else if target is BarService {
+        return barToken
+    }
+    return ""
+}
+let provider = MoyaProvider<MultiTarget>(plugins: [authPlugin])
+```
+
 `AccessTokenPlugin` 构造器接收一个`tokenClosure`闭包来负责返回一个可以被添加到request头部的令牌 。
 
 2. 您的 `TargetType` 需要遵循`AccessTokenAuthorizable` 协议:


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
Adding support for `MultiTarget` with different token:
``` swift
let fooToken = "eyeAm.AJsoN.weBTOKen.foo"
let barToken = "eyeAm.AJsoN.weBTOKen.bar"
let authPlugin = AccessTokenPlugin { target in 
    if target is FooService {
        return fooToken    
    } else if target is BarService {
        return barToken
    }
    return ""
}
let provider = MoyaProvider<MultiTarget>(plugins: [authPlugin])
```