### PR TITLE
#2078 Issue about path

### DIFF
--- a/Sources/Moya/URL+Moya.swift
+++ b/Sources/Moya/URL+Moya.swift
@@ -11,7 +11,7 @@ public extension URL {
         if targetPath.isEmpty {
             self = target.baseURL
         } else {
-            self = target.baseURL.appendingPathComponent(targetPath)
+            self = URL(string: target.baseURL.absoluteString + target.path)!
         }
     }
 }


### PR DESCRIPTION
Fixes #2078 

In a project I'm working on, we had a problem to navigate between the pathes,

because it is a back-end driven-ui solution and there we from the json the path we should navigate to.

So basically, this path tells the whole url itself, without separating the query params.
So we get into that problem of having %3f in the place of ?
Debugging, we noticed that changing

from             self = target.baseURL.appendingPathComponent(targetPath)
to             self = URL(string: target.baseURL.absoluteString + target.path)!

It would work very well.
So this is the solution I'm suggesting, it worked for us.