### PR TITLE
Prepare Moya 15

### DIFF
--- a/Moya.podspec
+++ b/Moya.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Moya"
-  s.version      = "15.0.0-alpha.1"
+  s.version      = "15.0.0"
   s.summary      = "Network abstraction layer written in Swift"
   s.description  = <<-EOS
   Moya abstracts network commands using Swift Generics to provide developers
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '3.0'
   s.source       = { :git => "https://github.com/Moya/Moya.git", :tag => s.version }
   s.default_subspec = "Core"
-  s.swift_version = '5.2'
+  s.swift_version = '5.3'
   s.cocoapods_version = '>= 1.4.0'
 
   s.subspec "Core" do |ss|


### PR DESCRIPTION
This sets up the last bits to release Moya 15; both Carthage and SwiftPM base the library version on git tags; this will be created as part of the release when this has been merged into `development`, and `development` subsequently gets merged into the main branch.