### PR TITLE
Allow a custom urlEncoding in Task.requestCompositeParameters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+### Added
+
+- Added an optional `urlEncoding` parameter to `Task.requestCompositeParameters`, so `urlParameters` can be encoded with a custom `boolEncoding` (e.g. `.literal`) or `arrayEncoding`. [#2377](https://github.com/Moya/Moya/pull/2377) by [@ManjunathAnawal](https://github.com/ManjunathAnawal).
+
 ### Fixed
 
 - Un-break Package.swift parsing when releasing through Rocket. [#2275](https://github.com/Moya/Moya/pull/2274) by [@AndrewSB](https://github.com/AndrewSB)

--- a/Sources/Moya/Endpoint.swift
+++ b/Sources/Moya/Endpoint.swift
@@ -105,12 +105,16 @@ public extension Endpoint {
             request.httpBody = bodyData
             let parameterEncoding = URLEncoding(destination: .queryString)
             return try request.encoded(parameters: urlParameters, parameterEncoding: parameterEncoding)
-        case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters):
+        case let .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyParameterEncoding, urlParameters: urlParameters, urlEncoding: urlParameterEncoding):
             if let bodyParameterEncoding = bodyParameterEncoding as? URLEncoding, bodyParameterEncoding.destination != .httpBody {
                 fatalError("Only URLEncoding that `bodyEncoding` accepts is URLEncoding.httpBody. Others like `default`, `queryString` or `methodDependent` are prohibited - if you want to use them, add your parameters to `urlParameters` instead.")
             }
             let bodyfulRequest = try request.encoded(parameters: bodyParameters, parameterEncoding: bodyParameterEncoding)
-            let urlEncoding = URLEncoding(destination: .queryString)
+            // `urlParameters` always belong in the query string, so the given `destination` is
+            // pinned to `.queryString` - otherwise it could overwrite the body encoded above.
+            let urlEncoding = URLEncoding(destination: .queryString,
+                                          arrayEncoding: urlParameterEncoding.arrayEncoding,
+                                          boolEncoding: urlParameterEncoding.boolEncoding)
             return try bodyfulRequest.encoded(parameters: urlParameters, parameterEncoding: urlEncoding)
         }
     }

--- a/Sources/Moya/Task.swift
+++ b/Sources/Moya/Task.swift
@@ -22,7 +22,11 @@ public enum Task {
     case requestCompositeData(bodyData: Data, urlParameters: [String: Any])
 
     /// A requests body set with encoded parameters combined with url parameters.
-    case requestCompositeParameters(bodyParameters: [String: Any], bodyEncoding: ParameterEncoding, urlParameters: [String: Any])
+    ///
+    /// - Note: `urlParameters` are always appended to the query string, so only the `arrayEncoding`
+    ///         and `boolEncoding` options of `urlEncoding` are taken into account - its `destination`
+    ///         is always treated as `.queryString` so that it can never overwrite the encoded body.
+    case requestCompositeParameters(bodyParameters: [String: Any], bodyEncoding: ParameterEncoding, urlParameters: [String: Any], urlEncoding: URLEncoding = URLEncoding(destination: .queryString))
 
     /// A file upload task.
     case uploadFile(URL)

--- a/Tests/MoyaTests/EndpointSpec.swift
+++ b/Tests/MoyaTests/EndpointSpec.swift
@@ -278,6 +278,57 @@ final class EndpointSpec: QuickSpec {
                 }
             }
 
+            context("when task is .requestCompositeParameters with a custom urlEncoding") {
+                var bodyParameters: [String: Any]!
+                var bodyEncoding: ParameterEncoding!
+
+                beforeEach {
+                    bodyParameters = ["Nemesis": "Harvey"]
+                    bodyEncoding = JSONEncoding.default
+                }
+
+                func urlRequest(urlParameters: [String: Any], urlEncoding: URLEncoding) -> URLRequest {
+                    endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: bodyParameters,
+                                                                                   bodyEncoding: bodyEncoding,
+                                                                                   urlParameters: urlParameters,
+                                                                                   urlEncoding: urlEncoding))
+                    return try! endpoint.urlRequest()
+                }
+
+                it("encodes bools numerically by default") {
+                    endpoint = endpoint.replacing(task: .requestCompositeParameters(bodyParameters: bodyParameters, bodyEncoding: bodyEncoding, urlParameters: ["Harvey": true]))
+                    let request = try! endpoint.urlRequest()
+
+                    expect(request.url?.absoluteString).to(equal(endpoint.url + "?Harvey=1"))
+                }
+
+                it("encodes bools literally when boolEncoding is .literal") {
+                    let request = urlRequest(urlParameters: ["Harvey": true],
+                                             urlEncoding: URLEncoding(destination: .queryString, boolEncoding: .literal))
+
+                    expect(request.url?.absoluteString).to(equal(endpoint.url + "?Harvey=true"))
+                }
+
+                it("encodes arrays with the given arrayEncoding") {
+                    let request = urlRequest(urlParameters: ["Harvey": [1, 2]],
+                                             urlEncoding: URLEncoding(destination: .queryString, arrayEncoding: .noBrackets))
+
+                    expect(request.url?.absoluteString).to(equal(endpoint.url + "?Harvey=1&Harvey=2"))
+                }
+
+                it("keeps the encoded body when the given destination is not .queryString") {
+                    let request = urlRequest(urlParameters: ["Harvey": true],
+                                             urlEncoding: URLEncoding(destination: .httpBody, boolEncoding: .literal))
+
+                    let newEndpoint = endpoint.replacing(task: .requestPlain)
+                    let newRequest = try! newEndpoint.urlRequest()
+                    let newEncodedRequest = try? bodyEncoding.encode(newRequest, with: bodyParameters)
+
+                    expect(request.url?.absoluteString).to(equal(endpoint.url + "?Harvey=true"))
+                    expect(request.httpBody).to(equal(newEncodedRequest?.httpBody))
+                }
+            }
+
             context("when task is .uploadCompositeMultipart") {
                 var urlParameters: [String: Any]!
                 var request: URLRequest!

--- a/docs/Targets.md
+++ b/docs/Targets.md
@@ -96,7 +96,23 @@ A `task` property represents how you are sending / receiving data and allows you
 - `.requestJSONEncodable(_:)` with which you can send objects that conform to the `Encodable` protocol
 - `.requestCustomJSONEncodable(_:encoder:)`  which allows you to send objects conforming to `Encodable` encoded with provided custom JSONEncoder
 - `.requestParameters(parameters:encoding:)` which allows you to send parameters with an encoding
-- `.requestCompositeData(bodyData:urlParameters:)` & `.requestCompositeParameters(bodyParameters:bodyEncoding:urlParameters)` which allow you to combine url encoded parameters with another type (data / parameters)
+- `.requestCompositeData(bodyData:urlParameters:)` & `.requestCompositeParameters(bodyParameters:bodyEncoding:urlParameters:)` which allow you to combine url encoded parameters with another type (data / parameters)
+
+`.requestCompositeParameters` also takes an optional `urlEncoding:` parameter for the cases where the
+default query string encoding does not fit the API you are talking to, e.g. when booleans have to be
+sent as `true` / `false` instead of `1` / `0`:
+
+```swift
+var task: Task {
+    .requestCompositeParameters(bodyParameters: ["some": "body"],
+                                bodyEncoding: JSONEncoding.default,
+                                urlParameters: ["flag": true],
+                                urlEncoding: URLEncoding(destination: .queryString, boolEncoding: .literal))
+}
+```
+
+Since `urlParameters` are always appended to the query string, only the `arrayEncoding` and
+`boolEncoding` options of the given `URLEncoding` are taken into account.
 
 Also, there are three upload types: 
 - `.uploadFile(_:)` to upload a file from a URL, 


### PR DESCRIPTION
:sparkles:

Fixes #2362.

### Problem

`.requestCompositeParameters` builds the encoder for its `urlParameters` inline:

```swift
let urlEncoding = URLEncoding(destination: .queryString)
```

That pins Alamofire's defaults — `boolEncoding: .numeric` and `arrayEncoding: .brackets` — and nothing at the call site can influence them. So an API that expects `?flag=true` rather than `?flag=1` is unreachable through this task type. `bodyEncoding` is not an escape hatch either: any `URLEncoding` whose destination isn't `.httpBody` trips the `fatalError` directly above.

### Change

`Task.requestCompositeParameters` gains an `urlEncoding` associated value, defaulted to today's behaviour:

```swift
.requestCompositeParameters(bodyParameters: ["some": "body"],
                            bodyEncoding: JSONEncoding.default,
                            urlParameters: ["flag": true],
                            urlEncoding: URLEncoding(destination: .queryString, boolEncoding: .literal))
```

Because the value is defaulted, every existing construction site compiles and behaves exactly as before.

### One design choice worth your review

When encoding, the supplied encoding's `destination` is pinned to `.queryString` and only its `arrayEncoding` / `boolEncoding` are honoured. `urlParameters` are query-string parameters by definition, and a `.httpBody` or `.methodDependent` destination would otherwise silently overwrite the body encoded from `bodyParameters` one line earlier.

The alternative — a `fatalError` guard mirroring the existing `bodyEncoding` one — would be more consistent with the surrounding code but adds a new crash path. Happy to switch if you would rather have the guard.

### Notes

- Only `.requestCompositeParameters` is touched. `.requestCompositeData` and `.uploadCompositeMultipartFormData` hardcode the same encoder and could get the same treatment in a follow-up.
- Targeting `master` since this is additive and source-compatible for construction sites. Adding an associated value is source-breaking for code that pattern-matches the case with three bindings, so if you consider that a breaking change I will retarget to `development` — I avoided it initially because `development` is currently diverged from `master` (17 ahead / 57 behind).

### Tests

Four new cases in `EndpointSpec`, all passing under `swift test`:

- numeric-by-default (regression guard on existing behaviour)
- `.literal` bools — the case from the issue
- `arrayEncoding: .noBrackets`
- body preservation when a non-`.queryString` destination is supplied

The suite has some pre-existing failures on my machine that fail identically without this patch: the macOS 26 SDK now percent-encodes the `"some invalid URL"` fixture instead of rejecting it, and the httpbin multipart integration tests time out.

`Changelog.md` and `docs/Targets.md` updated. SwiftLint reports no new violations.
