### PR TITLE
Race condition fix for interceptor setup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Next
 
+### Fixed
+- Fixed race condition that could prevent plugin's `willSend(_:target:)` from being fired.
+
 # [14.0.0] - 2020-02-15
 
 ### Changed

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -184,7 +184,7 @@ private extension MoyaProvider {
         formData.applyMoyaMultipartFormData(multipartBody)
 
         let interceptor = self.interceptor(target: target)
-        let request: UploadRequest = session.rootQueue.sync {
+        let request: UploadRequest = session.requestQueue.sync {
             let request = session.upload(multipartFormData: formData, with: request, interceptor: interceptor)
             setup(interceptor: interceptor, with: target, and: request)
 
@@ -198,7 +198,7 @@ private extension MoyaProvider {
 
     func sendUploadFile(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, file: URL, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let uploadRequest: UploadRequest = session.rootQueue.sync {
+        let uploadRequest: UploadRequest = session.requestQueue.sync {
             let downloadRequest = session.upload(file, with: request, interceptor: interceptor)
             setup(interceptor: interceptor, with: target, and: downloadRequest)
 
@@ -212,7 +212,7 @@ private extension MoyaProvider {
 
     func sendDownloadRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let downloadRequest: DownloadRequest = session.rootQueue.sync {
+        let downloadRequest: DownloadRequest = session.requestQueue.sync {
             let downloadRequest = session.download(request, interceptor: interceptor, to: destination)
             setup(interceptor: interceptor, with: target, and: downloadRequest)
 
@@ -226,7 +226,7 @@ private extension MoyaProvider {
 
     func sendRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let initialRequest: DataRequest = session.rootQueue.sync {
+        let initialRequest: DataRequest = session.requestQueue.sync {
             let initialRequest = session.request(request, interceptor: interceptor)
             setup(interceptor: interceptor, with: target, and: initialRequest)
 

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -184,8 +184,12 @@ private extension MoyaProvider {
         formData.applyMoyaMultipartFormData(multipartBody)
 
         let interceptor = self.interceptor(target: target)
-        let request = session.upload(multipartFormData: formData, with: request, interceptor: interceptor)
-        setup(interceptor: interceptor, with: target, and: request)
+        let request: UploadRequest = session.rootQueue.sync {
+            let request = session.upload(multipartFormData: formData, with: request, interceptor: interceptor)
+            setup(interceptor: interceptor, with: target, and: request)
+
+            return request
+        }
 
         let validationCodes = target.validationType.statusCodes
         let validatedRequest = validationCodes.isEmpty ? request : request.validate(statusCode: validationCodes)
@@ -194,8 +198,12 @@ private extension MoyaProvider {
 
     func sendUploadFile(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, file: URL, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let uploadRequest = session.upload(file, with: request, interceptor: interceptor)
-        setup(interceptor: interceptor, with: target, and: uploadRequest)
+        let uploadRequest: UploadRequest = session.rootQueue.sync {
+            let downloadRequest = session.upload(file, with: request, interceptor: interceptor)
+            setup(interceptor: interceptor, with: target, and: downloadRequest)
+
+            return downloadRequest
+        }
 
         let validationCodes = target.validationType.statusCodes
         let alamoRequest = validationCodes.isEmpty ? uploadRequest : uploadRequest.validate(statusCode: validationCodes)
@@ -204,8 +212,12 @@ private extension MoyaProvider {
 
     func sendDownloadRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, destination: @escaping DownloadDestination, progress: ProgressBlock? = nil, completion: @escaping Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let downloadRequest = session.download(request, interceptor: interceptor, to: destination)
-        setup(interceptor: interceptor, with: target, and: downloadRequest)
+        let downloadRequest: DownloadRequest = session.rootQueue.sync {
+            let downloadRequest = session.download(request, interceptor: interceptor, to: destination)
+            setup(interceptor: interceptor, with: target, and: downloadRequest)
+
+            return downloadRequest
+        }
 
         let validationCodes = target.validationType.statusCodes
         let alamoRequest = validationCodes.isEmpty ? downloadRequest : downloadRequest.validate(statusCode: validationCodes)
@@ -214,8 +226,12 @@ private extension MoyaProvider {
 
     func sendRequest(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, progress: Moya.ProgressBlock?, completion: @escaping Moya.Completion) -> CancellableToken {
         let interceptor = self.interceptor(target: target)
-        let initialRequest = session.request(request, interceptor: interceptor)
-        setup(interceptor: interceptor, with: target, and: initialRequest)
+        let initialRequest: DataRequest = session.rootQueue.sync {
+            let initialRequest = session.request(request, interceptor: interceptor)
+            setup(interceptor: interceptor, with: target, and: initialRequest)
+
+            return initialRequest
+        }
 
         let validationCodes = target.validationType.statusCodes
         let alamoRequest = validationCodes.isEmpty ? initialRequest : initialRequest.validate(statusCode: validationCodes)


### PR DESCRIPTION
Although rare it's possible that `interceptor` setup will happen after request `adapt` is called and so `willSend` call will be missed. It's easy to reproduce by blocking execution thread with `sleep` call:
<img width="916" alt="Screen Shot 2020-12-07 at 16 12 45" src="https://user-images.githubusercontent.com/10807812/101356030-87446600-38a8-11eb-9211-8219769c8586.png">

<img width="937" alt="Screen Shot 2020-12-07 at 16 13 29" src="https://user-images.githubusercontent.com/10807812/101356114-a93de880-38a8-11eb-9552-84ccfe86d596.png">

<img width="715" alt="Screen Shot 2020-12-07 at 16 15 10" src="https://user-images.githubusercontent.com/10807812/101356163-b955c800-38a8-11eb-93fc-347997b5b02c.png">

After fix:
<img width="942" alt="Screen Shot 2020-12-07 at 16 18 43" src="https://user-images.githubusercontent.com/10807812/101356180-bfe43f80-38a8-11eb-8bee-2dfd079e6da2.png">

