### PR TITLE
Add Moya-Integration-Testing to community projects

### DIFF
--- a/docs/CommunityProjects.md
+++ b/docs/CommunityProjects.md
@@ -17,6 +17,7 @@ We appreciate all the work being done by the community around Moya. If you would
 - [Moya-Marshal](https://github.com/JARMourato/Moya-Marshal) - Marshal bindings for Moya for easier JSON serialization
 - [Moya-Decodable](https://github.com/xiaoyaogaojian/Moya-Decodable) - Decodable bindings for Moya for easier JSON serialization
 - [SwiftMoyaCodeGenerator](https://github.com/narlei/SwiftMoyaCodeGenerator) - Extension for [Paw Mac App](https://paw.cloud) to generate Moya files based in rest documentation.
+- [Moya-Integration-Testing](https://github.com/wvteijlingen/moya-integration-testing) - Flexible integration testing of your Moya network requests using XCTest
 
 ## Libraries
 


### PR DESCRIPTION
I've written a small library to run integration tests on my Moya network stack, called [moya-integration-testing](https://github.com/wvteijlingen/moya-integration-testing). It allows you to:

- Fire off network requests as usual.
- Inspect the actual URLRequest going over the wire, after all your closures and plugins have ran.
- Assert that the correct urls were called and mock their responses.
- Assert that your code handles the response the way you expect it to.

This PR adds the project to the list of community projects.