### PR TITLE
Fix missing documentation check

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -57,7 +57,7 @@ if (addedSwiftLibraryFiles || deletedSwiftLibraryFiles) && !modifiedCarthageXcod
     fail("Added or removed library files require the Carthage Xcode project to be updated. See the Readme")
 }
 
-let missingDocChanges = danger.git.modifiedFiles.contains { $0.contains("docs") }
+let missingDocChanges = !danger.git.modifiedFiles.contains { $0.contains("docs") }
 let docChangeRecommended = (danger.github.pullRequest.additions ?? 0) > 15
 if sourceChanges && missingDocChanges && docChangeRecommended && isNotTrivial {
     warn("Consider adding supporting documentation to this change. Documentation can be found in the `docs` directory.")


### PR DESCRIPTION
Yesterday I was also looking for the reason why `"Consider adding supporting documentation to this change. Documentation can be found in the `docs` directory."` message was appearing also when the docs was updating, the reason was actually simple:
If it contains docs, it means the documentaion was changed and is then not missing, it needs to be negated 😄 