### PR TITLE
Remove outdated ReactiveSwift fork note

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,8 +108,6 @@ let package = Package(
 )
 ```
 
-Note: If you are using **ReactiveMoya**, we are using [our own fork of ReactiveSwift](https://github.com/Moya/ReactiveSwift). This fork adds 2 commits to remove testing dependencies on releases (starting 6.1.0). This is to prevent Xcode Previews on Xcode 11/11.1 to build testing dependencies (FB7316430). If you don't want to use our fork, you can just add another dependency to your SPM package list: `git@github.com:ReactiveCocoa/ReactiveSwift.git` and it should fetch the original repository.
-
 Combine note: if you're using **CombineMoya**, make sure that you use Xcode 11.5.0 
 or later. With earlier versions of Xcode you will have to manually add Combine as
 a weakly linked framework to your application target.


### PR DESCRIPTION
Does what it says on the tin! This workaround is no longer needed and was removed in #2197