### PR TITLE
boundary can now be passed to MultipartFormData

### DIFF
--- a/Examples/_shared/GiphyAPI.swift
+++ b/Examples/_shared/GiphyAPI.swift
@@ -24,8 +24,9 @@ extension Giphy: TargetType {
     public var task: Task {
         switch self {
         case let .upload(data):
-            let multipartFormData = [MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]
-            return .uploadCompositeMultipart(multipartFormData, urlParameters: ["api_key": "dc6zaTOxFJmzC", "username": "Moya"])
+            let multipartFormBodyParts = [MultipartFormBodyPart(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")]
+            let multipartFormData = MultipartFormData(fileManager: .default, boundary: nil, parts: multipartFormBodyParts)
+            return .uploadCompositeMultipartFormData(multipartFormData, urlParameters: ["api_key": "dc6zaTOxFJmzC", "username": "Moya"])
         }
     }
     public var sampleData: Data {

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -85,7 +85,7 @@ public extension Endpoint {
         request.allHTTPHeaderFields = httpHeaderFields
 
         switch task {
-        case .requestPlain, .uploadFile, .uploadMultipart, .downloadDestination:
+        case .requestPlain, .uploadFile, .uploadMultipart, .uploadMultipartFormData, .downloadDestination:
             return request
         case .requestData(let data):
             request.httpBody = data
@@ -96,7 +96,7 @@ public extension Endpoint {
             return try request.encoded(encodable: encodable, encoder: encoder)
         case let .requestParameters(parameters, parameterEncoding):
             return try request.encoded(parameters: parameters, parameterEncoding: parameterEncoding)
-        case let .uploadCompositeMultipart(_, urlParameters):
+        case let .uploadCompositeMultipart(_, urlParameters), let .uploadCompositeMultipartFormData(_, urlParameters):
             let parameterEncoding = URLEncoding(destination: .queryString)
             return try request.encoded(parameters: urlParameters, parameterEncoding: parameterEncoding)
         case let .downloadParameters(parameters, parameterEncoding, _):

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -125,6 +125,8 @@ extension Endpoint: Equatable, Hashable {
             hasher.combine(file)
         case let .uploadMultipart(multipartData), let .uploadCompositeMultipart(multipartData, _):
             hasher.combine(multipartData)
+        case let .uploadMultipartFormData(multipartFormData), let .uploadCompositeMultipartFormData(multipartFormData, _):
+            hasher.combine(multipartFormData)
         default:
             break
         }
@@ -146,6 +148,9 @@ extension Endpoint: Equatable, Hashable {
             case (let .uploadMultipart(multipartData1), let .uploadMultipart(multipartData2)),
                  (let .uploadCompositeMultipart(multipartData1, _), let .uploadCompositeMultipart(multipartData2, _)):
                 return multipartData1 == multipartData2
+            case (let .uploadMultipartFormData(multipartFormData1), let .uploadMultipartFormData(multipartFormData2)),
+                 (let .uploadCompositeMultipartFormData(multipartFormData1, _), let .uploadCompositeMultipartFormData(multipartFormData2, _)):
+                return multipartFormData1 == multipartFormData2
             default:
                 return true
             }

--- a/Sources/Moya/MoyaProvider+Internal.swift
+++ b/Sources/Moya/MoyaProvider+Internal.swift
@@ -84,11 +84,11 @@ public extension MoyaProvider {
                 return self.sendRequest(target, request: request, callbackQueue: callbackQueue, progress: progress, completion: completion)
             case .uploadFile(let file):
                 return self.sendUploadFile(target, request: request, callbackQueue: callbackQueue, file: file, progress: progress, completion: completion)
-            case .uploadMultipart(let multipartBody), .uploadCompositeMultipart(let multipartBody, _):
-                guard !multipartBody.isEmpty && endpoint.method.supportsMultipart else {
+            case .uploadMultipart(let multipartFormData), .uploadCompositeMultipart(let multipartFormData, _):
+                guard !multipartFormData.parts.isEmpty && endpoint.method.supportsMultipart else {
                     fatalError("\(target) is not a multipart upload target.")
                 }
-                return self.sendUploadMultipart(target, request: request, callbackQueue: callbackQueue, multipartBody: multipartBody, progress: progress, completion: completion)
+                return self.sendUploadMultipart(target, request: request, callbackQueue: callbackQueue, multipartFormData: multipartFormData, progress: progress, completion: completion)
             case .downloadDestination(let destination), .downloadParameters(_, _, let destination):
                 return self.sendDownloadRequest(target, request: request, callbackQueue: callbackQueue, destination: destination, progress: progress, completion: completion)
             }
@@ -172,9 +172,9 @@ private extension MoyaProvider {
         }
     }
 
-    func sendUploadMultipart(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, multipartBody: [MultipartFormData], progress: Moya.ProgressBlock? = nil, completion: @escaping Moya.Completion) -> CancellableToken {
-        let formData = RequestMultipartFormData()
-        formData.applyMoyaMultipartFormData(multipartBody)
+    func sendUploadMultipart(_ target: Target, request: URLRequest, callbackQueue: DispatchQueue?, multipartFormData: MultipartFormData, progress: Moya.ProgressBlock? = nil, completion: @escaping Moya.Completion) -> CancellableToken {
+        let formData = RequestMultipartFormData(fileManager: multipartFormData.fileManager, boundary: multipartFormData.boundary)
+        formData.applyMoyaMultipartFormData(multipartFormData)
 
         let interceptor = self.interceptor(target: target)
         let uploadRequest: UploadRequest = session.requestQueue.sync {

--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -3,6 +3,30 @@ import Alamofire
 
 /// Represents "multipart/form-data" for an upload.
 public struct MultipartFormData: Hashable {
+    /// `FileManager` to use for file operations, if needed. `FileManager.default` by default.
+    public let fileManager: FileManager
+
+    /// Separates ``parts`` in the encoded form data. `nil` by default.
+    public let boundary: String?
+
+    /// Blocks of data to send, separated with ``boundary``.
+    public let parts: [MultipartFormBodyPart]
+
+    public init(fileManager: FileManager = .default, boundary: String? = nil, parts: [MultipartFormBodyPart]) {
+        self.fileManager = fileManager
+        self.boundary = boundary
+        self.parts = parts
+    }
+}
+
+extension MultipartFormData: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: MultipartFormBodyPart...) {
+        self.init(parts: elements)
+    }
+}
+
+/// Represents the body part of "multipart/form-data" for an upload.
+public struct MultipartFormBodyPart: Hashable {
 
     /// Method to provide the form data.
     public enum FormDataProvider: Hashable {
@@ -34,11 +58,11 @@ public struct MultipartFormData: Hashable {
 
 // MARK: RequestMultipartFormData appending
 internal extension RequestMultipartFormData {
-    func append(data: Data, bodyPart: MultipartFormData) {
+    func append(data: Data, bodyPart: MultipartFormBodyPart) {
         append(data, withName: bodyPart.name, fileName: bodyPart.fileName, mimeType: bodyPart.mimeType)
     }
 
-    func append(fileURL url: URL, bodyPart: MultipartFormData) {
+    func append(fileURL url: URL, bodyPart: MultipartFormBodyPart) {
         if let fileName = bodyPart.fileName, let mimeType = bodyPart.mimeType {
             append(url, withName: bodyPart.name, fileName: fileName, mimeType: mimeType)
         } else {
@@ -46,12 +70,12 @@ internal extension RequestMultipartFormData {
         }
     }
 
-    func append(stream: InputStream, length: UInt64, bodyPart: MultipartFormData) {
+    func append(stream: InputStream, length: UInt64, bodyPart: MultipartFormBodyPart) {
         append(stream, withLength: length, name: bodyPart.name, fileName: bodyPart.fileName ?? "", mimeType: bodyPart.mimeType ?? "")
     }
 
-    func applyMoyaMultipartFormData(_ multipartBody: [Moya.MultipartFormData]) {
-        for bodyPart in multipartBody {
+    func applyMoyaMultipartFormData(_ multipartFormData: Moya.MultipartFormData) {
+        for bodyPart in multipartFormData.parts {
             switch bodyPart.provider {
             case .data(let data):
                 append(data: data, bodyPart: bodyPart)

--- a/Sources/Moya/MultipartFormData.swift
+++ b/Sources/Moya/MultipartFormData.swift
@@ -3,6 +3,14 @@ import Alamofire
 
 /// Represents "multipart/form-data" for an upload.
 public struct MultipartFormData: Hashable {
+
+    /// Method to provide the form data.
+    public enum FormDataProvider: Hashable {
+        case data(Foundation.Data)
+        case file(URL)
+        case stream(InputStream, UInt64)
+    }
+
     /// `FileManager` to use for file operations, if needed. `FileManager.default` by default.
     public let fileManager: FileManager
 
@@ -28,14 +36,7 @@ extension MultipartFormData: ExpressibleByArrayLiteral {
 /// Represents the body part of "multipart/form-data" for an upload.
 public struct MultipartFormBodyPart: Hashable {
 
-    /// Method to provide the form data.
-    public enum FormDataProvider: Hashable {
-        case data(Foundation.Data)
-        case file(URL)
-        case stream(InputStream, UInt64)
-    }
-
-    public init(provider: FormDataProvider, name: String, fileName: String? = nil, mimeType: String? = nil) {
+    public init(provider: MultipartFormData.FormDataProvider, name: String, fileName: String? = nil, mimeType: String? = nil) {
         self.provider = provider
         self.name = name
         self.fileName = fileName
@@ -43,7 +44,7 @@ public struct MultipartFormBodyPart: Hashable {
     }
 
     /// The method being used for providing form data.
-    public let provider: FormDataProvider
+    public let provider: MultipartFormData.FormDataProvider
 
     /// The name.
     public let name: String

--- a/Sources/Moya/Task.swift
+++ b/Sources/Moya/Task.swift
@@ -28,10 +28,10 @@ public enum Task {
     case uploadFile(URL)
 
     /// A "multipart/form-data" upload task.
-    case uploadMultipart([MultipartFormData])
+    case uploadMultipart(MultipartFormData)
 
     /// A "multipart/form-data" upload task  combined with url parameters.
-    case uploadCompositeMultipart([MultipartFormData], urlParameters: [String: Any])
+    case uploadCompositeMultipart(MultipartFormData, urlParameters: [String: Any])
 
     /// A file download task to a destination.
     case downloadDestination(DownloadDestination)

--- a/Sources/Moya/Task.swift
+++ b/Sources/Moya/Task.swift
@@ -28,10 +28,18 @@ public enum Task {
     case uploadFile(URL)
 
     /// A "multipart/form-data" upload task.
-    case uploadMultipart(MultipartFormData)
+    case uploadMultipartFormData(MultipartFormData)
+
+    /// A "multipart/form-data" upload task.
+    @available(*, deprecated, message: "use `uploadMultipartFormData(MultipartFormData)` instead")
+    case uploadMultipart([MultipartFormBodyPart])
 
     /// A "multipart/form-data" upload task  combined with url parameters.
-    case uploadCompositeMultipart(MultipartFormData, urlParameters: [String: Any])
+    case uploadCompositeMultipartFormData(MultipartFormData, urlParameters: [String: Any])
+
+    /// A "multipart/form-data" upload task  combined with url parameters.
+    @available(*, deprecated, message: "use `uploadCompositeMultipartFormData(MultipartFormData)` instead")
+    case uploadCompositeMultipart([MultipartFormBodyPart], urlParameters: [String: Any])
 
     /// A file download task to a destination.
     case downloadDestination(DownloadDestination)

--- a/Tests/MoyaTests/EndpointClosureSpec.swift
+++ b/Tests/MoyaTests/EndpointClosureSpec.swift
@@ -17,9 +17,8 @@ final class EndpointClosureSpec: QuickSpec {
 
                 switch target.task {
                 case let .uploadMultipart(multipartFormData):
-                    let additional = Moya.MultipartFormData(provider: .data("test2".data(using: .utf8)!), name: "test2")
-                    var newMultipartFormData = multipartFormData
-                    newMultipartFormData.append(additional)
+                    let additionalBodyPart = Moya.MultipartFormBodyPart(provider: .data("test2".data(using: .utf8)!), name: "test2")
+                    let newMultipartFormData = MultipartFormData(parts: multipartFormData.parts + CollectionOfOne(additionalBodyPart))
                     task = .uploadMultipart(newMultipartFormData)
                 default:
                     task = target.task
@@ -31,16 +30,16 @@ final class EndpointClosureSpec: QuickSpec {
         }
 
         it("appends additional multipart body in endpointClosure") {
-            let multipartData1 = Moya.MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test1")
-            let multipartData2 = Moya.MultipartFormData(provider: .data("test2".data(using: .utf8)!), name: "test2")
+            let multipartData1 = Moya.MultipartFormBodyPart(provider: .data("test1".data(using: .utf8)!), name: "test1")
+            let multipartData2 = Moya.MultipartFormBodyPart(provider: .data("test2".data(using: .utf8)!), name: "test2")
 
-            let providedMultipartData = [multipartData1]
-            let sentMultipartData = [multipartData1, multipartData2]
+            let providedMultipartData: Moya.MultipartFormData = [multipartData1]
+            let sentMultipartData: Moya.MultipartFormData = [multipartData1, multipartData2]
 
             _ = provider.request(.uploadMultipart(providedMultipartData, nil)) { _ in }
             let stringData1 = session.uploadMultipartString!
 
-            let requestMultipartFormData = RequestMultipartFormData()
+            let requestMultipartFormData = RequestMultipartFormData(fileManager: sentMultipartData.fileManager, boundary: sentMultipartData.boundary)
             requestMultipartFormData.applyMoyaMultipartFormData(sentMultipartData)
             let stringData2 = String(decoding: try! requestMultipartFormData.encode(), as: UTF8.self)
 

--- a/Tests/MoyaTests/EndpointClosureSpec.swift
+++ b/Tests/MoyaTests/EndpointClosureSpec.swift
@@ -16,9 +16,13 @@ final class EndpointClosureSpec: QuickSpec {
                 let task: Task
 
                 switch target.task {
-                case let .uploadMultipart(multipartFormData):
+                case let .uploadMultipartFormData(multipartFormData):
                     let additionalBodyPart = Moya.MultipartFormBodyPart(provider: .data("test2".data(using: .utf8)!), name: "test2")
                     let newMultipartFormData = MultipartFormData(parts: multipartFormData.parts + CollectionOfOne(additionalBodyPart))
+                    task = .uploadMultipartFormData(newMultipartFormData)
+                case let .uploadMultipart(multipartFormBodyParts):
+                    let additionalBodyPart = Moya.MultipartFormBodyPart(provider: .data("test2".data(using: .utf8)!), name: "test2")
+                    let newMultipartFormData = multipartFormBodyParts + CollectionOfOne(additionalBodyPart)
                     task = .uploadMultipart(newMultipartFormData)
                 default:
                     task = target.task
@@ -36,11 +40,41 @@ final class EndpointClosureSpec: QuickSpec {
             let providedMultipartData: Moya.MultipartFormData = [multipartData1]
             let sentMultipartData: Moya.MultipartFormData = [multipartData1, multipartData2]
 
-            _ = provider.request(.uploadMultipart(providedMultipartData, nil)) { _ in }
+            _ = provider.request(HTTPBin.uploadMultipartFormData(providedMultipartData, nil)) { _ in }
             let stringData1 = session.uploadMultipartString!
 
             let requestMultipartFormData = RequestMultipartFormData(fileManager: sentMultipartData.fileManager, boundary: sentMultipartData.boundary)
             requestMultipartFormData.applyMoyaMultipartFormData(sentMultipartData)
+            let stringData2 = String(decoding: try! requestMultipartFormData.encode(), as: UTF8.self)
+
+            let formData1 = "data; name=\"test1\"\r\n\r\ntest1\r\n"
+            let formData2 = "data; name=\"test2\"\r\n\r\ntest2\r\n"
+
+            let splitString1 = stringData1.split(separator: "-").map { String($0) }
+            let splitString2 = stringData2.split(separator: "-").map { String($0) }
+
+            // flacky tes
+            expect(splitString1).to(contain(formData1))
+            expect(splitString1).to(contain(formData2))
+            expect(splitString2).to(contain(formData1))
+            expect(splitString2).to(contain(formData2))
+
+        }
+
+        it("appends additional multipart body parts in endpointClosure") {
+            let multipartData1 = Moya.MultipartFormBodyPart(provider: .data("test1".data(using: .utf8)!), name: "test1")
+            let multipartData2 = Moya.MultipartFormBodyPart(provider: .data("test2".data(using: .utf8)!), name: "test2")
+
+            let providedMultipartData = [multipartData1]
+            let sentMultipartData = [multipartData1, multipartData2]
+
+            _ = provider.request(HTTPBin.uploadMultipartBodyParts(providedMultipartData, nil)) { _ in }
+            let stringData1 = session.uploadMultipartString!
+
+            let multipartFormData = MultipartFormData(parts: sentMultipartData)
+
+            let requestMultipartFormData = RequestMultipartFormData(fileManager: multipartFormData.fileManager, boundary: multipartFormData.boundary)
+            requestMultipartFormData.applyMoyaMultipartFormData(multipartFormData)
             let stringData2 = String(decoding: try! requestMultipartFormData.encode(), as: UTF8.self)
 
             let formData1 = "data; name=\"test1\"\r\n\r\ntest1\r\n"

--- a/Tests/MoyaTests/EndpointSpec.swift
+++ b/Tests/MoyaTests/EndpointSpec.swift
@@ -369,15 +369,15 @@ final class EndpointSpec: QuickSpec {
         describe("given endpoint comparison") {
             context("when task is .uploadMultipart") {
                 it("should correctly acknowledge as equal for the same url, headers and form data") {
-                    endpoint = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")]))
-                    let endpointToCompare = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")]))
+                    endpoint = endpoint.replacing(task: .uploadMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]))
 
                     expect(endpoint) == endpointToCompare
                 }
 
                 it("should correctly acknowledge as not equal for the same url, headers and different form data") {
-                    endpoint = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")]))
-                    let endpointToCompare = endpoint.replacing(task: .uploadMultipart([MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test")]))
+                    endpoint = endpoint.replacing(task: .uploadMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadMultipart([MultipartFormBodyPart(provider: .data("test1".data(using: .utf8)!), name: "test")]))
 
                     expect(endpoint) != endpointToCompare
                 }
@@ -385,22 +385,22 @@ final class EndpointSpec: QuickSpec {
 
             context("when task is .uploadCompositeMultipart") {
                 it("should correctly acknowledge as equal for the same url, headers and form data") {
-                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
-                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
 
                     expect(endpoint) == endpointToCompare
                 }
 
                 it("should correctly acknowledge as not equal for the same url, headers and different form data") {
-                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
-                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test1".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test1".data(using: .utf8)!), name: "test")], urlParameters: [:]))
 
                     expect(endpoint) != endpointToCompare
                 }
 
                 it("should correctly acknowledge as not equal for the same url, headers and different url parameters") {
-                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test2"]))
-                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormData(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test3"]))
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test2"]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test3"]))
 
                     expect(endpoint) != endpointToCompare
                 }

--- a/Tests/MoyaTests/EndpointSpec.swift
+++ b/Tests/MoyaTests/EndpointSpec.swift
@@ -96,6 +96,12 @@ final class EndpointSpec: QuickSpec {
                 }
             }
 
+            context("when task is .uploadMultipartFormData") {
+                itBehavesLike("endpoint with no request property changed") {
+                    ["task": Task.uploadMultipartFormData([]), "endpoint": self.simpleGitHubEndpoint]
+                }
+            }
+
             context("when task is .downloadDestination") {
                 itBehavesLike("endpoint with no request property changed") {
                     let destination: DownloadDestination = { url, response in
@@ -287,6 +293,22 @@ final class EndpointSpec: QuickSpec {
                     expect(request.url?.absoluteString).to(equal(expectedUrl))
                 }
             }
+
+            context("when task is .uploadCompositeMultipartFormData") {
+                var urlParameters: [String: Any]!
+                var request: URLRequest!
+
+                beforeEach {
+                    urlParameters = ["Harvey": "Nemesis"]
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipartFormData([], urlParameters: urlParameters))
+                    request = try! endpoint.urlRequest()
+                }
+
+                it("updates url") {
+                    let expectedUrl = endpoint.url + "?Harvey=Nemesis"
+                    expect(request.url?.absoluteString).to(equal(expectedUrl))
+                }
+            }
         }
 
         describe("unsuccessful converting to urlRequest") {
@@ -383,6 +405,22 @@ final class EndpointSpec: QuickSpec {
                 }
             }
 
+            context("when task is .uploadMultipartFormData") {
+                it("should correctly acknowledge as equal for the same url, headers and form data") {
+                    endpoint = endpoint.replacing(task: .uploadMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")])))
+                    let endpointToCompare = endpoint.replacing(task: .uploadMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")])))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different form data") {
+                    endpoint = endpoint.replacing(task: .uploadMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")])))
+                    let endpointToCompare = endpoint.replacing(task: .uploadMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test1".data(using: .utf8)!), name: "test")])))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
             context("when task is .uploadCompositeMultipart") {
                 it("should correctly acknowledge as equal for the same url, headers and form data") {
                     endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: [:]))
@@ -399,8 +437,31 @@ final class EndpointSpec: QuickSpec {
                 }
 
                 it("should correctly acknowledge as not equal for the same url, headers and different url parameters") {
-                    endpoint = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test2"]))
-                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipart([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test3"]))
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipartFormData([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test2"]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipartFormData([MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")], urlParameters: ["test": "test3"]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+            }
+
+            context("when task is .uploadCompositeMultipartFormData") {
+                it("should correctly acknowledge as equal for the same url, headers and form data") {
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]), urlParameters: [:]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]), urlParameters: [:]))
+
+                    expect(endpoint) == endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different form data") {
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]), urlParameters: [:]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test1".data(using: .utf8)!), name: "test")]), urlParameters: [:]))
+
+                    expect(endpoint) != endpointToCompare
+                }
+
+                it("should correctly acknowledge as not equal for the same url, headers and different url parameters") {
+                    endpoint = endpoint.replacing(task: .uploadCompositeMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]), urlParameters: ["test": "test2"]))
+                    let endpointToCompare = endpoint.replacing(task: .uploadCompositeMultipartFormData(MultipartFormData(parts: [MultipartFormBodyPart(provider: .data("test".data(using: .utf8)!), name: "test")]), urlParameters: ["test": "test3"]))
 
                     expect(endpoint) != endpointToCompare
                 }

--- a/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
@@ -360,7 +360,28 @@ final class MoyaProviderIntegrationTests: QuickSpec {
             let formData = HTTPBin.createTestMultipartFormData()
 
             it("returns an error for status code different than 287") {
-                let target = HTTPBin.validatedUploadMultipart(formData, nil, [287])
+                let target = HTTPBin.validatedUploadMultipartFormData(MultipartFormData(parts: formData), nil, [287])
+                var receievedResponse: Response?
+                var receivedError: Error?
+
+                waitUntil(timeout: .seconds(10)) { done in
+                    provider.request(target) { result in
+                        switch result {
+                        case .success(let response):
+                            receievedResponse = response
+                        case .failure(let error):
+                            receivedError = error
+                        }
+                        done()
+                    }
+                }
+
+                expect(receievedResponse).to(beNil())
+                expect(receivedError).toNot(beNil())
+            }
+
+            it("returns an error for status code different than 287") {
+                let target = HTTPBin.validatedUploadMultipartBodyParts(formData, nil, [287])
                 var receievedResponse: Response?
                 var receivedError: Error?
 
@@ -382,7 +403,29 @@ final class MoyaProviderIntegrationTests: QuickSpec {
 
             it("returns a valid response for .succesCodes") {
                 let successCodes = ValidationType.successCodes.statusCodes
-                let target = HTTPBin.validatedUploadMultipart(formData, nil, successCodes)
+                let target = HTTPBin.validatedUploadMultipartFormData(MultipartFormData(parts: formData), nil, successCodes)
+                var receievedResponse: Response?
+                var receivedError: Error?
+
+                waitUntil(timeout: .seconds(10)) { done in
+                    provider.request(target) { result in
+                        switch result {
+                        case .success(let response):
+                            receievedResponse = response
+                        case .failure(let error):
+                            receivedError = error
+                        }
+                        done()
+                    }
+                }
+
+                expect(receievedResponse).toNot(beNil())
+                expect(receivedError).to(beNil())
+            }
+
+            it("returns a valid response for .succesCodes") {
+                let successCodes = ValidationType.successCodes.statusCodes
+                let target = HTTPBin.validatedUploadMultipartBodyParts(formData, nil, successCodes)
                 var receievedResponse: Response?
                 var receivedError: Error?
 

--- a/Tests/MoyaTests/MoyaProviderSpec.swift
+++ b/Tests/MoyaTests/MoyaProviderSpec.swift
@@ -945,7 +945,42 @@ final class MoyaProviderSpec: QuickSpec {
             it("tracks progress of multipart request") {
 
                 let formData = HTTPBin.createTestMultipartFormData()
-                let target = HTTPBin.uploadMultipart(formData, nil)
+                let target = HTTPBin.uploadMultipartFormData(MultipartFormData(parts: formData), nil)
+
+                var progressObjects: [Progress?] = []
+                var progressValues: [Double] = []
+                var completedValues: [Bool] = []
+                var error: MoyaError?
+
+                waitUntil(timeout: .seconds(10)) { done in
+                    let progressClosure: ProgressBlock = { progress in
+                        progressObjects.append(progress.progressObject)
+                        progressValues.append(progress.progress)
+                        completedValues.append(progress.completed)
+                    }
+
+                    let progressCompletionClosure: Completion = { (result) in
+                        if case .failure(let err) = result {
+                            error = err
+                        }
+                        done()
+                    }
+
+                    provider.request(target, callbackQueue: nil, progress: progressClosure, completion: progressCompletionClosure)
+                }
+
+                expect(error).to(beNil())
+                expect(progressValues.count) > 1
+                expect(completedValues.count) > 1
+                expect(completedValues.filter { !$0 }.count) == completedValues.count - 1 // only false except one
+                expect(completedValues.last) == true // the last must be true
+                expect(progressObjects.filter { $0 != nil }.count) == progressObjects.count // no nil object
+            }
+
+            it("tracks progress of multipart request") {
+
+                let formData = HTTPBin.createTestMultipartFormData()
+                let target = HTTPBin.uploadMultipartBodyParts(formData, nil)
 
                 var progressObjects: [Progress?] = []
                 var progressValues: [Double] = []

--- a/Tests/MoyaTests/MultipartFormDataSpec.swift
+++ b/Tests/MoyaTests/MultipartFormDataSpec.swift
@@ -8,7 +8,7 @@ final class MultiPartFormData: QuickSpec {
     override func spec() {
         it("initializes correctly") {
             let fileURL = URL(fileURLWithPath: "/tmp.txt")
-            let data = MultipartFormData(
+            let data = MultipartFormBodyPart(
                 provider: .file(fileURL),
                 name: "MyName",
                 fileName: "tmp.txt",

--- a/Tests/MoyaTests/MultipartFormDataSpec.swift
+++ b/Tests/MoyaTests/MultipartFormDataSpec.swift
@@ -8,18 +8,22 @@ final class MultiPartFormData: QuickSpec {
     override func spec() {
         it("initializes correctly") {
             let fileURL = URL(fileURLWithPath: "/tmp.txt")
-            let data = MultipartFormBodyPart(
+            let bodyPart = MultipartFormBodyPart(
                 provider: .file(fileURL),
                 name: "MyName",
                 fileName: "tmp.txt",
                 mimeType: "text/plain"
             )
+            let data = MultipartFormData(parts: [bodyPart])
 
-            expect(data.name) == "MyName"
-            expect(data.fileName) == "tmp.txt"
-            expect(data.mimeType) == "text/plain"
+            expect(data.boundary).to(beNil())
+            expect(data.fileManager) == FileManager.default
+            expect(data.parts.count) == 1
+            expect(data.parts[0].name) == "MyName"
+            expect(data.parts[0].fileName) == "tmp.txt"
+            expect(data.parts[0].mimeType) == "text/plain"
 
-            if case .file(let url) = data.provider {
+            if case .file(let url) = data.parts[0].provider {
                 expect(url) == fileURL
             } else {
                 fail("The provider was not initialized correctly.")

--- a/Tests/MoyaTests/TestHelpers.swift
+++ b/Tests/MoyaTests/TestHelpers.swift
@@ -66,8 +66,8 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
     case bearer
     case post
     case upload(file: URL)
-    case uploadMultipart([MultipartFormData], [String: Any]?)
-    case validatedUploadMultipart([MultipartFormData], [String: Any]?, [Int])
+    case uploadMultipart(MultipartFormData, [String: Any]?)
+    case validatedUploadMultipart(MultipartFormData, [String: Any]?, [Int])
 
     var baseURL: URL { URL(string: "http://httpbin.org")! }
     var path: String {
@@ -184,15 +184,15 @@ extension GitHubUserContent: TargetType {
 // MARK: - Upload Multipart Helpers
 
 extension HTTPBin {
-    static func createTestMultipartFormData() -> [MultipartFormData] {
+    static func createTestMultipartFormData() -> MultipartFormData {
         let url = testImageUrl
         let string = "some data"
         guard let data = string.data(using: .utf8) else {
             fatalError("Failed creating Data from String \(string)")
         }
         return [
-            MultipartFormData(provider: .file(url), name: "file", fileName: "testImage"),
-            MultipartFormData(provider: .data(data), name: "data")
+            MultipartFormBodyPart(provider: .file(url), name: "file", fileName: "testImage"),
+            MultipartFormBodyPart(provider: .data(data), name: "data")
         ]
     }
 }

--- a/Tests/MoyaTests/TestHelpers.swift
+++ b/Tests/MoyaTests/TestHelpers.swift
@@ -66,8 +66,10 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
     case bearer
     case post
     case upload(file: URL)
-    case uploadMultipart(MultipartFormData, [String: Any]?)
-    case validatedUploadMultipart(MultipartFormData, [String: Any]?, [Int])
+    case uploadMultipartFormData(MultipartFormData, [String: Any]?)
+    case uploadMultipartBodyParts([MultipartFormBodyPart], [String: Any]?)
+    case validatedUploadMultipartFormData(MultipartFormData, [String: Any]?, [Int])
+    case validatedUploadMultipartBodyParts([MultipartFormBodyPart], [String: Any]?, [Int])
 
     var baseURL: URL { URL(string: "http://httpbin.org")! }
     var path: String {
@@ -76,7 +78,7 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
             return "/basic-auth/user/passwd"
         case .bearer:
             return "/bearer"
-        case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
+            case .post, .upload, .uploadMultipartBodyParts, .uploadMultipartFormData, .validatedUploadMultipartBodyParts, .validatedUploadMultipartFormData:
             return "/post"
         }
     }
@@ -85,7 +87,7 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
         switch self {
         case .basicAuth, .bearer:
             return .get
-        case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
+        case .post, .upload, .uploadMultipartBodyParts, .uploadMultipartFormData, .validatedUploadMultipartBodyParts, .validatedUploadMultipartFormData:
             return .post
         }
     }
@@ -96,11 +98,17 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
             return .requestParameters(parameters: [:], encoding: URLEncoding.default)
         case .upload(let fileURL):
             return .uploadFile(fileURL)
-        case .uploadMultipart(let data, let urlParameters), .validatedUploadMultipart(let data, let urlParameters, _):
+        case .uploadMultipartFormData(let data, let urlParameters), .validatedUploadMultipartFormData(let data, let urlParameters, _):
             if let urlParameters = urlParameters {
-                return .uploadCompositeMultipart(data, urlParameters: urlParameters)
+                return .uploadCompositeMultipartFormData(data, urlParameters: urlParameters)
             } else {
-                return .uploadMultipart(data)
+                return .uploadMultipartFormData(data)
+            }
+        case .uploadMultipartBodyParts(let bodyParts, let urlParameters), .validatedUploadMultipartBodyParts(let bodyParts, let urlParameters, _):
+            if let urlParameters = urlParameters {
+                return .uploadCompositeMultipart(bodyParts, urlParameters: urlParameters)
+            } else {
+                return .uploadMultipart(bodyParts)
             }
         }
     }
@@ -111,7 +119,7 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
             return "{\"authenticated\": true, \"user\": \"user\"}".data(using: String.Encoding.utf8)!
         case .bearer:
             return "{\"authenticated\": true, \"token\": \"4D4A9C7D-F6E7-4FD7-BDBD-03880550A80D\"}".data(using: String.Encoding.utf8)!
-        case .post, .upload, .uploadMultipart, .validatedUploadMultipart:
+        case .post, .upload, .uploadMultipartBodyParts, .uploadMultipartFormData, .validatedUploadMultipartBodyParts, .validatedUploadMultipartFormData:
             return "{\"args\": {}, \"data\": \"\", \"files\": {}, \"form\": {}, \"headers\": { \"Connection\": \"close\", \"Content-Length\": \"0\", \"Host\": \"httpbin.org\" },  \"json\": null, \"origin\": \"198.168.1.1\", \"url\": \"https://httpbin.org/post\"}".data(using: String.Encoding.utf8)!
         }
     }
@@ -120,7 +128,7 @@ enum HTTPBin: TargetType, AccessTokenAuthorizable {
 
     var validationType: ValidationType {
         switch self {
-        case .validatedUploadMultipart(_, _, let codes):
+        case .validatedUploadMultipartFormData(_, _, let codes), .validatedUploadMultipartBodyParts(_, _, let codes):
             return .customCodes(codes)
         default:
             return .none
@@ -184,7 +192,7 @@ extension GitHubUserContent: TargetType {
 // MARK: - Upload Multipart Helpers
 
 extension HTTPBin {
-    static func createTestMultipartFormData() -> MultipartFormData {
+    static func createTestMultipartFormData() -> [MultipartFormBodyPart] {
         let url = testImageUrl
         let string = "some data"
         guard let data = string.data(using: .utf8) else {

--- a/docs/Examples/MultipartUpload.md
+++ b/docs/Examples/MultipartUpload.md
@@ -16,7 +16,7 @@ Here, our additional parameter is `description`, which is a `String`.
 
 ## Parameters in body
 
-When we want to perform a multipart upload request with additional parameters in the request body, we have to create a `MultipartFormData` for each of our parts and then return a `.uploadMultipart(_:)` in the `task` property:
+When we want to perform a multipart upload request with additional parameters in the request body, we have to create a `MultipartFormData` for each of our parts and then return a `.uploadMultipartFormData(_:)` in the `task` property:
 
 ```swift
 extension MyService: TargetType {
@@ -24,11 +24,13 @@ extension MyService: TargetType {
     public var task: Task {
         switch self {
         case let .uploadGif(data, description):
-            let gifData = MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
-            let descriptionData = MultipartFormData(provider: .data(description.data(using: .utf8)!), name: "description")
-            let multipartData = [gifData, descriptionData]
+            let gifData = MultipartFormBodyPart(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
+            let descriptionData = MultipartFormBodyPart(provider: .data(description.data(using: .utf8)!), name: "description")
+            let multipartData: MultipartFormData = [gifData, descriptionData]
+            // Or if you want to specify the boundary and file manager:
+            // let multipartData = MultipartFormData(fileManager: .default, boundary: "...", parts: [gifData, descriptionData])
 
-            return .uploadMultipart(multipartData)
+            return .uploadMultipartFormData(multipartData)
         }
     }
 //...
@@ -37,7 +39,7 @@ extension MyService: TargetType {
 
 ## Parameters in URL
 
-In case of parameters in URL, we can just use our new `Task` type, `uploadCompositeMultipart(_:urlParameters)`:
+In case of parameters in URL, we can just use our new `Task` type, `uploadCompositeMultipartFormData(_:urlParameters)`:
 
 ```swift
 extension MyService: TargetType {
@@ -45,11 +47,14 @@ extension MyService: TargetType {
     public var task: Task {
         switch self {
         case let .uploadGif(data, description):
-            let gifData = MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
-            let multipartData = [gifData]
+            let gifData = MultipartFormBodyPart(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
+            let multipartData: MultipartFormData = [gifData]
+            // Or if you want to specify the boundary and file manager:
+            // let multipartData = MultipartFormData(fileManager: .default, boundary: "...", parts: [gifData])
+            
             let urlParameters = ["description": description]
 
-            return .uploadCompositeMultipart(multipartData, urlParameters: urlParameters)
+            return .uploadCompositeMultipartFormData(multipartData, urlParameters: urlParameters)
         }
     }
 //...

--- a/docs_CN/Examples/MultipartUpload.md
+++ b/docs_CN/Examples/MultipartUpload.md
@@ -16,7 +16,7 @@ public enum MyService {
 
 ## body中的参数
 
-当我们想在一个请求body中完成附加参数的多部分上传请求时，我们必须为每个创建一个`MultipartFormData`对象，然后在 `task`中返回一个`.uploadMultipart(_:)`实例对象 :
+当我们想在一个请求body中完成附加参数的多部分上传请求时，我们必须为每个创建一个`MultipartFormData`对象，然后在 `task`中返回一个`.uploadMultipartFormData(_:)`实例对象 :
 
 ```swift
 extension MyService: TargetType {
@@ -24,11 +24,13 @@ extension MyService: TargetType {
     public var task: Task {
         switch self {
         case let .uploadGif(data, description):
-            let gifData = MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
-            let descriptionData = MultipartFormData(provider: .data(description.data(using: .utf8)!), name: "description")
-            let multipartData = [gifData, descriptionData]
+            let gifData = MultipartFormBodyPart(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
+            let descriptionData = MultipartFormBodyPart(provider: .data(description.data(using: .utf8)!), name: "description")
+            let multipartData: MultipartFormData = [gifData, descriptionData]
+            // Or if you want to specify the boundary and file manager:
+            // let multipartData = MultipartFormData(fileManager: .default, boundary: "...", parts: [gifData, descriptionData])
 
-            return .uploadMultipart(multipartData)
+            return .uploadMultipartFormData(multipartData)
         }
     }
 //...
@@ -37,7 +39,7 @@ extension MyService: TargetType {
 
 ## 在 URL中的参数
 
-在 URL中的附加参数, 我们只需要使用新的 `Task` 类型, `uploadCompositeMultipart(_:urlParameters)`:
+在 URL中的附加参数, 我们只需要使用新的 `Task` 类型, `uploadCompositeMultipartFormData(_:urlParameters)`:
 
 ```swift
 extension MyService: TargetType {
@@ -45,11 +47,14 @@ extension MyService: TargetType {
     public var task: Task {
         switch self {
         case let .uploadGif(data, description):
-            let gifData = MultipartFormData(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
-            let multipartData = [gifData]
+            let gifData = MultipartFormBodyPart(provider: .data(data), name: "file", fileName: "gif.gif", mimeType: "image/gif")
+            let multipartData: MultipartFormData = [gifData]
+            // Or if you want to specify the boundary and file manager:
+            // let multipartData = MultipartFormData(fileManager: .default, boundary: "...", parts: [gifData])
+            
             let urlParameters = ["description": description]
 
-            return .uploadCompositeMultipart(multipartData, urlParameters: urlParameters)
+            return .uploadCompositeMultipartFormData(multipartData, urlParameters: urlParameters)
         }
     }
 //...


### PR DESCRIPTION
✨

[MultipartFormData](https://github.com/Moya/Moya/blob/master/Sources/Moya/MultipartFormData.swift) can now take in `fileManager` and `boundary` inputs and pass it to [Alamofire's MultipartFormData](https://github.com/Alamofire/Alamofire/blob/master/Source/MultipartFormData.swift).

This doesn't introduce breaking API changes. Call site for `.uploadMultipart` will stay the same, ie:

```swift
enum MyTarget: TargetType {
   case test(Data, URL)

    var task: Task {
        switch self {
            case let .test(data, url):
                let bodyPart1 = MultipartFormBodyPart(provider: .file(url), name: "bp1")
                let bodyPart2 = MultipartFormBodyPart(provider: .data(data), name: "bp2")

                return .uploadMultipart([bodyPart1, bodyPart2]) // This is valid thanks to ExpressibleByArrayLiteral
        }
    }
}
```

Fixes #1988 
Fixes #2050 
Fixes #2051