### PR TITLE
Delayed stubs with range

### DIFF
--- a/Sources/Moya/MoyaProvider.swift
+++ b/Sources/Moya/MoyaProvider.swift
@@ -189,6 +189,16 @@ public extension MoyaProvider {
     final class func delayedStub(_ seconds: TimeInterval) -> (Target) -> Moya.StubBehavior {
         return { _ in .delayed(seconds: seconds) }
     }
+
+    /// Return a response after a delay that is randomized based on the range parameter.
+    final class func delayedStub(_ range: ClosedRange<TimeInterval>) -> (Target) -> Moya.StubBehavior {
+        return { _ in .delayed(seconds: TimeInterval.random(in: range)) }
+    }
+
+    /// Return a response after a delay that is randomized based on the range parameter.
+    final class func delayedStub(_ range: Range<TimeInterval>) -> (Target) -> Moya.StubBehavior {
+        return { _ in .delayed(seconds: TimeInterval.random(in: range)) }
+    }
 }
 
 /// A public function responsible for converting the result of a `URLRequest` to a Result<Moya.Response, MoyaError>.

--- a/Tests/MoyaTests/MoyaProviderSpec.swift
+++ b/Tests/MoyaTests/MoyaProviderSpec.swift
@@ -178,11 +178,11 @@ final class MoyaProviderSpec: QuickSpec {
         describe("a provider with delayed stubs") {
             var provider: MoyaProvider<GitHub>!
             var plugin: TestingPlugin!
-            let delay: TimeInterval = 0.5
+            let delayRange = 0.15...0.30
 
             beforeEach {
                 plugin = TestingPlugin()
-                provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(delay), plugins: [plugin])
+                provider = MoyaProvider<GitHub>(stubClosure: MoyaProvider.delayedStub(delayRange), plugins: [plugin])
             }
 
             it("delays execution") {
@@ -196,8 +196,9 @@ final class MoyaProviderSpec: QuickSpec {
                     }
                     return
                 }
-
-                expect(endDate?.timeIntervalSince(startDate)) >= delay
+                let actualDelay = endDate?.timeIntervalSince(startDate) ?? 0.0
+                let delayRangeWithTeardown = delayRange.lowerBound...delayRange.upperBound + 0.2
+                expect(actualDelay).to(beWithin(range: delayRangeWithTeardown))
             }
 
             it("returns an error when request is canceled") {

--- a/Tests/MoyaTests/NimbleHelpers.swift
+++ b/Tests/MoyaTests/NimbleHelpers.swift
@@ -16,3 +16,23 @@ public func containOne(of substrings: [String]) -> Predicate<String> {
         return .fail
     }
 }
+
+public func beWithin<T: Comparable>(range: Range<T>) -> Predicate<T> {
+    let errorMessage = "be within range <\(stringify(range))>"
+    return Predicate.simple(errorMessage) { actualExpression in
+        if let actual = try actualExpression.evaluate() {
+            return PredicateStatus(bool: range.contains(actual))
+        }
+        return .fail
+    }
+}
+
+public func beWithin<T: Comparable>(range: ClosedRange<T>) -> Predicate<T> {
+    let errorMessage = "be within range <\(stringify(range))>"
+    return Predicate.simple(errorMessage) { actualExpression in
+        if let actual = try actualExpression.evaluate() {
+            return PredicateStatus(bool: range.contains(actual))
+        }
+        return .fail
+    }
+}


### PR DESCRIPTION
So this is something I've been using for a while: delayed stubs with specified range instead of always the same (+ teardown, of course) number of seconds. My use-case for this is when I use stubs for the app, instead of real-backend responses, and I just want to make sure I imitate the real world response time a little bit better.

I'd love to see if anyone else sees that as a viable option to add to the core itself, so pinging @Moya/contributors!