### PR TITLE
Update RxSwift.md (#2321)

### DIFF
--- a/docs/RxSwift.md
+++ b/docs/RxSwift.md
@@ -19,7 +19,7 @@ provider.rx.request(.zen).subscribe { event in
     switch event {
     case .success(let response):
         // do something with the data
-    case .error(let error):
+    case .failure(let error):
         // handle the error
     }
 }


### PR DESCRIPTION
Hi, i fix example code to work.

- pre example code. it has error😭
```swift
provider.rx.request(.zen).subscribe { event in
     switch event {
     case .success(let response):
         // do something with the data
     case .error(let error):
         // handle the error
     }
 }
```

### 👉 Here are the reasons.
MoyaProvider is provide `reqeust()` method that returns `Single<Response>` trait.

<img width="350" alt="a" src="https://github.com/Moya/Moya/assets/69136340/57b8129e-cbac-465d-b86c-fed1958873d4">

Let me see **subscribe(_:)** implementation.
`next` and `error` events are sent in `success` and `failure`**(not error event).**

<img width="500" alt="b" src="https://github.com/Moya/Moya/assets/69136340/a903c109-10a4-4fe2-8b83-f034a322cbf0">

In addition in `Single.swift`, i guess why example code that has error.
Below is the deprecated method. It has handling `onError` so, i think that's why the example code was written like that.

<img width="600" alt="c" src="https://github.com/Moya/Moya/assets/69136340/cf8a565d-11d1-4cc6-8f97-f0d7a6918d08">

- Fixes #2321 
