### PR TITLE
Remove unexpected cyrillic letter in a comment

### DIFF
--- a/Sources/Moya/Plugins/AccessTokenPlugin.swift
+++ b/Sources/Moya/Plugins/AccessTokenPlugin.swift
@@ -56,7 +56,7 @@ extension AuthorizationType: Equatable {
  ```
  Authorization: Basic <token>
  Authorization: Bearer <token>
- Authorization: <Сustom> <token>
+ Authorization: <Custom> <token>
  ```
 
  */


### PR DESCRIPTION
Accidentally found a cyrillic letter in a comment. This might trip people up when copying the text of the comment somewhere else.
e.g. this line currently doesn't show up if you cmd+f for "Custom" in xcode