### PR TITLE
Update circle ci xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 defaults: &defaults
   macos:
-    xcode: 11.0.0
+    xcode: 11.4.0
   parallelism: 1
   shell: /bin/bash --login    
   environment:


### PR DESCRIPTION
> /Users/distiller/Moya/Moya/SwiftLint: error: package at '/Users/distiller/Moya/Moya/SwiftLint' is using Swift tools version 5.2.0 but the installed version is 5.1.0

There is a problem during the installation of swiftlint in circle ci.