### PR TITLE
Add default network loggers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Added
+- Added `NetworkLoggerPlugin.default` and `NetworkLoggerPlugin.verbose` to conveniently access the default plugins. [#2095](https://github.com/Moya/Moya/pull/2095) by [@sunshinejr](https://github.com/sunshinejr).
+
 ### Changed
 - **Breaking Change** `AccessTokenPlugin` now uses `TargetType`, instead of `AuthorizationType`, in the closure to determine the token. Full `MultiTarget` integration added as well. [#2046](https://github.com/Moya/Moya/pull/2046) by [@Coder-ZJQ](https://github.com/Coder-ZJQ).
 - `Target.sampleData` is now automatically implemented as `Data()` with default protocol extension. [#2015](https://github.com/Moya/Moya/pull/2015) by [jdisho](https://github.com/jdisho).

--- a/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
+++ b/Sources/Moya/Plugins/NetworkLoggerPlugin.swift
@@ -235,3 +235,15 @@ public extension NetworkLoggerPlugin.Configuration {
         }()
     }
 }
+
+public extension NetworkLoggerPlugin {
+    /// Returns the default logger plugin
+    class var `default`: NetworkLoggerPlugin {
+        return NetworkLoggerPlugin(configuration: Configuration(logOptions: .default))
+    }
+
+    /// Returns the default verbose logger plugin
+    class var verbose: NetworkLoggerPlugin {
+        return NetworkLoggerPlugin(configuration: Configuration(logOptions: .verbose))
+    }
+}


### PR DESCRIPTION
This adds `.verbose` and `.default` `NetworkLoggerPlugin`s so the call site is a bit cleaner.