### PR TITLE
Install rocket only on OSX and linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")), // dev
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")), // dev
-        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0")), // dev
+        .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0")) // dev
     ] + rocketIfNeeded,
     targets: [
         .target(name: "Moya", dependencies: ["Alamofire"]),

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,16 @@
 
 import PackageDescription
 
+let rocketIfNeeded: [Package.Dependency]
+
+#if os(OSX) || os(Linux)
+rocketIfNeeded = [
+    .package(url: "https://github.com/shibapm/Rocket", .upToNextMajor(from: "1.0.0")) // dev
+]
+#else
+rocketIfNeeded = []
+#endif
+
 let package = Package(
     name: "Moya",
     platforms: [
@@ -23,8 +33,7 @@ let package = Package(
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")), // dev
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.0")), // dev
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .upToNextMajor(from: "9.0.0")), // dev
-        .package(url: "https://github.com/shibapm/Rocket", .upToNextMajor(from: "1.0.0")) // dev
-    ],
+    ] + rocketIfNeeded,
     targets: [
         .target(name: "Moya", dependencies: ["Alamofire"]),
         .target(name: "CombineMoya", dependencies: ["Moya"]),


### PR DESCRIPTION
This should fix the issue reported on https://github.com/Moya/Moya/issues/1928

Adds Rocket to the dependencies only if the platform is Linux or OSX
For the rest, given rocket still has the `// dev` flag it will be anyway commented out on releases