### PR TITLE
[Danger] Removing danger prose from Danger step

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,5 +1,4 @@
 import Danger
-import DangerSwiftProse // package: https://github.com/f-meloni/danger-swift-prose.git
 import DangerXCodeSummary // package: https://github.com/f-meloni/danger-swift-xcodesummary.git
 import Foundation
 
@@ -61,23 +60,6 @@ let missingDocChanges = !danger.git.modifiedFiles.contains { $0.contains("docs")
 let docChangeRecommended = (danger.github.pullRequest.additions ?? 0) > 15
 if sourceChanges && missingDocChanges && docChangeRecommended && isNotTrivial {
     warn("Consider adding supporting documentation to this change. Documentation can be found in the `docs` directory.")
-}
-
-// Run danger-prose to lint Chinese docs
-let addedAndModifiedCnDocsMarkdown = allSourceFiles.filter { $0.fileType == .markdown && $0.contains("docs_CN") }
-if #available(OSX 10.12, *),
-    !addedAndModifiedCnDocsMarkdown.isEmpty {
-    Proselint.performSpellCheck(files: addedAndModifiedCnDocsMarkdown, excludedRules: ["misc.scare_quotes", "typography.symbols"])
-}
-
-// Run danger-prose to lint and check spelling English docs
-let addedAndModifiedEnDocsMarkdown = allSourceFiles.filter { $0.fileType == .markdown && $0.contains("docs/") }
-if #available(OSX 10.12, *),
-    !addedAndModifiedEnDocsMarkdown.isEmpty {
-    Proselint.performSpellCheck(files: addedAndModifiedEnDocsMarkdown)
-
-    let ignoredWords = ["Auth", "auth", "Moya", "enum", "enums", "OAuth", "Artsy's", "Heimdallr.swift", "SwiftyJSONMapper", "ObjectMapper", "Argo", "ModelMapper", "ReactiveSwift", "RxSwift", "multipart", "JSONEncoder", "Alamofire", "CocoaPods", "URLSession", "plugin", "plugins", "stubClosure", "requestClosure", "endpointClosure", "Unsplash", "ReactorKit", "Dribbble", "EVReflection", "Unbox"]
-    Mdspell.performSpellCheck(files: addedAndModifiedEnDocsMarkdown, ignoredWords: ignoredWords, language: "en-us")
 }
 
 // Warning message for not updated package manifest(s)


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
This is failing in the CI for a while now(it can be re-enabled in the future), so this PR is a test to disable danger prose to check if that is the only issue with the CI. Note that project looks unmaintained https://github.com/f-meloni/danger-swift-prose.