### PR TITLE
Add RedirectHandler to TargetType

### DIFF
--- a/Sources/Moya/Moya+Alamofire.swift
+++ b/Sources/Moya/Moya+Alamofire.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Alamofire
 
+public typealias RedirectHandler = Alamofire.RedirectHandler
 public typealias Session = Alamofire.Session
 internal typealias Request = Alamofire.Request
 internal typealias DownloadRequest = Alamofire.DownloadRequest

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -228,9 +228,6 @@ private extension MoyaProvider {
 
         let validationCodes = target.validationType.statusCodes
         let alamoRequest = validationCodes.isEmpty ? initialRequest : initialRequest.validate(statusCode: validationCodes)
-        if let redirectHandler = target.redirectHandler {
-            alamoRequest.redirect(using: redirectHandler)
-        }
         return sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
     }
 
@@ -249,6 +246,11 @@ private extension MoyaProvider {
             } else {
                 sendProgress()
             }
+        }
+        
+        // Prepare additional Alamofire request settings
+        if let redirectHandler = target.redirectHandler {
+            alamoRequest.redirect(using: redirectHandler)
         }
 
         // Perform the actual request

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -228,6 +228,9 @@ private extension MoyaProvider {
 
         let validationCodes = target.validationType.statusCodes
         let alamoRequest = validationCodes.isEmpty ? initialRequest : initialRequest.validate(statusCode: validationCodes)
+        if let redirectHandler = target.redirectHandler {
+            alamoRequest.redirect(using: redirectHandler)
+        }
         return sendAlamofireRequest(alamoRequest, target: target, callbackQueue: callbackQueue, progress: progress, completion: completion)
     }
 

--- a/Sources/Moya/TargetType.swift
+++ b/Sources/Moya/TargetType.swift
@@ -23,6 +23,8 @@ public protocol TargetType {
 
     /// The headers to be used in the request.
     var headers: [String: String]? { get }
+
+    var redirectHandler: RedirectHandler? { get }
 }
 
 public extension TargetType {
@@ -32,4 +34,6 @@ public extension TargetType {
 
     /// Provides stub data for use in testing. Default is `Data()`.
     var sampleData: Data { Data() }
+
+    var redirectHandler: RedirectHandler? { nil }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->

Alamofire supports setting  a `RedirectHandler` per `Session` and per `Request`

When using Moya, I can already inject a custom `Session` to setup a global `RedirectHandler` for all requests. But to implement a `RedirectHandler` per request, it's unnecessarily complicated because Moya hides Alamofire's Request from in public API, there is no way Moya's users can customise Alamofire's Request easily.

I have tested by adding an optional RedirectHandler to TargetType protocol so that Moya's users can customise a redirect handler for each Target. By default, the value is nil, which means Alamofire will use the default handling mechanism for redirection.

I'm aware of [this discussion](https://github.com/Moya/Moya/issues/1774) but I don't agree with it. We basically hide an useful feature of Alamofire from Moya's users.

If this approach is ok, I'll add more tests to this PR to make it mergeable.