### PR TITLE
SPM Package iOS Target iOS 10 -> iOS 11 Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     name: "Moya",
     platforms: [
         .macOS(.v10_12),
-        .iOS(.v10),
+        .iOS(.v11),
         .tvOS(.v10),
         .watchOS(.v3)
     ],


### PR DESCRIPTION
It is an environment that uses Moya using SPM.
When I build a project, I can't build because the minimum target for iOS is iOS 10.

[xcode-14-release-notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes)
The XCode 14 release notes show that the minimum build target is iOS 11.

I changed the iOS platforms version of the Package.swift file to iOS 11.