### PR TITLE
docs: fix typos

### DIFF
--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -128,7 +128,7 @@ public extension NetworkLoggerPlugin {
         public var output: OutputType
         public var logOptions: LogOptions
 
-        /// The designated way to instanciate a Configuration.
+        /// The designated way to instantiate a Configuration.
         ///
         /// - Parameters:
         ///   - formatter: An object holding all formatter closures available for customization.
@@ -200,7 +200,7 @@ public extension NetworkLoggerPlugin.Configuration {
         public var requestData: DataFormatterType
         public var responseData: DataFormatterType
 
-        /// The designated way to instanciate a Formatter.
+        /// The designated way to instantiate a Formatter.
         ///
         /// - Parameters:
         ///   - entry: The closure formatting a message into a new log entry.

--- a/docs/MigrationGuides/migration_13_to_14.md
+++ b/docs/MigrationGuides/migration_13_to_14.md
@@ -3,7 +3,7 @@
 This project follows [Semantic Versioning](http://semver.org).
 
 ### NetworkLoggerPlugin Migration
-`NetworkLoggerPlugin` have been revamped and a `NetworkLoggerPlugin.Configuration` instance is now needed to instanciate it:
+`NetworkLoggerPlugin` have been revamped and a `NetworkLoggerPlugin.Configuration` instance is now needed to instantiate it:
 - The `verbose` and `cURL` flag are replaced by the `NetworkLoggerPlugin.Configuration.LogOptions` option set that allows finer tuning of logged elements. Use `.verbose` value to display every possible element and `formatRequestAscURL` to format request's logs as cURL.
 - The `output` closure no longer provides a `separator` and `terminator`, and items are now of type `String` instead of `Any`. To provide extra context, the target is also now provided in parameters.
 - `requestDataFormatter` and `responseDataFormatter` moved into a new `Configuration.Formatter` object and are now called `requestData` and `responseData`. Their return type have also changed from `Data` to `String`.


### PR DESCRIPTION
Hello,

This tiny PR will fix : 

- 2 typos in `Sources/Moya/Plugins/NetworkLoggerPlugin.swift`
- 1 typo in `docs/MigrationGuides/migration_13_to_14.md`

Ref to https://github.com/Moya/moya.github.io/pull/2 😄 


Best! :robot: