### PR TITLE
Change deprecated option in JSONSerialization

### DIFF
--- a/Sources/Moya/Response.swift
+++ b/Sources/Moya/Response.swift
@@ -96,7 +96,7 @@ public extension Response {
     /// whether the mapping should fail if the data is empty.
     func mapJSON(failsOnEmptyData: Bool = true) throws -> Any {
         do {
-            return try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+            return try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
         } catch {
             if data.isEmpty && !failsOnEmptyData {
                 return NSNull()


### PR DESCRIPTION
allowFragments option will be deprecated
changed to fragmentsAllowed 

https://developer.apple.com/documentation/foundation/jsonserialization/readingoptions/1416042-allowfragments