### PR TITLE
Package.swift: mark entire testTarget region as dev for rocket

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+### Fixed
+
+- Un-break Package.swift parsing when releasing through Rocket. [#2275](https://github.com/Moya/Moya/pull/2274) by [@AndrewSB](https://github.com/AndrewSB)
+
 # [15.0.1] - 2022-08-11
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -64,18 +64,18 @@ let package = Package(
                 .product(name: "RxSwift", package: "RxSwift")
             ]
         ),
-        .testTarget(
+        .testTarget( // dev
             name: "MoyaTests",  // dev
-            dependencies: [
-                "Moya",
-                "CombineMoya",
-                "ReactiveMoya",
-                "RxMoya",
-                .product(name: "Quick", package: "Quick"),
-                .product(name: "Nimble", package: "Nimble"),
-                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs")
-            ]
-        )
+            dependencies: [ // dev
+                "Moya", // dev
+                "CombineMoya", // dev
+                "ReactiveMoya", // dev
+                "RxMoya", // dev
+                .product(name: "Quick", package: "Quick"), // dev
+                .product(name: "Nimble", package: "Nimble"), // dev
+                .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs") // dev
+            ] // dev
+        ) // dev
     ]
 )
 


### PR DESCRIPTION
As @lukewakeford pointed out in https://github.com/Moya/Moya/commit/3206a0f4bd770befa6dcaa9463e9b308f749ca76#r81024749
our rocket integration for hiding dev dependencies
(https://github.com/shibapm/Rocket#hide-dev-dependencies) was
producing a malformed Package.swift for releases. this should fix the
issue by instructing Rocket to comment out the entire testTarget,
instead of just the `name:` line

<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
