### PR TITLE
Improved Endpoint comparison

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,10 +4,13 @@
 - Added `NetworkLoggerPlugin.default` and `NetworkLoggerPlugin.verbose` to conveniently access the default plugins. [#2095](https://github.com/Moya/Moya/pull/2095) by [@sunshinejr](https://github.com/sunshinejr).
 
 ### Changed
+- **Breaking Change** Changed `Hashable` && `Equatable` implementation of `Endpoint` since it was returning false positives. [#2101](https://github.com/Moya/Moya/pull/2101) by [@sunshinejr](https://github.com/sunshinejr).
+- **Breaking Change** `MultiPartFormData` is now `Hashable`. [#2101](https://github.com/Moya/Moya/pull/2101) by [@sunshinejr](https://github.com/sunshinejr).
 - **Breaking Change** `AccessTokenPlugin` now uses `TargetType`, instead of `AuthorizationType`, in the closure to determine the token. Full `MultiTarget` integration added as well. [#2046](https://github.com/Moya/Moya/pull/2046) by [@Coder-ZJQ](https://github.com/Coder-ZJQ).
 - `Target.sampleData` is now automatically implemented as `Data()` with default protocol extension. [#2015](https://github.com/Moya/Moya/pull/2015) by [jdisho](https://github.com/jdisho).
 
 ### Fixed
+- Fixed an issue where when using `trackInflights` option in certain circumstances would return a cached response for an endpoint that's not really the same. [#2101](https://github.com/Moya/Moya/pull/2101) by [@sunshinejr](https://github.com/sunshinejr).
 - Fixed a crash where Combine Publisher would crash when using stubs.  [#2072](https://github.com/Moya/Moya/pull/2072) by [jshier](https://github.com/jshier).
 
 # [15.0.0-alpha.1] - 2020-07-07

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -130,11 +130,23 @@ extension Endpoint: Equatable, Hashable {
     /// Note: If both Endpoints fail to produce a URLRequest the comparison will
     /// fall back to comparing each Endpoint's hashValue.
     public static func == (lhs: Endpoint, rhs: Endpoint) -> Bool {
+        let areEndpointsEqualInAdditionalProperties: Bool = {
+            switch (lhs.task, rhs.task) {
+            case (let .uploadFile(file1), let .uploadFile(file2)):
+                return file1 == file2
+            case (let .uploadMultipart(multipartData1), let .uploadMultipart(multipartData2)):
+                return multipartData1 == multipartData2
+            case (let .uploadCompositeMultipart(multipartData1, _), let .uploadCompositeMultipart(multipartData2, _)):
+                return multipartData1 == multipartData2
+            default:
+                return true
+            }
+        }()
         let lhsRequest = try? lhs.urlRequest()
         let rhsRequest = try? rhs.urlRequest()
         if lhsRequest != nil, rhsRequest == nil { return false }
         if lhsRequest == nil, rhsRequest != nil { return false }
-        if lhsRequest == nil, rhsRequest == nil { return lhs.hashValue == rhs.hashValue }
-        return (lhsRequest == rhsRequest)
+        if lhsRequest == nil, rhsRequest == nil { return lhs.hashValue == rhs.hashValue && areEndpointsEqualInAdditionalProperties }
+        return lhsRequest == rhsRequest && areEndpointsEqualInAdditionalProperties
     }
 }

--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -2,10 +2,10 @@ import Foundation
 import Alamofire
 
 /// Represents "multipart/form-data" for an upload.
-public struct MultipartFormData {
+public struct MultipartFormData: Equatable {
 
     /// Method to provide the form data.
-    public enum FormDataProvider {
+    public enum FormDataProvider: Equatable {
         case data(Foundation.Data)
         case file(URL)
         case stream(InputStream, UInt64)

--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -2,10 +2,10 @@ import Foundation
 import Alamofire
 
 /// Represents "multipart/form-data" for an upload.
-public struct MultipartFormData: Equatable {
+public struct MultipartFormData: Hashable {
 
     /// Method to provide the form data.
-    public enum FormDataProvider: Equatable {
+    public enum FormDataProvider: Hashable {
         case data(Foundation.Data)
         case file(URL)
         case stream(InputStream, UInt64)

--- a/Tests/MoyaTests/EndpointSpec.swift
+++ b/Tests/MoyaTests/EndpointSpec.swift
@@ -365,6 +365,244 @@ final class EndpointSpec: QuickSpec {
             }
             #endif
         }
+
+        describe("given endpoint comparison") {
+            context("when task is .uploadMultipart") {
+                it("should correctly acknowledge as equal for the same url, headers and form data") {
+                    endpoint = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")]))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different form data") {
+                    endpoint = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test")]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .uploadCompositeMultipart") {
+                it("should correctly acknowledge as equal for the same url, headers and form data") {
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different form data") {
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different url parameters") {
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test2"]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test3"]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .uploadFile") {
+                it("should correctly acknowledge as equal for the same url, headers and file") {
+                    endpoint = endpoint.replacing(task: .uploadFile(URL(string: "https://google.com")!))
+                    let endpointToCompare = endpoint.replacing(task: .uploadFile(URL(string: "https://google.com")!))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different file") {
+                    endpoint = endpoint.replacing(task: .uploadFile(URL(string: "https://google.com")!))
+                    let endpointToCompare = endpoint.replacing(task: .uploadFile(URL(string: "https://google.com?q=test")!))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .downloadDestination") {
+                it("should correctly acknowledge as equal for the same url, headers and download destination") {
+                    endpoint = endpoint.replacing(task: .downloadDestination { temporaryUrl, _ in
+                        return (destinationURL: temporaryUrl, options: [])
+                    })
+                    let endpointToCompare = endpoint.replacing(task: .downloadDestination { temporaryUrl, _ in
+                        return (destinationURL: temporaryUrl, options: [])
+                    })
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as equal for the same url, headers and different download destination") {
+                    endpoint = endpoint.replacing(task: .downloadDestination { temporaryUrl, _ in
+                        return (destinationURL: temporaryUrl, options: [])
+                    })
+                    let endpointToCompare = endpoint.replacing(task: .downloadDestination { _, _ in
+                        return (destinationURL: URL(string: "https://google.com")!, options: [])
+                    })
+
+                    expect(endpoint) == endpointToCompare
+                }
+            }
+
+            context("when task is .downloadParameters") {
+                it("should correctly acknowledge as equal for the same url, headers and download destination") {
+                    endpoint = endpoint.replacing(task: .downloadParameters(parameters: ["test": "test2"], encoding: JSONEncoding.default, destination: { temporaryUrl, response in
+                        return (destinationURL: temporaryUrl, options: [])
+                    }))
+                    let endpointToCompare = endpoint.replacing(task: .downloadParameters(parameters: ["test": "test2"], encoding: JSONEncoding.default, destination: { temporaryUrl, response in
+                        return (destinationURL: temporaryUrl, options: [])
+                    }))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, download destionation and different parameters") {
+                    endpoint = endpoint.replacing(task: .downloadParameters(parameters: ["test": "test2"], encoding: JSONEncoding.default, destination: { temporaryUrl, response in
+                        return (destinationURL: temporaryUrl, options: [])
+                    }))
+                    let endpointToCompare = endpoint.replacing(task: .downloadParameters(parameters: ["test": "test3"], encoding: JSONEncoding.default, destination: { temporaryUrl, response in
+                        return (destinationURL: temporaryUrl, options: [])
+                    }))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .requestCompositeData") {
+                it("should correctly acknowledge as equal for the same url, headers, body and url parameters") {
+                    endpoint = endpoint.replacing(task: .requestCompositeData(bodyData: "test".data(using: .utf8)!, urlParameters: ["test": "test1"]))
+                    let endpointToCompare = endpoint.replacing(task: .requestCompositeData(bodyData: "test".data(using: .utf8)!, urlParameters: ["test": "test1"]))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, body and different url parameters") {
+                    endpoint = endpoint.replacing(task: .requestCompositeData(bodyData: "test".data(using: .utf8)!, urlParameters: ["test": "test1"]))
+                    let endpointToCompare = endpoint.replacing(task: .requestCompositeData(bodyData: "test".data(using: .utf8)!, urlParameters: ["test": "test2"]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, url parameters and different body") {
+                    endpoint = endpoint.replacing(task: .requestCompositeData(bodyData: "test".data(using: .utf8)!, urlParameters: ["test": "test1"]))
+                    let endpointToCompare = endpoint.replacing(task: .requestCompositeData(bodyData: "test2".data(using: .utf8)!, urlParameters: ["test": "test1"]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .requestPlain") {
+                it("should correctly acknowledge as equal for the same url, headers and body") {
+                    endpoint = endpoint.replacing(task: .requestPlain)
+                    let endpointToCompare = endpoint.replacing(task: .requestPlain)
+
+                    expect(endpoint) == endpointToCompare
+                }
+            }
+
+            context("when task is .requestData") {
+                it("should correctly acknowledge as equal for the same url, headers and data") {
+                    endpoint = endpoint.replacing(task: .requestData("test".data(using: .utf8)!))
+                    let endpointToCompare = endpoint.replacing(task: .requestData("test".data(using: .utf8)!))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different data") {
+                    endpoint = endpoint.replacing(task: .requestData("test".data(using: .utf8)!))
+                    let endpointToCompare = endpoint.replacing(task: .requestData("test1".data(using: .utf8)!))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .requestJSONEncodable") {
+                it("should correctly acknowledge as equal for the same url, headers and encodable") {
+                    let date = Date()
+                    endpoint = endpoint.replacing(task: .requestJSONEncodable(Issue(title: "T", createdAt: date, rating: 0)))
+                    let endpointToCompare = endpoint.replacing(task: .requestJSONEncodable(Issue(title: "T", createdAt: date, rating: 0)))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different encodable") {
+                    let date = Date()
+                    endpoint = endpoint.replacing(task: .requestJSONEncodable(Issue(title: "T", createdAt: date, rating: 0)))
+                    let endpointToCompare = endpoint.replacing(task: .requestJSONEncodable(Issue(title: "Ta", createdAt: date, rating: 0)))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .requestParameters") {
+                it("should correctly acknowledge as equal for the same url, headers and parameters") {
+                    endpoint = endpoint.replacing(task: .requestParameters(parameters: ["test": "test1"], encoding: URLEncoding.queryString))
+                    let endpointToCompare = endpoint.replacing(task: .requestParameters(parameters: ["test": "test1"], encoding: URLEncoding.queryString))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different parameters") {
+                    endpoint = endpoint.replacing(task: .requestParameters(parameters: ["test": "test1"], encoding: URLEncoding.queryString))
+                    let endpointToCompare = endpoint.replacing(task: .requestParameters(parameters: ["test": "test2"], encoding: URLEncoding.queryString))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .requestCompositeParameters") {
+                it("should correctly acknowledge as equal for the same url, headers, body and url parameters") {
+                    endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: ["test": "test1"], bodyEncoding: JSONEncoding.default, urlParameters: ["url_test": "test1"]))
+                    let endpointToCompare = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: ["test": "test1"], bodyEncoding: JSONEncoding.default, urlParameters: ["url_test": "test1"]))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, body parameters and different url parameters") {
+                    endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: ["test": "test1"], bodyEncoding: JSONEncoding.default, urlParameters: ["url_test": "test1"]))
+                    let endpointToCompare = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: ["test": "test1"], bodyEncoding: JSONEncoding.default, urlParameters: ["url_test": "test2"]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, url parameters and different body parameters") {
+                    endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: ["test": "test1"], bodyEncoding: JSONEncoding.default, urlParameters: ["url_test": "test1"]))
+                    let endpointToCompare = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: ["test": "test2"], bodyEncoding: JSONEncoding.default, urlParameters: ["url_test": "test1"]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .requestCustomJSONEncodable") {
+                it("should correctly acknowledge as equal for the same url, headers, encodable and encoder") {
+                    let date = Date()
+                    endpoint = endpoint.replacing(task: .requestCustomJSONEncodable(Issue(title: "T", createdAt: date, rating: 0), encoder: JSONEncoder()))
+                    let endpointToCompare = endpoint.replacing(task: .requestCustomJSONEncodable(Issue(title: "T", createdAt: date, rating: 0), encoder: JSONEncoder()))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, encoder and different encodable") {
+                    let date = Date()
+                    endpoint = endpoint.replacing(task: .requestCustomJSONEncodable(Issue(title: "T", createdAt: date, rating: 0), encoder: JSONEncoder()))
+                    let endpointToCompare = endpoint.replacing(task: .requestCustomJSONEncodable(Issue(title: "Ta", createdAt: date, rating: 0), encoder: JSONEncoder()))
+
+                    expect(endpoint) != endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers, encodable and different encoder") {
+                    let date = Date()
+                    endpoint = endpoint.replacing(task: .requestCustomJSONEncodable(Issue(title: "T", createdAt: date, rating: 0), encoder: JSONEncoder()))
+                    let snakeEncoder = JSONEncoder()
+                    snakeEncoder.keyEncodingStrategy = .convertToSnakeCase
+                    let endpointToCompare = endpoint.replacing(task: .requestCustomJSONEncodable(Issue(title: "T", createdAt: date, rating: 0), encoder: snakeEncoder))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2100.

TL;DR
- Added unit tests for comparing endpoints
- Fixed comparing endpoints where the task was `.uploadFile`, `.uploadMultipart` and `.uploadCompositeMultipart`
- This also fixes `trackInflights` option since it certain circumstances it would return a cached response for an endpoint that's not really the same (e.g. see #2097)
- Needed to make `MultipartFormData` `Hashable` in the process