### PR TITLE
fixed 3 tests not imported needing types

### DIFF
--- a/Tests/MoyaTests/Observable+MoyaSpec.swift
+++ b/Tests/MoyaTests/Observable+MoyaSpec.swift
@@ -3,6 +3,7 @@ import Moya
 import RxSwift
 import Nimble
 import Foundation
+import CoreGraphics
 
 final class ObservableMoyaSpec: QuickSpec {
     override func spec() {

--- a/Tests/MoyaTests/SignalProducer+MoyaSpec.swift
+++ b/Tests/MoyaTests/SignalProducer+MoyaSpec.swift
@@ -3,6 +3,7 @@ import Moya
 import ReactiveSwift
 import Nimble
 import Foundation
+import CoreGraphics
 
 private func signalSendingData(_ data: Data, statusCode: Int = 200) -> SignalProducer<Response, MoyaError> {
     SignalProducer(value: Response(statusCode: statusCode, data: data as Data, response: nil))

--- a/Tests/MoyaTests/Single+MoyaSpec.swift
+++ b/Tests/MoyaTests/Single+MoyaSpec.swift
@@ -3,6 +3,7 @@ import Moya
 import RxSwift
 import Nimble
 import Foundation
+import CoreGraphics
 
 final class SingleMoyaSpec: QuickSpec {
     override func spec() {


### PR DESCRIPTION
<!--
Thank you for contributing to Moya! 🙌


Choosing a base branch:

  master: bug fixes, non breaking API changes, documentation fixes
  development: breaking changes, features for the next version


If your pull request fixes an issue, please reference the issue.
For example, when your pull request fixes issue 10, add the following line:

Fixes #10

This will make sure that when the pull request is merged, the issue will automatically be closed.

-->
Steps for error reproduction: clone the repo, open Package.swift file, launch tests (by command+u) and after you'll have an error - "Cannot find type 'CGSize' in scope" in "SignalProducer+MoyaSpec", "Single+MoyaSpec" and "Observable+MoyaSpec" files