### PR TITLE
Migrate CI to GitHub Actions and fix Xcode 16.4 / macOS 26 SDK compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,116 +1,15 @@
 version: 2.1
-defaults: &defaults
-  macos:
-    xcode: 12.5.1
-  parallelism: 1
-  shell: /bin/bash --login    
-  environment:
-    CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-    CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-    LANG: en_US.UTF-8
-    BUNDLE_PATH: vendor/bundle
 jobs:
-  carthage_without_swiftlint_integration:
-    <<: *defaults
-    working_directory: ~/Moya/Moya_Carthage_1
-    steps:
-      - checkout
-      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-      - restore_cache:
-          keys:
-            - v{{ .Environment.CACHE_VERSION }}-carthage-no-swiftlint-deps-{{ checksum "Cartfile.resolved" }}
-      - run:
-          name: Set Ruby Version
-          command: echo "ruby-2.4" > ~/.ruby-version
-      - run:
-          name: Carthage checkout
-          command: carthage checkout
-      - run:
-          name: Test Carthage Build before installing SwiftLint
-          command: scripts/carthage.sh build --no-skip-current --cache-builds --no-use-binaries --verbose             
-      - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-carthage-no-swiftlint-deps-{{ checksum "Cartfile.resolved" }}
-          paths:
-            - Carthage               
   build:
-    <<: *defaults
-    working_directory: ~/Moya/Moya
+    docker:
+      - image: cimg/base:current
     steps:
-      - checkout
-      - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-      - restore_cache:
-          keys:
-            - v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-dep-{{ checksum "Cartfile.resolved" }}
-      - run:
-          name: Set Ruby Version
-          command: echo "ruby-2.4" > ~/.ruby-version
-      - run:
-          name: Install Swiftlint
-          command: git clone git@github.com:realm/SwiftLint.git && cd SwiftLint && git submodule update --init --recursive && make install && cd ../
-      - run:
-          name: Add Python directory to PATH
-          command: echo 'export PATH=~/Library/Python/2.7/bin:$PATH' >> $BASH_ENV        
-      - run:
-          name: Install Ruby Dependencies
-          command: bundle check || bundle install
-          environment:
-            BUNDLE_JOBS: 4
-            BUNDLE_RETRY: 3
-      - run:
-          name: Upgrade Carthage
-          command: brew upgrade carthage
-      - run: 
-          name: Bootstrap Carthage
-          command: scripts/bootstrap-if-needed.sh
-      - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-dep-{{ checksum "Cartfile.resolved" }}
-          paths:
-            - vendor/bundle
-            - Carthage
-      - run: 
-          name: Test on iOS
-          command: rake test:ios
-      - run: 
-          name: Test on macOS
-          command: rake test:macos
-      - run:
-          name: Test on tvOS
-          command: rake test:tvos
-      - run: 
-          name: Test with Carthage
-          command: rake test:carthage
-      - run:
-          name: Build Example Project
-          command: rake build_example
-      - run:
-          name: Install MDSpell
-          command: sudo npm install -g orta/node-markdown-spellcheck
-      - restore_cache:
-          keys:
-          - v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-danger-dependencies-{{ checksum "Dangerfile.swift" }}
-      - run:
-          name: Run Danger
-          command: brew install danger/tap/danger-swift && danger-swift ci
-      - save_cache:
-          key: v{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-danger-dependencies-{{ checksum "Dangerfile.swift" }}
-          paths:
-            - ~/.danger-swift
-            - /usr/local/Homebrew
-      - run:
-          name: CocoaPods Spec linting
-          command: bundle exec pod lib lint --allow-warnings
-      - run:
-          name: Send Code Coverage to Codecov.io
-          command: bash <(curl -s https://codecov.io/bash) -J Moya
-      - run:
-          name: Store Xcode Activity Log
-          command: find $HOME/Library/Developer/Xcode/DerivedData -name '*.xcactivitylog' -exec cp {} $CIRCLE_ARTIFACTS/xcactivitylog \; || true
-      - store_test_results:
-          path: /tmp/circleci-test-results
-      - store_artifacts:
-          path: /tmp/circleci-artifacts
-      - store_artifacts:
-          path: /tmp/circleci-test-results
+      - run: echo "CI moved to GitHub Actions"
+  carthage_without_swiftlint_integration:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run: echo "CI moved to GitHub Actions"
 workflows:
   version: 2
   pr_build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,204 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-15
+    env:
+      BUNDLE_PATH: vendor/bundle
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Cache Bundler
+        uses: actions/cache@v4
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
+
+      - name: Install Ruby Dependencies
+        run: bundle install
+
+      - name: Cache Carthage
+        id: cache-carthage
+        uses: actions/cache@v4
+        with:
+          path: Carthage
+          key: ${{ runner.os }}-carthage-v15-${{ hashFiles('Cartfile.resolved') }}
+
+      - name: Install Carthage
+        run: brew install carthage
+
+      - name: Carthage Checkout
+        if: steps.cache-carthage.outputs.cache-hit != 'true'
+        run: carthage checkout
+
+      - name: Fix Nimble DSL.m for Xcode 16
+        if: steps.cache-carthage.outputs.cache-hit != 'true'
+        run: |
+          find Carthage/Checkouts/Nimble -name "DSL.m" -exec \
+            sed -i '' 's/\*NMB_\([a-zA-Z_]*\)()/\*NMB_\1(void)/g' {} \;
+
+      - name: Patch Carthage checkouts for native macOS builds on Apple Silicon
+        if: steps.cache-carthage.outputs.cache-hit != 'true'
+        # On Apple Silicon + Xcode 16, iOS schemes have SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD
+        # enabled by default, which makes them claim macOS support. Carthage --platform Mac
+        # then picks the iOS scheme (not the native macOS one), producing arm64-apple-ios
+        # swiftmodules instead of arm64-apple-macos. XCODE_XCCONFIG_FILE is the lowest-
+        # priority override mechanism and cannot fix this.
+        #
+        # Two-part fix at the highest file-based priority (target build settings in pbxproj):
+        # 1. Remove IPHONEOS_DEPLOYMENT_TARGET so native macOS targets don't inherit it.
+        # 2. Use the xcodeproj gem (already installed via CocoaPods) to inject
+        #    SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO into each iOS target's build
+        #    settings (priority 6, above xcconfig at 5) so Carthage skips the iOS scheme
+        #    when building for --platform Mac and uses the native macOS scheme instead.
+        # scripts/carthage.sh re-adds IPHONEOS_DEPLOYMENT_TARGET for iphoneos/simulator
+        # SDKs via XCODE_XCCONFIG_FILE, so iOS builds are unaffected.
+        run: |
+          find Carthage/Checkouts -name "*.xcconfig" -o -name "project.pbxproj" | \
+            xargs grep -l "IPHONEOS_DEPLOYMENT_TARGET" 2>/dev/null | \
+            xargs sed -i '' '/IPHONEOS_DEPLOYMENT_TARGET/d'
+          bundle exec ruby -e '
+            require "xcodeproj"
+            Dir.glob("Carthage/Checkouts/**/*.xcodeproj").select { |p| File.directory?(p) }.each do |proj_path|
+              begin
+                project = Xcodeproj::Project.open(proj_path)
+                modified = false
+                project.targets.each do |target|
+                  target.build_configurations.each do |config|
+                    config.build_settings["SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD"] = "NO"
+                    modified = true
+                  end
+                end
+                if modified
+                  project.save
+                  puts "Patched: #{proj_path}"
+                end
+              rescue => e
+                puts "Skip #{proj_path}: #{e.message}"
+              end
+            end
+          '
+
+      - name: Bootstrap Carthage (iOS, tvOS, watchOS)
+        if: steps.cache-carthage.outputs.cache-hit != 'true'
+        run: scripts/carthage.sh build --cache-builds --platform iOS,tvOS,watchOS
+
+      - name: Remove iOS xcschemes before Mac build
+        if: steps.cache-carthage.outputs.cache-hit != 'true'
+        # iOS/tvOS/watchOS builds are complete; remove iOS xcscheme files so that
+        # `carthage build --platform Mac` only discovers native macOS schemes.
+        # Without this, Carthage still builds iOS schemes for Mac (via DISFIPAD),
+        # producing arm64-apple-ios swiftmodules that overwrite the native
+        # arm64-apple-macos ones — even after patching DISFIPAD=NO in pbxproj.
+        run: |
+          find Carthage/Checkouts -name "*iOS*.xcscheme" -delete
+          echo "Deleted iOS xcscheme files from Carthage/Checkouts"
+
+      - name: Bootstrap Carthage (Mac)
+        if: steps.cache-carthage.outputs.cache-hit != 'true'
+        # Build Mac separately. After "Clear IPHONEOS_DEPLOYMENT_TARGET" above removed
+        # the setting from all project files, macOS native schemes no longer inherit it
+        # and build with the correct arm64-apple-macos target triple.
+        # SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO is belt-and-suspenders: prevents
+        # any residual iOS-mode scheme from creating an arm64-apple-macos alias that
+        # would overwrite the native macOS swiftmodule.
+        run: |
+          xcconfig=$(mktemp /tmp/carthage-mac.xcconfig.XXXXXX)
+          echo 'MACOSX_DEPLOYMENT_TARGET = 10.15' > "$xcconfig"
+          echo 'GCC_WARN_STRICT_PROTOTYPES = NO' >> "$xcconfig"
+          echo 'OTHER_CFLAGS = $(inherited) -Wno-error=strict-prototypes' >> "$xcconfig"
+          echo 'IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos*] = 12.0' >> "$xcconfig"
+          echo 'IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator*] = 12.0' >> "$xcconfig"
+          echo 'SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO' >> "$xcconfig"
+          XCODE_XCCONFIG_FILE="$xcconfig" carthage build --cache-builds --platform Mac
+          rm -f "$xcconfig"
+
+      - name: Patch Mac swiftmodules for Apple Silicon
+        # Safety net: if a dependency's macOS build still produced an arm64-apple-ios
+        # binary swiftmodule (because SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD was
+        # ignored at target level), Swift rejects it with an SDK mismatch error.
+        # Detect these bad modules via `strings` and remove them so Swift falls back
+        # to arm64-apple-ios.swiftmodule (which is accepted for iPad-on-Mac lookup)
+        # or the framework binary directly.
+        # This step always runs so it also fixes frameworks restored from cache.
+        run: |
+          for fw in Carthage/Build/Mac/*.framework; do
+            name=$(basename "$fw" .framework)
+            moddir="$fw/Modules/$name.swiftmodule"
+            [ -d "$moddir" ] || continue
+            macos_mod="$moddir/arm64-apple-macos.swiftmodule"
+            [ -f "$macos_mod" ] || continue
+            # If arm64-apple-macos.swiftmodule contains "iphoneos" it was compiled
+            # with the iOS SDK — remove it to avoid the SDK mismatch linker error.
+            if strings "$macos_mod" 2>/dev/null | grep -q 'iphoneos'; then
+              echo "Removing iOS-SDK binary from $name/arm64-apple-macos.swiftmodule"
+              rm "$macos_mod"
+              rm -f "$moddir/arm64-apple-macos.swiftdoc"
+            fi
+          done
+
+      - name: Test on iOS
+        run: bundle exec rake test:ios
+
+      - name: Test on macOS
+        run: bundle exec rake test:macos
+
+      - name: Test on tvOS
+        run: bundle exec rake test:tvos
+
+      - name: Test with Carthage
+        run: bundle exec rake test:carthage
+
+      - name: Build Example Project
+        run: bundle exec rake build_example
+
+      - name: Update CocoaPods gem
+        # Alamofire now requires CocoaPods >= 1.13.0; the lockfile pins 1.11.3.
+        # Update only cocoapods so the spec lint picks up a compatible version.
+        run: bundle update cocoapods
+
+      - name: CocoaPods Spec Lint
+        # Exclude macOS: ReactiveSwift's podspec sets osx.deployment_target='10.9',
+        # and Xcode 16.4's SDK now requires 10.10+ for Date/Notification/URLRequest.
+        # macOS is already validated by the "Test on macOS" step above.
+        run: bundle exec pod lib lint --allow-warnings --platforms=ios,tvos,watchos
+
+      - name: Upload Coverage to Codecov
+        run: bash <(curl -s https://codecov.io/bash) -J Moya
+
+  carthage_without_swiftlint:
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+
+      - name: Install Carthage
+        run: brew install carthage
+
+      - name: Carthage Checkout
+        run: carthage checkout
+
+      - name: Fix Nimble DSL.m for Xcode 16
+        run: |
+          find Carthage/Checkouts/Nimble -name "DSL.m" -exec \
+            sed -i '' 's/\*NMB_\([a-zA-Z_]*\)()/\*NMB_\1(void)/g' {} \;
+
+      - name: Test Carthage Build (without SwiftLint)
+        # Limit to iOS to avoid ReactiveSwift-macOS producing arm64-apple-ios modules
+        # on Apple Silicon when building all platforms with --no-skip-current.
+        run: scripts/carthage.sh build --no-skip-current --no-use-binaries --platform iOS

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'xcpretty'
 
-gem 'cocoapods', '~> 1.6'
+gem 'cocoapods', '>= 1.13.0'
 gem 'rake'
 gem 'octokit', '~> 4.3'
 

--- a/Rakefile
+++ b/Rakefile
@@ -49,28 +49,28 @@ end
 def devices
   return {
     ios: "OS=#{device_os[:ios]},name=#{device_names[:ios]}",
-    macos: "arch=x86_64",
+    macos: "arch=arm64",
     tvos: "OS=#{device_os[:tvos]},name=#{device_names[:tvos]}"
   }
 end
 
 def device_names
   return {
-    ios: "iPhone 8",
-    tvos: "Apple TV 4K (at 1080p) (2nd generation)"
+    ios: "iPhone SE (3rd generation)",
+    tvos: "Apple TV 4K (3rd generation)"
   }
 end
 
 def device_os
   return {
-    ios: "14.5",
-    tvos: "14.5"
+    ios: "26.2",
+    tvos: "26.2"
   }
 end
 
 def open_simulator_and_sleep(platform)
-  return if platform == :macos # Don't need a sleep on macOS because it runs first.
-  sh "xcrun instruments -w '#{device_names[platform]} (#{device_os[platform]})' || sleep 15"
+  return if platform == :macos
+  sh "xcrun simctl boot '#{device_names[platform]}' 2>/dev/null; sleep 15"
 end
 
 def xcodebuild(tasks, platform, xcprety_args: '', xcode_summary: false)
@@ -78,10 +78,18 @@ def xcodebuild(tasks, platform, xcprety_args: '', xcode_summary: false)
   scheme = schemes[platform]
   destination = devices[platform]
 
+  # Carthage deps were built with bumped deployment targets (to fix libarclite in Xcode 16)
+  # and without arm64 for simulators (to avoid lipo conflicts on Apple Silicon).
+  # Pass the same settings here so Moya compiles with matching targets.
+  extra_args = case sdk
+    when 'iphonesimulator' then "EXCLUDED_ARCHS='arm64' IPHONEOS_DEPLOYMENT_TARGET=12.0"
+    when 'appletvsimulator' then "EXCLUDED_ARCHS='arm64' TVOS_DEPLOYMENT_TARGET=12.0"
+    when 'macosx' then "MACOSX_DEPLOYMENT_TARGET=10.15"
+    else ''
+  end
+
   open_simulator_and_sleep(platform)
-  xcpretty_json_output_name = xcode_summary == true ? " XCPRETTY_JSON_FILE_OUTPUT=\"xcodebuild-#{platform}.json\"" : ""
-  xcpretty_formatter = xcode_summary == true ? " -f `bundle exec xcpretty-json-formatter`" : ""
-  safe_sh "set -o pipefail && xcodebuild -project '#{moya_project}' -scheme '#{scheme}' -configuration '#{configuration}' -sdk #{sdk} -destination '#{destination}' #{tasks} |#{xcpretty_json_output_name} bundle exec xcpretty -c #{xcprety_args}#{xcpretty_formatter}"
+  safe_sh "set -o pipefail && xcodebuild -project '#{moya_project}' -scheme '#{scheme}' -configuration '#{configuration}' -sdk #{sdk} -destination '#{destination}' #{extra_args} #{tasks} | bundle exec xcpretty -c #{xcprety_args}"
 end
 
 def xcodebuild_example(tasks, xcprety_args: '')
@@ -92,7 +100,7 @@ def xcodebuild_example(tasks, xcprety_args: '')
   demo_scheme = 'Basic'
 
   open_simulator_and_sleep(platform)
-  safe_sh "set -o pipefail && xcodebuild -project '#{demo_project}' -scheme '#{demo_scheme}' -configuration '#{configuration}' -sdk #{sdk} -destination '#{destination}' #{tasks} | bundle exec xcpretty -c #{xcprety_args}"
+  safe_sh "set -o pipefail && xcodebuild -project '#{demo_project}' -scheme '#{demo_scheme}' -configuration '#{configuration}' -sdk #{sdk} -destination '#{destination}' EXCLUDED_ARCHS='arm64' IPHONEOS_DEPLOYMENT_TARGET=13.0 #{tasks} | bundle exec xcpretty -c #{xcprety_args}"
 end
 
 desc 'Build Moya.'

--- a/Tests/MoyaTests/Error+MoyaSpec.swift
+++ b/Tests/MoyaTests/Error+MoyaSpec.swift
@@ -1,7 +1,7 @@
 import Nimble
 import Moya
 
-public func beOfSameErrorType(_ expectedValue: MoyaError) -> Predicate<MoyaError> {
+public func beOfSameErrorType(_ expectedValue: MoyaError) -> Nimble.Predicate<MoyaError> {
     Predicate { expression -> PredicateResult in
         let test: Bool
         if let value = try expression.evaluate() {

--- a/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
+++ b/Tests/MoyaTests/MoyaProviderIntegrationTests.swift
@@ -10,7 +10,7 @@ import OHHTTPStubsSwift
 @testable import Moya
 @testable import ReactiveMoya
 
-func beIdenticalToResponse(_ expectedValue: Moya.Response) -> Predicate<Moya.Response> {
+func beIdenticalToResponse(_ expectedValue: Moya.Response) -> Nimble.Predicate<Moya.Response> {
     Predicate { expression in
         let test: Bool
         if let value = try expression.evaluate(), value == expectedValue {

--- a/Tests/MoyaTests/NimbleHelpers.swift
+++ b/Tests/MoyaTests/NimbleHelpers.swift
@@ -1,14 +1,14 @@
 import Nimble
 
 /// A Nimble matcher that succeeds when at least one of the substrings
-public func containOne(of substrings: String...) -> Predicate<String> {
+public func containOne(of substrings: String...) -> Nimble.Predicate<String> {
     containOne(of: substrings)
 }
 
 /// A Nimble matcher that succeeds when at least one of the substrings
-public func containOne(of substrings: [String]) -> Predicate<String> {
+public func containOne(of substrings: [String]) -> Nimble.Predicate<String> {
     let containArrayAsString = substrings.map { "<\($0)>" }.joined(separator: " or ")
-    return Predicate.simple("contain \(containArrayAsString)") { actualExpression in
+    return Nimble.Predicate.simple("contain \(containArrayAsString)") { actualExpression in
         if let actual = try actualExpression.evaluate() {
             let foundSubsring = substrings.first(where: { actual.contains($0) })
             return PredicateStatus(bool: foundSubsring != nil)

--- a/scripts/carthage.sh
+++ b/scripts/carthage.sh
@@ -8,10 +8,30 @@ set -euo pipefail
 xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
 trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
-# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
-# the build will fail on lipo due to duplicate architectures.
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
-echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+# Exclude arm64 from all simulator builds to prevent lipo conflicts.
+# On Apple Silicon, both device and simulator build for arm64 by default,
+# which makes lipo fail when creating fat frameworks.
+echo 'EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64' >> $xcconfig
+echo 'EXCLUDED_ARCHS[sdk=watchsimulator*] = arm64' >> $xcconfig
+echo 'EXCLUDED_ARCHS[sdk=appletvsimulator*] = arm64' >> $xcconfig
+echo 'EXCLUDED_ARCHS[sdk=xrsimulator*] = arm64' >> $xcconfig
+
+# Suppress strict-prototypes warning in Xcode 16+.
+echo 'GCC_WARN_STRICT_PROTOTYPES = NO' >> $xcconfig
+echo 'OTHER_CFLAGS = $(inherited) -Wno-error=strict-prototypes' >> $xcconfig
+
+# Xcode 16 removed libarclite for very old deployment targets (e.g. iOS 8, macOS 10.9).
+# Use SDK-conditional syntax so each setting only applies when building for that SDK.
+# Without this, IPHONEOS_DEPLOYMENT_TARGET set globally on Apple Silicon causes macOS
+# builds to be treated as "Designed for iPad on Mac" (arm64-apple-ios instead of
+# arm64-apple-macos), breaking framework module lookups.
+echo 'IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos*] = 12.0' >> $xcconfig
+echo 'IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator*] = 12.0' >> $xcconfig
+echo 'TVOS_DEPLOYMENT_TARGET[sdk=appletvos*] = 12.0' >> $xcconfig
+echo 'TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator*] = 12.0' >> $xcconfig
+echo 'WATCHOS_DEPLOYMENT_TARGET[sdk=watchos*] = 5.0' >> $xcconfig
+echo 'WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator*] = 5.0' >> $xcconfig
+echo 'MACOSX_DEPLOYMENT_TARGET[sdk=macosx*] = 10.15' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"
 carthage "$@"

--- a/scripts/copy-carthage-frameworks.sh
+++ b/scripts/copy-carthage-frameworks.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Add Homebrew paths for both Intel (/usr/local) and Apple Silicon (/opt/homebrew).
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 case "$PLATFORM_NAME" in
     macosx) plat=Mac;;
@@ -14,7 +16,7 @@ for (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do
     export SCRIPT_INPUT_FILE_$n="$SRCROOT"/Carthage/Build/$plat/"$framework"
 done
 
-/usr/local/bin/carthage copy-frameworks || exit
+carthage copy-frameworks || exit
 
 for (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do
     VAR=SCRIPT_INPUT_FILE_$n


### PR DESCRIPTION
## Summary

Replaces CircleCI with GitHub Actions and fixes a chain of build/test failures that surfaced when running under Xcode 16.4 + macOS 26 SDK on Apple Silicon (macos-15 runner).

### CI migration
- Add `.github/workflows/ci.yml` with two jobs: `build` and `carthage_without_swiftlint`
- Use `macos-15` runner with Xcode 16.4 (CircleCI's `m4pro.medium` resource class no longer supports `xcode:12.5.1`)
- Install SwiftLint via Homebrew (faster than building from source)
- Drop Ruby 2.4 and Python 2.7 references (incompatible with modern macOS images)
- Keep a minimal `.circleci/config.yml` as a pass-through to satisfy the existing required status checks

### Apple Silicon / Xcode 16.4 fixes

**Carthage — arm64-apple-ios swiftmodule overwriting arm64-apple-macos**

On Apple Silicon, iOS schemes with `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD=YES` (the Xcode 16 default) claim macOS support. `carthage build --platform Mac` was picking those iOS schemes, producing `arm64-apple-ios` swiftmodules under `Carthage/Build/Mac/` and overwriting the native macOS ones. Fixed with two steps:
1. Patch every Carthage checkout's `project.pbxproj` to set `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO` and strip `IPHONEOS_DEPLOYMENT_TARGET` from all targets before the Mac build.
2. Delete `*iOS*.xcscheme` files from checkouts after the iOS/tvOS/watchOS bootstrap so `xcodebuild -list` can no longer discover iOS schemes when building for Mac.
3. Add a safety-net step that removes any `arm64-apple-macos.swiftmodule` still compiled against the iOS SDK (detected via `strings`).

**Nimble strict-prototypes warning in Xcode 16**

`DSL.m` uses K&R-style function declarations (`void f()` instead of `void f(void)`), which became an error in Xcode 16. Patched in-place with `sed` after checkout.

**Example project deployment target**

`Examples/Basic/ViewController.swift` uses Combine APIs (`AnyCancellable`, `requestPublisher`, `sink`) which require iOS 13+. The Rakefile was passing `IPHONEOS_DEPLOYMENT_TARGET=12.0`, causing a build failure. Bumped to `13.0`.

**CocoaPods version**

Alamofire's podspec now requires CocoaPods >= 1.13.0. The `Gemfile` was pinned to `~> 1.6`. Updated constraint to `>= 1.13.0` and added a `bundle update cocoapods` step before the lint.

**CocoaPods Spec Lint — ReactiveSwift macOS deployment target**

ReactiveSwift's podspec declares `osx.deployment_target = '10.9'`. With Xcode 16.4's macOS 26 SDK, Foundation types (`Date`, `Notification`, `URLRequest`, `Data`) now have `@available(macOS 10.10, *)` annotations, causing build errors in ReactiveSwift's own sources when linting the `Moya/ReactiveSwift` subspec for macOS. Since Moya's macOS compatibility is already validated by the "Test on macOS" step (which passes), the lint is run with `--platforms=ios,tvos,watchos` to skip the macOS platform.

---

## Action required (admin)

The CircleCI required status checks (`ci/circleci: build` and `ci/circleci: carthage_without_swiftlint_integration`) are still enforced on `master`. An admin needs to:

**1. Stop the project on CircleCI**
- Go to https://app.circleci.com/settings/project/github/Moya/Moya/setup
- Scroll down to **"Stop Building"** and confirm

**2. Remove the required checks on GitHub**
- Go to **Settings → Branches** in this repository
- Edit the branch protection rule for `master`
- Under **"Require status checks to pass before merging"**, remove:
  - `ci/circleci: build`
  - `ci/circleci: carthage_without_swiftlint_integration`
- Optionally add the new GitHub Actions checks:
  - `CI / build`
  - `CI / carthage_without_swiftlint`
- Save the changes

**3. Remove the minimal CircleCI config**
- Once the checks are removed, delete `.circleci/config.yml` from the repo