### PR TITLE
Fix Combine crash while using stubs

### DIFF
--- a/Sources/CombineMoya/MoyaPublisher.swift
+++ b/Sources/CombineMoya/MoyaPublisher.swift
@@ -12,15 +12,17 @@ internal class MoyaPublisher<Output>: Publisher {
     internal typealias Failure = MoyaError
 
     private class Subscription: Combine.Subscription {
-
-        private let cancellable: Moya.Cancellable?
+        private let performCall: () -> Moya.Cancellable?
+        private var cancellable: Moya.Cancellable?
 
         init(subscriber: AnySubscriber<Output, MoyaError>, callback: @escaping (AnySubscriber<Output, MoyaError>) -> Moya.Cancellable?) {
-            self.cancellable = callback(subscriber)
+            performCall = { callback(subscriber) }
         }
 
         func request(_ demand: Subscribers.Demand) {
-            // We don't care for the demand right now
+            guard demand > .none else { return }
+
+            cancellable = performCall()
         }
 
         func cancel() {


### PR DESCRIPTION
Fixes #2071.

This PR is a minimal change to fix private project testing crashes seen when using stubs. In short, with `immediatelyStub`, the stub completes the request immediately (and synchronously) while the Combine subscription is still being set up, causing the runtime failures seen in #2071. Instead, this PR captures the `callback` invocation and calls it once a non-zero demand has been received.

This PR does not address the thread-safety issues in `MoyaPublisher.Subscription`, and may make cancellation less reliable. Additionally, I was unable to run tests due to a dependency on a binary version of RxSwift.
