### PR TITLE
moved inflightsRequest getter inside thread lock to resolve data race…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,8 @@ jobs:
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - restore_cache:
           keys:
-            - v{{ .Environment.CACHE_VERSION }}-dep-{{ checksum "Cartfile.resolved" }}
-      - restore_cache:
-          keys:
-            - v{{ .Environment.CACHE_VERSION }}-dep-{{ checksum "Dangerfile.swift" }}
+            - v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-dep-{{ checksum "Cartfile.resolved" }}
+            - v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-dep-{{ checksum "Dangerfile.swift" }}
       - run:
           name: Set Ruby Version
           command: echo "ruby-2.4" > ~/.ruby-version
@@ -63,7 +61,7 @@ jobs:
           name: Bootstrap Carthage
           command: scripts/bootstrap-if-needed.sh
       - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-dep-{{ checksum "Cartfile.resolved" }}
+          key: v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-dep-{{ checksum "Cartfile.resolved" }}
           paths:
             - vendor/bundle
             - Carthage
@@ -89,7 +87,7 @@ jobs:
           name: Run Danger
           command: brew install danger/tap/danger-swift && danger-swift ci
       - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-dep-{{ checksum "Dangerfile.swift" }}
+          key: v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-dep-{{ checksum "Dangerfile.swift" }}
           paths:
             - ~/.danger-swift
             - /usr/local/Homebrew

--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,9 @@ _Note: If you are using Swift 4.2 in your project, but you are using Xcode 10.2,
 
 ### Swift Package Manager
 
-To integrate using Apple's Swift package manager, add the following as a dependency to your `Package.swift`:
+_Note: Instructions below are for using **SwiftPM** without the Xcode UI. It's the easiest to go to your Project Settings -> Swift Packages and add Moya from there._
+
+To integrate using Apple's Swift package manager, without Xcode integration, add the following as a dependency to your `Package.swift`:
 
 ```swift
 .package(url: "https://github.com/Moya/Moya.git", .upToNextMajor(from: "14.0.0"))

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -64,9 +64,8 @@ public extension MoyaProvider {
 
             let networkCompletion: Moya.Completion = { result in
               if self.trackInflights {
-                self.inflightRequests[endpoint]?.forEach { $0(result) }
-
                 self.lock.lock()
+                self.inflightRequests[endpoint]?.forEach { $0(result) }
                 self.inflightRequests.removeValue(forKey: endpoint)
                 self.lock.unlock()
               } else {

--- a/docs/Examples/README.md
+++ b/docs/Examples/README.md
@@ -23,3 +23,4 @@
 
 * [Creating a custom plugin](CustomPlugin.md)
 * [Creating an authorization plugin](AuthPlugin.md)
+* [Cache Policy plugin](CachePolicyPlugin.md)


### PR DESCRIPTION
Fixes #2085.

The `trackInflights` getter caused a data race issue when performing the same API request multiple times in a row. When removing or adding into the `trackInflights` dictionary, a `NSRecursiveLock` is being used. But not when getting the dictionary and looping through, which can result in a data race bad access crash.

To resolve this, the forEach loop should also be in the `NSRecursiveLock` to ensure no mutations are happening when getting the `trackInflights` for the specific endpoint.

<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
